### PR TITLE
Letterboxd: skip miniseries and TV Shows

### DIFF
--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -12,7 +12,7 @@ class LetterboxdAPI:
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000)
     def send_request(self, url, language):
-        return html.fromstring(requests.get(url, header={"Accept-Language": language, "User-Agent": "Mozilla/5.0 x64"}).content)
+        return html.fromstring(requests.get(url, headers={"Accept-Language": language, "User-Agent": "Mozilla/5.0 x64"}).content)
 
     def get_list_description(self, list_url, language):
         descriptions = self.send_request(list_url, language).xpath("//meta[@property='og:description']/@content")
@@ -32,6 +32,8 @@ class LetterboxdAPI:
     def get_tmdb(self, letterboxd_url, language):
         response = self.send_request(letterboxd_url, language)
         ids = response.xpath("//body/@data-tmdb-id")
+        if not ids[0]:
+            raise Failed(f"Letterboxd Error: Miniseries / TV Show found at {letterboxd_url}")
         if len(ids) > 0:
             return int(ids[0])
         raise Failed(f"Letterboxd Error: TMDb ID not found at {letterboxd_url}")
@@ -49,7 +51,7 @@ class LetterboxdAPI:
         for i, slug in enumerate(slugs, 1):
             length = util.print_return(length, f"Finding TMDb ID {i}/{total_slugs}")
             try:
-                movie_ids.append(self.get_tmdb(slug, language))
+                movie_ids.append(self.get_tmdb_from_slug(slug, language))
             except Failed as e:
                 logger.error(e)
         util.print_end(length, f"Processed {total_slugs} TMDb IDs")


### PR DESCRIPTION
Letterboxd have limited support for TV, which means the module will choke if a list contains a miniseries or TV Show, as they have empty `data-tmdb-id` attributes:

```html
<body data-type="film" data-tmdb-type="movie" data-tmdb-id="">
```

See [Small Axe](https://letterboxd.com/film/small-axe/) or [Wandavision](https://letterboxd.com/film/wandavision/). You can quickly test this by importing this [list](https://letterboxd.com/randomfunnyname/list/small-axe/):

```
Processing Letterboxd List: https://letterboxd.com/randomfunnyname/list/small-axe
Traceback (most recent call last):
  File "[...]/.apps/plex-meta-manager/modules/config.py", line 463, in update_libraries
    builder.run_methods(collection_obj, collection_name, rating_key_map, movie_map, show_map)
  File "[...]/.apps/plex-meta-manager/modules/builder.py", line 744, in run_methods
    elif "letterboxd" in method:                        items_found += check_map(self.config.Letterboxd.get_items(method, value, self.library.Plex.language))
  File "[...]/.apps/plex-meta-manager/modules/letterboxd.py", line 52, in get_items
    movie_ids.append(self.get_tmdb_from_slug(slug, language))
  File "[...]/.apps/plex-meta-manager/modules/letterboxd.py", line 30, in get_tmdb_from_slug
    return self.get_tmdb(f"{self.url}{slug}", language)
  File "[...]/.apps/plex-meta-manager/modules/letterboxd.py", line 36, in get_tmdb
    return int(ids[0])
ValueError: invalid literal for int() with base 10: ''

Unknown Error: invalid literal for int() with base 10: ''
```
Also fixes a typo — `header` argument in `send_request` — and calls `get_tmdb_from_slug` instead of `get_tmdb`, which prevented the module from running at all in the first place.

Bear in mind my python knowledge is next to nonexistent, so there's probably a more robust way to address this. 