### PR TITLE
v1.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Plex Meta Manager
-#### Version 1.9.1
+#### Version 1.9.2
 
 The original concept for Plex Meta Manager is [Plex Auto Collections](https://github.com/mza921/Plex-Auto-Collections), but this is rewritten from the ground up to be able to include a scheduler, metadata edits, multiple libraries, and logging. Plex Meta Manager is a Python 3 script that can be continuously run using YAML configuration files to update on a schedule the metadata of the movies, shows, and collections in your libraries as well as automatically build collections based on various methods all detailed in the wiki. Some collection examples that the script can automatically build and update daily include Plex Based Searches like actor, genre, or studio collections or Collections based on TMDb, IMDb, Trakt, TVDb, AniDB, or MyAnimeList lists and various other services.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The script is designed to work with most Metadata agents including the new Plex 
 
 ## Support
 
-* Before posting on Github about an enhancement, error, or configuration question please visit the [Plex Meta Manager Discord Server](https://discord.gg/NfH6mGFuAB).
+* Before posting on Github about an enhancement, error, or configuration question please visit the [Plex Meta Manager Discord Server](https://discord.gg/TsdpsFYqqm).
 * If you're getting an Error or have an Enhancement post in the [Issues](https://github.com/meisnate12/Plex-Meta-Manager/issues).
 * If you have a configuration question post in the [Discussions](https://github.com/meisnate12/Plex-Meta-Manager/discussions).
 * To see user submitted Metadata configuration files, and you to even add your own, go to the [Plex Meta Manager Configs](https://github.com/meisnate12/Plex-Meta-Manager-Configs).

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -495,7 +495,7 @@ class CollectionBuilder:
                     def build_url_arg(arg, mod=None, arg_s=None, mod_s=None, param_s=None):
                         arg_key = plex.search_translation[smart] if smart in plex.search_translation else smart
                         if mod is None:
-                            mod = plex.modifier_translation[smart_mod] if smart_mod in plex.search_translation else smart_mod
+                            mod = plex.modifier_translation[smart_mod] if smart_mod in plex.modifier_translation else smart_mod
                         if arg_s is None:
                             arg_s = arg
                         if smart in string_filters and smart_mod in ["", ".not"]:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -102,8 +102,6 @@ numbered_builders = [
 ]
 smart_collection_invalid = ["collection_mode", "collection_order"]
 smart_url_collection_invalid = [
-    "item_label", "item_label.sync", "item_episode_sorting", "item_keep_episodes", "item_delete_episodes",
-    "item_season_display", "item_episode_ordering", "item_metadata_language", "item_use_original_title",
     "run_again", "sync_mode", "show_filtered", "show_missing", "save_missing", "smart_label",
     "radarr_add", "radarr_folder", "radarr_monitor", "radarr_availability", 
     "radarr_quality", "radarr_tag", "radarr_search",
@@ -641,7 +639,7 @@ class CollectionBuilder:
                 elif method_name not in collectionless_details and self.collectionless:
                     raise Failed(f"Collection Error: {method_name} attribute does not work for Collectionless collection")
                 elif self.smart_url and method_name in all_builders:
-                    raise Failed(f"Collection Error: {method_name} builder not allowed when using smart_url")
+                    raise Failed(f"Collection Error: {method_name} builder not allowed when using smart_filter")
                 elif self.smart_url and method_name in smart_url_collection_invalid:
                     raise Failed(f"Collection Error: {method_name} detail not allowed when using smart_url")
                 elif method_name == "summary":

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -548,7 +548,7 @@ class CollectionBuilder:
                         else:
                             raise Failed("Collection Error: HDR must be true or false")
                     else:
-                        if smart in ["title", "episode_title"] and smart_mod in ["", ".not", ".begins", ".ends"]:
+                        if smart in ["title", "episode_title", "studio"] and smart_mod in ["", ".not", ".begins", ".ends"]:
                             results_list = [(t, t) for t in util.get_list(smart_data, split=False)]
                         elif smart in plex.tags and smart_mod in ["", ".not", ".begins", ".ends"]:
                             if smart_final in plex.tmdb_searches:
@@ -559,8 +559,6 @@ class CollectionBuilder:
                                             smart_values.append(tmdb_name)
                                     else:
                                         smart_values.append(tmdb_value)
-                            elif smart == "studio":
-                                smart_values = util.get_list(smart_data, split=False)
                             else:
                                 smart_values = util.get_list(smart_data)
                             results_list = []
@@ -775,7 +773,7 @@ class CollectionBuilder:
                     self.sonarr_options[method_name[7:]] = util.get_bool(method_name, method_data)
                 elif method_name == "sonarr_tag":
                     self.sonarr_options["tag"] = util.get_list(method_data)
-                elif method_name in ["title", "title.and", "title.not", "title.begins", "title.ends"]:
+                elif method_name in ["title", "title.and", "title.not", "title.begins", "studio.ends", "studio", "studio.and", "studio.not", "studio.begins", "studio.ends"]:
                     self.methods.append(("plex_search", [{method_name: util.get_list(method_data, split=False)}]))
                 elif method_name in ["year.gt", "year.gte", "year.lt", "year.lte"]:
                     self.methods.append(("plex_search", [{method_name: util.check_year(method_data, current_year, method_name)}]))
@@ -951,7 +949,7 @@ class CollectionBuilder:
                                         raise Failed(f"Collection Warning: plex search limit attribute: {search_data} must be an integer greater then 0")
                                     else:
                                         searches[search] = search_data
-                                elif search == "title" and modifier in ["", ".and", ".not", ".begins", ".ends"]:
+                                elif search in ["title", "studio"] and modifier in ["", ".and", ".not", ".begins", ".ends"]:
                                     searches[search_final] = util.get_list(search_data, split=False)
                                 elif search in plex.tags and modifier in ["", ".and", ".not", ".begins", ".ends"]:
                                     if search_final in plex.tmdb_searches:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -933,8 +933,6 @@ class CollectionBuilder:
                                     raise Failed(f"Collection Error: {search_final} plex search attribute only works for movie libraries")
                                 elif search_final in plex.show_only_searches and self.library.is_movie:
                                     raise Failed(f"Collection Error: {search_final} plex search attribute only works for show libraries")
-                                elif search_final not in plex.searches:
-                                    raise Failed(f"Collection Error: {search_final} is not a valid plex search attribute")
                                 elif search_data is None:
                                     raise Failed(f"Collection Error: {search_final} plex search attribute is blank")
                                 elif search == "sort_by":
@@ -949,6 +947,8 @@ class CollectionBuilder:
                                         raise Failed(f"Collection Warning: plex search limit attribute: {search_data} must be an integer greater then 0")
                                     else:
                                         searches[search] = search_data
+                                elif search_final not in plex.searches:
+                                    raise Failed(f"Collection Error: {search_final} is not a valid plex search attribute")
                                 elif search in ["title", "studio"] and modifier in ["", ".and", ".not", ".begins", ".ends"]:
                                     searches[search_final] = util.get_list(search_data, split=False)
                                 elif search in plex.tags and modifier in ["", ".and", ".not", ".begins", ".ends"]:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1631,24 +1631,11 @@ class CollectionBuilder:
             if "name_mapping" in self.details:
                 if self.details["name_mapping"]:                    name_mapping = self.details["name_mapping"]
                 else:                                               logger.error("Collection Error: name_mapping attribute is blank")
-            for ad in self.library.asset_directory:
-                path = os.path.join(ad, f"{name_mapping}")
-                if self.library.asset_folders:
-                    if not os.path.isdir(path):
-                        continue
-                    poster_filter = os.path.join(ad, name_mapping, "poster.*")
-                    background_filter = os.path.join(ad, name_mapping, "background.*")
-                else:
-                    poster_filter = os.path.join(ad, f"{name_mapping}.*")
-                    background_filter = os.path.join(ad, f"{name_mapping}_background.*")
-                matches = glob.glob(poster_filter)
-                if len(matches) > 0:
-                    self.posters["asset_directory"] = os.path.abspath(matches[0])
-                matches = glob.glob(background_filter)
-                if len(matches) > 0:
-                    self.backgrounds["asset_directory"] = os.path.abspath(matches[0])
-                for item in self.library.query(self.obj.items):
-                    self.library.update_item_from_assets(item, dirs=[path])
+            poster_image, background_image = self.library.update_item_from_assets(self.obj, collection_mode=True, upload=False, name=name_mapping)
+            if poster_image:
+                self.posters["asset_directory"] = poster_image
+            if background_image:
+                self.backgrounds["asset_directory"] = background_image
 
         def set_image(image_method, images, is_background=False):
             message = f"{'background' if is_background else 'poster'} to [{'File' if image_method in image_file_details else 'URL'}] {images[image_method]}"

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -492,7 +492,7 @@ class CollectionBuilder:
                 for smart_key, smart_data in filter_dict.items():
                     smart, smart_mod, smart_final = _split(smart_key)
 
-                    def build_url_arg(arg, mod=None, arg_s=None, mod_s=None):
+                    def build_url_arg(arg, mod=None, arg_s=None, mod_s=None, param_s=None):
                         arg_key = plex.search_translation[smart] if smart in plex.search_translation else smart
                         if mod is None:
                             mod = plex.modifier_translation[smart_mod] if smart_mod in plex.search_translation else smart_mod
@@ -502,7 +502,9 @@ class CollectionBuilder:
                             mod_s = "does not contain" if smart_mod == ".not" else "contains"
                         elif mod_s is None:
                             mod_s = plex.mod_displays[smart_mod]
-                        display_line = f"{indent}{smart.title().replace('_', ' ')} {mod_s} {arg_s}"
+                        if param_s is None:
+                            param_s = smart.title().replace('_', ' ')
+                        display_line = f"{indent}{param_s} {mod_s} {arg_s}"
                         return f"{arg_key}{mod}={arg}&", display_line
 
                     if smart_final in plex.movie_only_smart_searches and self.library.is_show:
@@ -538,6 +540,13 @@ class CollectionBuilder:
                         results, display_add = build_url_arg(util.check_number(smart_data, smart_final, minimum=1))
                     elif smart in ["user_rating", "episode_user_rating", "critic_rating", "audience_rating"] and smart_mod in [".gt", ".gte", ".lt", ".lte"]:
                         results, display_add = build_url_arg(util.check_number(smart_data, smart_final, number_type="float", minimum=0, maximum=10))
+                    elif smart == "hdr":
+                        if isinstance(smart_data, bool):
+                            hdr_mod = "" if smart_data else "!"
+                            hdr_arg = "true" if smart_data else "false"
+                            results, display_add = build_url_arg(1, mod=hdr_mod, arg_s=hdr_arg, mod_s="is", param_s="HDR")
+                        else:
+                            raise Failed("Collection Error: HDR must be true or false")
                     else:
                         if smart in ["title", "episode_title"] and smart_mod in ["", ".not", ".begins", ".ends"]:
                             results_list = [(t, t) for t in util.get_list(smart_data, split=False)]

--- a/modules/config.py
+++ b/modules/config.py
@@ -325,6 +325,7 @@ class Config:
             else:
                 params["name"] = str(library_name)
                 logger.info(f"Connecting to {params['name']} Library...")
+            params["mapping_name"] = str(library_name)
 
             params["asset_directory"] = check_for_attribute(lib, "asset_directory", parent="settings", var_type="list_path", default=self.general["asset_directory"], default_is_none=True, save=False)
             if params["asset_directory"] is None:

--- a/modules/config.py
+++ b/modules/config.py
@@ -390,6 +390,16 @@ class Config:
             else:
                 params["mass_critic_rating_update"] = None
 
+            if lib and "radarr_add_all" in lib and lib["radarr_add_all"]:
+                params["radarr_add_all"] = check_for_attribute(lib, "radarr_add_all", var_type="bool", default=False, save=False)
+            else:
+                params["radarr_add_all"] = None
+
+            if lib and "sonarr_add_all" in lib and lib["sonarr_add_all"]:
+                params["sonarr_add_all"] = check_for_attribute(lib, "sonarr_add_all", var_type="bool", default=False, save=False)
+            else:
+                params["sonarr_add_all"] = None
+
             try:
                 if lib and "metadata_path" in lib:
                     params["metadata_path"] = []

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -276,6 +276,8 @@ class Convert:
                 except requests.exceptions.ConnectionError:
                     util.print_stacktrace()
                     raise Failed("No External GUIDs found")
+                if not tvdb_id and not imdb_id and not tmdb_id:
+                    raise Failed("Refresh Metadata")
             elif item_type == "imdb":                       imdb_id = check_id
             elif item_type == "thetvdb":                    tvdb_id = int(check_id)
             elif item_type == "themoviedb":                 tmdb_id = int(check_id)

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -2,6 +2,7 @@ import logging, re, requests
 from lxml import html
 from modules import util
 from modules.util import Failed
+from plexapi.exceptions import BadRequest
 from retrying import retry
 
 logger = logging.getLogger("Plex Meta Manager")
@@ -356,7 +357,9 @@ class Convert:
                 return "movie", tmdb_id
             else:
                 raise Failed(f"No ID to convert")
-
         except Failed as e:
             util.print_end(length, f"Mapping Error | {item.guid:<46} | {e} for {item.title}")
-            return None, None
+        except BadRequest:
+            util.print_stacktrace()
+            util.print_end(length, f"Mapping Error: | {item.guid} for {item.title} not found")
+        return None, None

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -396,7 +396,11 @@ class PlexAPI:
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000, retry_on_exception=util.retry_if_not_plex)
     def get_guids(self, item):
-        item.reload(includeOnDeck=False, includeRelated=False, includeReviews=False)
+        item.reload(checkFiles=False, includeAllConcerts=False, includeBandwidths=False, includeChapters=False,
+                    includeChildren=False, includeConcerts=False, includeExternalMedia=False, inclueExtras=False,
+                    includeFields='', includeGeolocation=False, includeLoudnessRamps=False, includeMarkers=False,
+                    includeOnDeck=False, includePopularLeaves=False, includePreferences=False, includeRelated=False,
+                    includeRelatedCount=0, includeReviews=False, includeStations=False)
         return item.guids
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000, retry_on_exception=util.retry_if_not_plex)

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -2,6 +2,7 @@ import glob, logging, os, requests
 from modules import util
 from modules.meta import Metadata
 from modules.util import Failed
+import plexapi
 from plexapi import utils
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 from plexapi.collection import Collections
@@ -638,7 +639,11 @@ class PlexAPI:
         if smart_label_collection:
             return self.get_labeled_items(collection.title if isinstance(collection, Collections) else str(collection))
         elif isinstance(collection, Collections):
-            return self.query(collection.items)
+            if self.smart(collection):
+                key = f"/library/sections/{self.Plex.key}/all{self.smart_filter(collection)}"
+                return self.Plex._search(key, None, 0, plexapi.X_PLEX_CONTAINER_SIZE)
+            else:
+                return self.query(collection.items)
         else:
             return []
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -396,6 +396,7 @@ class PlexAPI:
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000, retry_on_exception=util.retry_if_not_plex)
     def get_guids(self, item):
+        item.reload(includeOnDeck=False, includeRelated=False, includeReviews=False)
         return item.guids
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000, retry_on_exception=util.retry_if_not_plex)

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -324,6 +324,7 @@ class PlexAPI:
         self.Sonarr = None
         self.Tautulli = None
         self.name = params["name"]
+        self.mapping_name = util.validate_filename(params["mapping_name"])
         self.missing_path = os.path.join(params["default_dir"], f"{self.name}_missing.yml")
         self.metadata_path = params["metadata_path"]
         self.asset_directory = params["asset_directory"]

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -565,14 +565,14 @@ class PlexAPI:
                             or_des = conjunction if o > 0 else f"{search_method}("
                             ors += f"{or_des}{param}"
                     if has_processed:
-                        logger.info(f"\t\t      AND {ors})")
+                        logger.info(f"                        AND {ors})")
                     else:
                         logger.info(f"Processing {pretty}: {ors})")
                         has_processed = True
             if search_sort:
-                logger.info(f"\t\t      SORT BY {search_sort})")
+                logger.info(f"                        SORT BY {search_sort}")
             if search_limit:
-                logger.info(f"\t\t      LIMIT {search_limit})")
+                logger.info(f"                        LIMIT {search_limit}")
             logger.debug(f"Search: {search_terms}")
             items = self.search(sort=sorts[search_sort], maxresults=search_limit, **search_terms)
         elif method == "plex_collectionless":
@@ -720,3 +720,4 @@ class PlexAPI:
                             episode_path = os.path.abspath(matches[0])
                             self.upload_image(episode, episode_path, url=False)
                             logger.info(f"Detail: asset_directory updated {item.title} {episode.seasonEpisode.upper()}'s poster to [file] {episode_path}")
+        return None, None

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -338,7 +338,9 @@ class PlexAPI:
         self.mass_genre_update = params["mass_genre_update"]
         self.mass_audience_rating_update = params["mass_audience_rating_update"]
         self.mass_critic_rating_update = params["mass_critic_rating_update"]
-        self.mass_update = self.mass_genre_update or self.mass_audience_rating_update or self.mass_critic_rating_update
+        self.radarr_add_all = params["radarr_add_all"]
+        self.sonarr_add_all = params["sonarr_add_all"]
+        self.mass_update = self.mass_genre_update or self.mass_audience_rating_update or self.mass_critic_rating_update or self.radarr_add_all or self.sonarr_add_all
         self.plex = params["plex"]
         self.url = params["plex"]["url"]
         self.token = params["plex"]["token"]

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -182,7 +182,7 @@ smart_searches = [
     "producer", "producer.not",
     "subtitle_language", "subtitle_language.not",
     "writer", "writer.not",
-    "decade", "resolution",
+    "decade", "resolution", "hdr",
     "added", "added.not", "added.before", "added.after",
     "originally_available", "originally_available.not",
     "originally_available.before", "originally_available.after",

--- a/modules/util.py
+++ b/modules/util.py
@@ -366,16 +366,22 @@ def centered(text, do_print=True):
     return final_text
 
 def separator(text=None):
-    logger.handlers[0].setFormatter(logging.Formatter(f"%(message)-{screen_width - 2}s"))
-    logger.handlers[1].setFormatter(logging.Formatter(f"[%(asctime)s] %(filename)-27s %(levelname)-10s %(message)-{screen_width - 2}s"))
+    for handler in logger.handlers:
+        apply_formatter(handler, border=False)
     logger.info(f"|{separating_character * screen_width}|")
     if text:
         text_list = text.split("\n")
         for t in text_list:
             logger.info(f"| {centered(t, do_print=False)} |")
         logger.info(f"|{separating_character * screen_width}|")
-    logger.handlers[0].setFormatter(logging.Formatter(f"| %(message)-{screen_width - 2}s |"))
-    logger.handlers[1].setFormatter(logging.Formatter(f"[%(asctime)s] %(filename)-27s %(levelname)-10s | %(message)-{screen_width - 2}s |"))
+    for handler in logger.handlers:
+        apply_formatter(handler)
+
+def apply_formatter(handler, border=True):
+    text = f"| %(message)-{screen_width - 2}s |" if border else f"%(message)-{screen_width - 2}s"
+    if not isinstance(handler, logging.StreamHandler):
+        text = f"[%(asctime)s] %(filename)-27s %(levelname)-10s {text}"
+    handler.setFormatter(logging.Formatter(text))
 
 def print_return(length, text):
     print(adjust_space(length, f"| {text}"), end="\r")

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,5 +1,6 @@
 import logging, re, signal, sys, time, traceback
 from datetime import datetime
+from pathvalidate import is_valid_filename, sanitize_filename
 from plexapi.exceptions import BadRequest, NotFound, Unauthorized
 
 try:
@@ -378,7 +379,7 @@ def separator(text=None):
 
 def apply_formatter(handler, border=True):
     text = f"| %(message)-{screen_width - 2}s |" if border else f"%(message)-{screen_width - 2}s"
-    if not isinstance(handler, logging.StreamHandler):
+    if isinstance(handler, logging.handlers.RotatingFileHandler):
         text = f"[%(asctime)s] %(filename)-27s %(levelname)-10s {text}"
     handler.setFormatter(logging.Formatter(text))
 
@@ -389,3 +390,11 @@ def print_return(length, text):
 def print_end(length, text=None):
     if text:        logger.info(adjust_space(length, text))
     else:           print(adjust_space(length, " "), end="\r")
+
+def validate_filename(filename):
+    if is_valid_filename(filename):
+        return filename
+    else:
+        mapping_name = sanitize_filename(filename)
+        logger.info(f"Folder Name: {filename} is invalid using {mapping_name}")
+        return mapping_name

--- a/modules/util.py
+++ b/modules/util.py
@@ -220,7 +220,6 @@ def compile_list(data):
     else:
         return data
 
-
 def get_list(data, lower=False, split=True, int_list=False):
     if isinstance(data, list):      return data
     elif isinstance(data, dict):    return [data]

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -98,7 +98,7 @@ def start(config_path, is_test, daily, requested_collections, requested_librarie
     util.centered("|  __/| |  __/>  <  | |  | |  __/ || (_| | | |  | | (_| | | | | (_| | (_| |  __/ |   ")
     util.centered("|_|   |_|\\___/_/\\_\\ |_|  |_|\\___|\\__\\__,_| |_|  |_|\\__,_|_| |_|\\__,_|\\__, |\\___|_|   ")
     util.centered("                                                                     |___/           ")
-    util.centered("    Version: 1.9.1                                                                   ")
+    util.centered("    Version: 1.9.2                                                                   ")
     util.separator()
     if daily:                       start_type = "Daily "
     elif is_test:                   start_type = "Test "

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -18,10 +18,10 @@ parser.add_argument("-t", "--time", dest="time", help="Time to update each day u
 parser.add_argument("-re", "--resume", dest="resume", help="Resume collection run from a specific collection", type=str)
 parser.add_argument("-r", "--run", dest="run", help="Run without the scheduler", action="store_true", default=False)
 parser.add_argument("-rt", "--test", "--tests", "--run-test", "--run-tests", dest="test", help="Run in debug mode with only collections that have test: true", action="store_true", default=False)
-parser.add_argument("-lo", "--library-only", dest="library_only", help="Run only library operations", action="store_true", default=False)
-parser.add_argument("-co", "--collection-only", dest="collection_only", help="Run only collection operations", action="store_true", default=False)
-parser.add_argument("-cl", "--collection", "--collections", dest="collections", help="Process only specified collections (comma-separated list)", type=str)
-parser.add_argument("-l", "--library", "--libraries", dest="libraries", help="Process only specified libraries (comma-separated list)", type=str)
+parser.add_argument("-co", "--collection-only", "--collections-only", dest="collection_only", help="Run only collection operations", action="store_true", default=False)
+parser.add_argument("-lo", "--library-only", "--libraries-only", dest="library_only", help="Run only library operations", action="store_true", default=False)
+parser.add_argument("-rc", "-cl", "--collection", "--collections", "--run-collection", "--run-collections", dest="collections", help="Process only specified collections (comma-separated list)", type=str)
+parser.add_argument("-rl", "-l", "--library", "--libraries", "--run-library", "--run-libraries", dest="libraries", help="Process only specified libraries (comma-separated list)", type=str)
 parser.add_argument("-d", "--divider", dest="divider", help="Character that divides the sections (Default: '=')", default="=", type=str)
 parser.add_argument("-w", "--width", dest="width", help="Screen Width (Default: 100)", default=100, type=int)
 args = parser.parse_args()
@@ -41,8 +41,8 @@ def check_bool(env_str, default):
 test = check_bool("PMM_TEST", args.test)
 debug = check_bool("PMM_DEBUG", args.debug)
 run = check_bool("PMM_RUN", args.run)
-library_only = check_bool("PMM_LIBRARY_ONLY", args.library_only)
-collection_only = check_bool("PMM_COLLECTION_ONLY", args.collection_only)
+library_only = check_bool("PMM_LIBRARIES_ONLY", args.library_only)
+collection_only = check_bool("PMM_COLLECTIONS_ONLY", args.collection_only)
 collections = os.environ.get("PMM_COLLECTIONS") if os.environ.get("PMM_COLLECTIONS") else args.collections
 libraries = os.environ.get("PMM_LIBRARIES") if os.environ.get("PMM_LIBRARIES") else args.libraries
 resume = os.environ.get("PMM_RESUME") if os.environ.get("PMM_RESUME") else args.resume
@@ -156,7 +156,7 @@ def update_libraries(config, is_test, requested_collections, resume_from):
                     unmanaged_count += 1
             logger.info("{} Unmanaged Collections".format(unmanaged_count))
 
-        if library.assets_for_all is True and not is_test and not requested_collections:
+        if library.assets_for_all is True and not is_test and not requested_collections and not collection_only:
             logger.info("")
             util.separator(f"All {'Movies' if library.is_movie else 'Shows'} Assets Check for {library.name} Library")
             logger.info("")

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -141,24 +141,30 @@ def update_libraries(config, is_test, requested_collections, resume_from):
             if collections_to_run and not library_only:
                 resume_from = run_collection(config, library, metadata, collections_to_run, is_test, resume_from, movie_map, show_map)
 
-        if library.show_unmanaged is True and not is_test and not requested_collections and not library_only:
-            logger.info("")
-            util.separator(f"Unmanaged Collections in {library.name} Library")
-            logger.info("")
-            unmanaged_count = 0
-            collections_in_plex = [str(plex_col) for plex_col in library.collections]
+        if not is_test and not requested_collections:
+            unmanaged_collections = []
             for col in library.get_all_collections():
-                if col.title not in collections_in_plex:
-                    logger.info(col.title)
-                    unmanaged_count += 1
-            logger.info("{} Unmanaged Collections".format(unmanaged_count))
+                if col.title not in library.collections:
+                    unmanaged_collections.append(col)
 
-        if library.assets_for_all is True and not is_test and not requested_collections and not collection_only:
-            logger.info("")
-            util.separator(f"All {'Movies' if library.is_movie else 'Shows'} Assets Check for {library.name} Library")
-            logger.info("")
-            for item in library.get_all():
-                library.update_item_from_assets(item)
+            if library.show_unmanaged and not library_only:
+                logger.info("")
+                util.separator(f"Unmanaged Collections in {library.name} Library")
+                logger.info("")
+                for col in unmanaged_collections:
+                    logger.info(col.title)
+                logger.info(f"{len(unmanaged_collections)} Unmanaged Collections")
+
+            if library.assets_for_all and not collection_only:
+                logger.info("")
+                util.separator(f"All {'Movies' if library.is_movie else 'Shows'} Assets Check for {library.name} Library")
+                logger.info("")
+                for col in unmanaged_collections:
+                    library.update_item_from_assets(col, collection_mode=True)
+                for item in library.get_all():
+                    library.update_item_from_assets(item)
+
+
     has_run_again = False
     for library in config.libraries:
         if library.run_again:

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -375,15 +375,16 @@ def run_collection(config, library, metadata, requested_collections, is_test, re
 
                 builder.collect_rating_keys(movie_map, show_map)
                 logger.info("")
-                if len(builder.rating_keys) > 0:
+                if len(builder.rating_keys) > 0 and builder.build_collection:
                     builder.add_to_collection(movie_map)
                 if len(builder.missing_movies) > 0 or len(builder.missing_shows) > 0:
                     builder.run_missing()
-                if builder.sync and len(builder.rating_keys) > 0:
+                if builder.sync and len(builder.rating_keys) > 0 and builder.build_collection:
                     builder.sync_collection()
                 logger.info("")
 
-            builder.update_details()
+            if builder.build_collection:
+                builder.update_details()
 
             if builder.run_again and (len(builder.run_again_movies) > 0 or len(builder.run_again_shows) > 0):
                 library.run_again.append(builder)

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -124,7 +124,6 @@ def update_libraries(config, is_test, requested_collections, resume_from):
         should_roll_over = os.path.isfile(col_file_logger)
         library_handler = logging.handlers.RotatingFileHandler(col_file_logger, delay=True, mode="w", backupCount=3, encoding="utf-8")
         util.apply_formatter(library_handler)
-        library_handler.addFilter(fmt_filter)
         if should_roll_over:
             library_handler.doRollover()
         logger.addHandler(library_handler)
@@ -388,7 +387,6 @@ def run_collection(config, library, metadata, requested_collections, is_test, re
         should_roll_over = os.path.isfile(col_file_logger)
         collection_handler = logging.handlers.RotatingFileHandler(col_file_logger, delay=True, mode="w", backupCount=3, encoding="utf-8")
         util.apply_formatter(collection_handler)
-        collection_handler.addFilter(fmt_filter)
         if should_roll_over:
             collection_handler.doRollover()
         logger.addHandler(collection_handler)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests>=2.4.2
 ruamel.yaml
 schedule
 retrying
+pathvalidate


### PR DESCRIPTION
Added [pathvalidate](https://github.com/thombashi/pathvalidate) requirement (requirements will need to be reinstalled)

## New Features
Adds better logging
Adds `--collections-only` and `--libraries-only` flags to only run parts of PMM
Adds `.remove` to any details that could use `.sync` to only remove tags
Closes #235 - use `radarr_add_all` or `sonarr_add_all` as a [Library Attribute](https://github.com/meisnate12/Plex-Meta-Manager/wiki/Libraries-Attributes) to add all items in your plex library 
Closes #245 - Adds `build_collection` which when set to false 
Closes #247 - `hdr` added to `smart_filter`
Closes #248 - Smart Collections now can edit the items inside them

## Bug Fixes
Fixes #258 - faster loading of item guids
Fixes various small errors