### PR TITLE
Added `original_languages` attribute for trakt to filter movies with unneeded languages

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -106,7 +106,6 @@ class Config:
                 self.trakt["client_id"] = check_for_attribute(self.data, "client_id", parent="trakt", throw=True)
                 self.trakt["client_secret"] = check_for_attribute(self.data, "client_secret", parent="trakt", throw=True)
                 self.trakt["config_path"] = self.config_path
-                self.trakt["original_languages"] = check_for_attribute(self.data, "original_languages", parent="trakt", default_is_none=True)
                 authorization = self.data["trakt"]["authorization"] if "authorization" in self.data["trakt"] and self.data["trakt"]["authorization"] else None
                 self.Trakt = TraktAPI(self.trakt, authorization)
             except Failed as e:
@@ -153,6 +152,8 @@ class Config:
         self.general["radarr"]["root_folder_path"] = check_for_attribute(self.data, "root_folder_path", parent="radarr", default_is_none=True) if "radarr" in self.data else None
         self.general["radarr"]["add"] = check_for_attribute(self.data, "add", parent="radarr", var_type="bool", default=False) if "radarr" in self.data else False
         self.general["radarr"]["search"] = check_for_attribute(self.data, "search", parent="radarr", var_type="bool", default=False) if "radarr" in self.data else False
+        self.general["radarr"]["allowed_languages"] = check_for_attribute(self.data, "allowed_languages", parent="radarr", default_is_none=True) if "radarr" in self.data else None
+
 
         self.general["sonarr"] = {}
         self.general["sonarr"]["url"] = check_for_attribute(self.data, "url", parent="sonarr", default_is_none=True) if "sonarr" in self.data else None
@@ -938,7 +939,7 @@ class Config:
                                 elif "tvdb" in method:                              items_found += check_map(self.TVDb.get_items(method, value, library.Plex.language))
                                 elif "imdb" in method:                              items_found += check_map(self.IMDb.get_items(method, value, library.Plex.language))
                                 elif "tmdb" in method:                              items_found += check_map(self.TMDb.get_items(method, value, library.is_movie))
-                                elif "trakt" in method:                             items_found += check_map(self.Trakt.get_items(method, value, library.is_movie, self.TMDb))
+                                elif "trakt" in method:                             items_found += check_map(self.Trakt.get_items(method, value, library.is_movie))
                                 else:                                               logger.error("Collection Error: {} method not supported".format(method))
 
                                 if len(items) > 0:                                  map = library.add_to_collection(collection_obj if collection_obj else collection_name, items, filters, map=map)

--- a/modules/config.py
+++ b/modules/config.py
@@ -106,6 +106,7 @@ class Config:
                 self.trakt["client_id"] = check_for_attribute(self.data, "client_id", parent="trakt", throw=True)
                 self.trakt["client_secret"] = check_for_attribute(self.data, "client_secret", parent="trakt", throw=True)
                 self.trakt["config_path"] = self.config_path
+                self.trakt["original_languages"] = check_for_attribute(self.data, "original_languages", parent="trakt", default_is_none=True)
                 authorization = self.data["trakt"]["authorization"] if "authorization" in self.data["trakt"] and self.data["trakt"]["authorization"] else None
                 self.Trakt = TraktAPI(self.trakt, authorization)
             except Failed as e:
@@ -937,7 +938,7 @@ class Config:
                                 elif "tvdb" in method:                              items_found += check_map(self.TVDb.get_items(method, value, library.Plex.language))
                                 elif "imdb" in method:                              items_found += check_map(self.IMDb.get_items(method, value, library.Plex.language))
                                 elif "tmdb" in method:                              items_found += check_map(self.TMDb.get_items(method, value, library.is_movie))
-                                elif "trakt" in method:                             items_found += check_map(self.Trakt.get_items(method, value, library.is_movie))
+                                elif "trakt" in method:                             items_found += check_map(self.Trakt.get_items(method, value, library.is_movie, self.TMDb))
                                 else:                                               logger.error("Collection Error: {} method not supported".format(method))
 
                                 if len(items) > 0:                                  map = library.add_to_collection(collection_obj if collection_obj else collection_name, items, filters, map=map)

