### PR TITLE
#26 command-line param to process only a specific collection(s)

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -426,7 +426,7 @@ class Config:
 
         util.seperator()
 
-    def update_libraries(self, test):
+    def update_libraries(self, test, requested_collections):
         for library in self.libraries:
             logger.info("")
             util.seperator("{} Library".format(library.name))
@@ -435,14 +435,15 @@ class Config:
             logger.info("")
             util.seperator("{} Library {}Collections".format(library.name, "Test " if test else ""))
             collections = library.collections
-            if collections:
+            collections_to_process = (collections.keys() & util.get_list(requested_collections)) if requested_collections else collections
+            if collections_to_process:
                 logger.info("")
                 util.seperator("Mapping {} Library".format(library.name))
                 logger.info("")
                 movie_map, show_map = self.map_guids(library)
                 logger.info(movie_map)
                 logger.info(show_map)
-                for c in collections:
+                for c in collections_to_process:
                     if test and ("test" not in collections[c] or collections[c]["test"] is not True):
                         continue
                     try:
@@ -1123,7 +1124,7 @@ class Config:
                     except Exception as e:
                         util.print_stacktrace()
                         logger.error("Unknown Error: {}".format(e))
-                if library.show_unmanaged is True and not test:
+                if library.show_unmanaged is True and not test and not requested_collections:
                     logger.info("")
                     util.seperator("Unmanaged Collections in {} Library".format(library.name))
                     logger.info("")

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -8,6 +8,7 @@ parser.add_argument("-c", "--config", dest="config", help="Run with desired *.ym
 parser.add_argument("-t", "--time", dest="time", help="Time to update each day use format HH:MM (Default: 03:00)", default="03:00", type=str)
 parser.add_argument("-r", "--run", dest="run", help="Run without the scheduler", action="store_true", default=False)
 parser.add_argument("-rt", "--test", "--tests", "--run-test", "--run-tests", dest="test", help="Run only tests without the scheduler", action="store_true", default=False)
+parser.add_argument("-cl", "--collections", dest="collections", help="Process only specified collections (comma-separated list)", type=str, default="")
 parser.add_argument("-d", "--divider", dest="divider", help="Character that divides the sections (Default: '=')", default="=", type=str)
 parser.add_argument("-w", "--width", dest="width", help="Screen Width (Default: 100)", default=100, type=int)
 args = parser.parse_args()
@@ -64,14 +65,15 @@ if args.tests:
     tests.run_tests(default_dir)
     sys.exit(0)
 
-def start(config_path, test, daily):
+def start(config_path, test, daily, collections = ""):
     if daily:               type = "Daily "
     elif test:              type = "Test "
+    elif collections:       type = "Collections "
     else:                   type = ""
     util.seperator("Starting {}Run".format(type))
     try:
         config = Config(default_dir, config_path)
-        config.update_libraries(test)
+        config.update_libraries(test, collections)
     except Exception as e:
         util.print_stacktrace()
         logger.critical(e)
@@ -79,8 +81,8 @@ def start(config_path, test, daily):
     util.seperator("Finished {}Run".format(type))
 
 try:
-    if args.run or args.test:
-        start(args.config, args.test, False)
+    if args.run or args.test or args.collections:
+        start(args.config, args.test, False, args.collections)
     else:
         length = 0
         schedule.every().day.at(args.time).do(start, args.config, False, True)


### PR DESCRIPTION
Ok, so out of sheer curiosity I had a look at how complicated it would be to achieve what I was thinking about originally, and apparently it was not that complicated at all. 

Bear with me though please, this is the very first time I am doing anything in Python, so there might be some silly things in the code. But then again, from quick tests it seems doing what I wanted it to do, meaning:

- `python3 plex_meta_manager.py` will process all defined collections
- `python3 plex_meta_manager.py --collections='Monty Python'` will process only `Monty Python` collection
- `python3 plex_meta_manager.py --collections=Action,Adventure` will process only `Action` and `Adventure` collections
- `python3 plex_meta_manager.py --collections=missing` (where there is no `missing` collection) will complain about `No collection to update`

Not really asking you here to merge it (although be my guest it you want), just wanted to share, and perhaps even ask for a code review if that's ok?