--- a/modules/radarr.py
+++ b/modules/radarr.py
@@ -37,6 +37,9 @@ class RadarrAPI:
         self.root_folder_path = params["root_folder_path"]
         self.add = params["add"]
         self.search = params["search"]
+        self.allowed_languages = None
+        if params["allowed_languages"] is not None:
+            self.allowed_languages = [x.strip().lower() for x in params["allowed_languages"].split(',')]
 
     def add_tmdb(self, tmdb_ids):
         logger.info("")
@@ -57,6 +60,10 @@ class RadarrAPI:
 
             if year.isdigit() is False:
                 logger.error("TMDb Error: No release date yet for ({}) {}".format(tmdb_id, movie.title))
+                continue
+
+            if self.allowed_languages is not None and movie.original_language not in self.allowed_languages:
+                logger.info("Skipped adding {} ({}) to Radarr; TMDB original_language ({}) not in allowed_languages ({})".format(movie.title, year, movie.original_language, self.allowed_languages))
                 continue
 
             poster = "https://image.tmdb.org/t/p/original{}".format(movie.poster_path)

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -8,7 +8,6 @@ from trakt.objects.episode import Episode
 from trakt.objects.movie import Movie
 from trakt.objects.season import Season
 from trakt.objects.show import Show
-from modules.tmdb import TMDbAPI
 
 logger = logging.getLogger("Plex Meta Manager")
 

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -173,5 +173,5 @@ class TraktAPI:
         if status_message:
             logger.debug("Trakt {} Found: {}".format(media_type, trakt_items))
             logger.debug("TMDb IDs Found: {}".format(movie_ids))
-            logger.debug("TVDb IDs Found: {}".format(show_ids))        
+            logger.debug("TVDb IDs Found: {}".format(show_ids))
         return movie_ids, show_ids

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -8,6 +8,7 @@ from trakt.objects.episode import Episode
 from trakt.objects.movie import Movie
 from trakt.objects.season import Season
 from trakt.objects.show import Show
+from modules.tmdb import TMDbAPI
 
 logger = logging.getLogger("Plex Meta Manager")
 
@@ -22,6 +23,9 @@ class TraktAPI:
         self.client_id = params["client_id"]
         self.client_secret = params["client_secret"]
         self.config_path = params["config_path"]
+        self.original_languages = None
+        if params["original_languages"] is not None:
+            self.original_languages = [x.strip().lower() for x in params["original_languages"].split(',')]
         self.authorization = authorization
         Trakt.configuration.defaults.client(self.client_id, self.client_secret)
         if not self.save_authorization(self.authorization):
@@ -134,7 +138,7 @@ class TraktAPI:
             raise Failed("Trakt Error: No valid Trakt Watchlists in {}".format(value))
         return trakt_values
 
-    def get_items(self, method, data, is_movie, status_message=True):
+    def get_items(self, method, data, is_movie, tmdb, status_message=True):
         if status_message:
             logger.debug("Data: {}".format(data))
         pretty = self.aliases[method] if method in self.aliases else method
@@ -150,12 +154,25 @@ class TraktAPI:
             if status_message:                          logger.info("Processing {}: {}".format(pretty, data))
         show_ids = []
         movie_ids = []
-        for trakt_item in trakt_items:
-            if isinstance(trakt_item, Movie):                                                                movie_ids.append(int(trakt_item.get_key("tmdb")))
+        for trakt_item in trakt_items:            
+            if isinstance(trakt_item, Movie):
+                try:                    
+                    tmdbid = int(trakt_item.get_key("tmdb"))
+                    if self.original_languages is None:
+                        movie_ids.append(tmdbid)
+                        continue
+                    movie = tmdb.get_movie(tmdbid)
+                    #logger.info("--- Movie {} ({}), TMDB original_language ({})".format(trakt_item.title, trakt_item.year, movie.original_language))
+                    if movie.original_language in self.original_languages:
+                        movie_ids.append(tmdbid)
+                    else:
+                        logger.info("--- Skipped Movie {} ({}), TMDB original_language ({}) not in original_languages attribute ({})".format(trakt_item.title, trakt_item.year, movie.original_language, self.original_languages))
+                except Failed as e:
+                    logger.error(e)
             elif isinstance(trakt_item, Show) and trakt_item.pk[1] not in show_ids:                          show_ids.append(int(trakt_item.pk[1]))
             elif (isinstance(trakt_item, (Season, Episode))) and trakt_item.show.pk[1] not in show_ids:      show_ids.append(int(trakt_item.show.pk[1]))
         if status_message:
             logger.debug("Trakt {} Found: {}".format(media_type, trakt_items))
             logger.debug("TMDb IDs Found: {}".format(movie_ids))
-            logger.debug("TVDb IDs Found: {}".format(show_ids))
+            logger.debug("TVDb IDs Found: {}".format(show_ids))        
         return movie_ids, show_ids

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -22,9 +22,6 @@ class TraktAPI:
         self.client_id = params["client_id"]
         self.client_secret = params["client_secret"]
         self.config_path = params["config_path"]
-        self.original_languages = None
-        if params["original_languages"] is not None:
-            self.original_languages = [x.strip().lower() for x in params["original_languages"].split(',')]
         self.authorization = authorization
         Trakt.configuration.defaults.client(self.client_id, self.client_secret)
         if not self.save_authorization(self.authorization):
@@ -137,7 +134,7 @@ class TraktAPI:
             raise Failed("Trakt Error: No valid Trakt Watchlists in {}".format(value))
         return trakt_values
 
-    def get_items(self, method, data, is_movie, tmdb, status_message=True):
+    def get_items(self, method, data, is_movie, status_message=True):
         if status_message:
             logger.debug("Data: {}".format(data))
         pretty = self.aliases[method] if method in self.aliases else method
@@ -153,21 +150,8 @@ class TraktAPI:
             if status_message:                          logger.info("Processing {}: {}".format(pretty, data))
         show_ids = []
         movie_ids = []
-        for trakt_item in trakt_items:            
-            if isinstance(trakt_item, Movie):
-                try:                    
-                    tmdbid = int(trakt_item.get_key("tmdb"))
-                    if self.original_languages is None:
-                        movie_ids.append(tmdbid)
-                        continue
-                    movie = tmdb.get_movie(tmdbid)
-                    #logger.info("--- Movie {} ({}), TMDB original_language ({})".format(trakt_item.title, trakt_item.year, movie.original_language))
-                    if movie.original_language in self.original_languages:
-                        movie_ids.append(tmdbid)
-                    else:
-                        logger.info("--- Skipped Movie {} ({}), TMDB original_language ({}) not in original_languages attribute ({})".format(trakt_item.title, trakt_item.year, movie.original_language, self.original_languages))
-                except Failed as e:
-                    logger.error(e)
+        for trakt_item in trakt_items:
+            if isinstance(trakt_item, Movie):                                                                movie_ids.append(int(trakt_item.get_key("tmdb")))
             elif isinstance(trakt_item, Show) and trakt_item.pk[1] not in show_ids:                          show_ids.append(int(trakt_item.pk[1]))
             elif (isinstance(trakt_item, (Season, Episode))) and trakt_item.show.pk[1] not in show_ids:      show_ids.append(int(trakt_item.show.pk[1]))
         if status_message:


### PR DESCRIPTION
Took a stab at implementing #13. These are the changes:

- Added `original_languages` attribute under trakt, accepts a list of language codes.
- trakt.py gets movie details from tmdb, compares `original_language` returned by tmdb against specified values in the new attribute.
- If found, movie is added to movie_ids, if not, movie is skipped and an info entry is logged.
- If `original_languages` is not specified, script behavior is unchanged.