### PR TITLE
v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Plex Meta Manager
-#### Version 1.9.3
+#### Version 1.10.0
 
 The original concept for Plex Meta Manager is [Plex Auto Collections](https://github.com/mza921/Plex-Auto-Collections), but this is rewritten from the ground up to be able to include a scheduler, metadata edits, multiple libraries, and logging. Plex Meta Manager is a Python 3 script that can be continuously run using YAML configuration files to update on a schedule the metadata of the movies, shows, and collections in your libraries as well as automatically build collections based on various methods all detailed in the wiki. Some collection examples that the script can automatically build and update daily include Plex Based Searches like actor, genre, or studio collections or Collections based on TMDb, IMDb, Trakt, TVDb, AniDB, or MyAnimeList lists and various other services.
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1176,7 +1176,7 @@ class CollectionBuilder:
                     display_line = f"{indent}{param_s} {mod_s} {arg_s}"
                     return f"{arg_key}{mod}={arg}&", display_line
 
-                if final not in plex.searches and final not in ["any", "all"] and modifier != ".and":
+                if final not in plex.searches and final not in ["any", "all"]:
                     raise Failed(f"Collection Error: {final} is not a valid {method} attribute")
                 elif final in plex.movie_only_searches and self.library.is_show:
                     raise Failed(f"Collection Error: {final} {method} attribute only works for movie libraries")
@@ -1251,13 +1251,13 @@ class CollectionBuilder:
     def validate_attribute(self, attribute, modifier, final, data, validate, smart=False):
         def smart_pair(list_to_pair):
             return [(t, t) for t in list_to_pair] if smart else list_to_pair
-        if attribute in ["title", "studio", "episode_title", "audio_track_title"] and modifier in ["", ".and", ".not", ".begins", ".ends"]:
+        if attribute in ["title", "studio", "episode_title", "audio_track_title"] and modifier in ["", ".not", ".begins", ".ends"]:
             return smart_pair(util.get_list(data, split=False))
         elif attribute == "original_language":
             return util.get_list(data, lower=True)
         elif attribute == "filepath":
             return util.get_list(data)
-        elif attribute in plex.tags and modifier in ["", ".and", ".not"]:
+        elif attribute in plex.tags and modifier in ["", ".not"]:
             if attribute in plex.tmdb_attributes:
                 final_values = []
                 for value in util.get_list(data):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -647,8 +647,11 @@ class CollectionBuilder:
                 raise Failed(f"Collection Error: {base} must be a dictionary: {smart_filter[smart_methods[base]]}")
             built_filter, filter_text = _filter(smart_filter[smart_methods[base]], validate, is_all=base_all)
             self.smart_filter_details = f"{filter_details}Filter:{filter_text}"
-            final_filter = built_filter[:-1] if base_all else f"push=1&{built_filter}pop=1"
-            self.smart_url = f"?type={self.smart_type_key}&{f'limit={limit}&' if limit else ''}sort={smart_sorts[smart_sort]}&{final_filter}"
+            if len(built_filter) > 0:
+                final_filter = built_filter[:-1] if base_all else f"push=1&{built_filter}pop=1"
+                self.smart_url = f"?type={self.smart_type_key}&{f'limit={limit}&' if limit else ''}sort={smart_sorts[smart_sort]}&{final_filter}"
+            else:
+                raise Failed("Collection Error: No Filter Created")
 
         def cant_interact(attr1, attr2, fail=False):
             if getattr(self, attr1) and getattr(self, attr2):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1369,7 +1369,6 @@ class CollectionBuilder:
         name, collection_items = self.library.get_collection_name_and_items(self.obj if self.obj else self.name, self.smart_label_collection)
         total = len(self.rating_keys)
         max_length = len(str(total))
-        length = 0
         for i, item in enumerate(self.rating_keys, 1):
             try:
                 current = self.library.fetchItem(item.ratingKey if isinstance(item, (Movie, Show)) else int(item))
@@ -1380,7 +1379,7 @@ class CollectionBuilder:
                 continue
             match = True
             if self.filters:
-                length = util.print_return(length, f"Filtering {(' ' * (max_length - len(str(i)))) + str(i)}/{total} {current.title}")
+                util.print_return(f"Filtering {(' ' * (max_length - len(str(i)))) + str(i)}/{total} {current.title}")
                 for filter_method, filter_data in self.filters:
                     modifier = filter_method[-4:]
                     method = filter_method[:-4] if modifier in [".not", ".lte", ".gte"] else filter_method
@@ -1474,9 +1473,9 @@ class CollectionBuilder:
                                 or (list(set(filter_data) & set(attrs)) and modifier == ".not"):
                             match = False
                             break
-                length = util.print_return(length, f"Filtering {(' ' * (max_length - len(str(i)))) + str(i)}/{total} {current.title}")
+                util.print_return(f"Filtering {(' ' * (max_length - len(str(i)))) + str(i)}/{total} {current.title}")
             if match:
-                logger.info(util.adjust_space(length, f"{name} Collection | {'=' if current in collection_items else '+'} | {current.title}"))
+                logger.info(util.adjust_space(f"{name} Collection | {'=' if current in collection_items else '+'} | {current.title}"))
                 if current in collection_items:
                     self.plex_map[current.ratingKey] = None
                 elif self.smart_label_collection:
@@ -1486,7 +1485,7 @@ class CollectionBuilder:
             elif self.details["show_filtered"] is True:
                 logger.info(f"{name} Collection | X | {current.title}")
         media_type = f"{'Movie' if self.library.is_movie else 'Show'}{'s' if total > 1 else ''}"
-        util.print_end(length)
+        util.print_end()
         logger.info("")
         logger.info(f"{total} {media_type} Processed")
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -726,9 +726,6 @@ class CollectionBuilder:
                 elif method_name == "file_background":
                     if os.path.exists(method_data):                             self.backgrounds[method_name] = os.path.abspath(method_data)
                     else:                                                       raise Failed(f"Collection Error: Background Path Does Not Exist: {os.path.abspath(method_data)}")
-                elif method_name == "sync_mode":
-                    if str(method_data).lower() in ["append", "sync"]:          self.details[method_name] = method_data.lower()
-                    else:                                                       raise Failed("Collection Error: sync_mode attribute must be either 'append' or 'sync'")
                 elif method_name == "label":
                     if "label" in self.data and "label.sync" in self.data:
                         raise Failed(f"Collection Error: Cannot use label and label.sync together")

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -16,6 +16,8 @@ class Cache:
                 else:
                     logger.info(f"Using cache database at {cache}")
                 cursor.execute("DROP TABLE IF EXISTS guids")
+                cursor.execute("DROP TABLE IF EXISTS imdb_to_tvdb_map")
+                cursor.execute("DROP TABLE IF EXISTS tmdb_to_tvdb_map")
                 cursor.execute("DROP TABLE IF EXISTS imdb_map")
                 cursor.execute(
                     """CREATE TABLE IF NOT EXISTS guid_map (
@@ -34,17 +36,17 @@ class Cache:
                     expiration_date TEXT)"""
                 )
                 cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS imdb_to_tvdb_map (
+                    """CREATE TABLE IF NOT EXISTS imdb_to_tvdb_map2 (
                     INTEGER PRIMARY KEY,
                     imdb_id TEXT UNIQUE,
-                    tvdb_id TEXT UNIQUE,
+                    tvdb_id TEXT,
                     expiration_date TEXT)"""
                 )
                 cursor.execute(
-                    """CREATE TABLE IF NOT EXISTS tmdb_to_tvdb_map (
+                    """CREATE TABLE IF NOT EXISTS tmdb_to_tvdb_map2 (
                     INTEGER PRIMARY KEY,
                     tmdb_id TEXT UNIQUE,
-                    tvdb_id TEXT UNIQUE,
+                    tvdb_id TEXT,
                     expiration_date TEXT)"""
                 )
                 cursor.execute(
@@ -110,18 +112,18 @@ class Cache:
     def query_imdb_to_tvdb_map(self, _id, imdb=True):
         from_id = "imdb_id" if imdb else "tvdb_id"
         to_id = "tvdb_id" if imdb else "imdb_id"
-        return self._query_map("imdb_to_tvdb_map", _id, from_id, to_id)
+        return self._query_map("imdb_to_tvdb_map2", _id, from_id, to_id)
 
     def update_imdb_to_tvdb_map(self, expired, imdb_id, tvdb_id):
-        self._update_map("imdb_to_tvdb_map", "imdb_id", imdb_id, "tvdb_id", tvdb_id, expired)
+        self._update_map("imdb_to_tvdb_map2", "imdb_id", imdb_id, "tvdb_id", tvdb_id, expired)
 
     def query_tmdb_to_tvdb_map(self, _id, tmdb=True):
         from_id = "tmdb_id" if tmdb else "tvdb_id"
         to_id = "tvdb_id" if tmdb else "tmdb_id"
-        return self._query_map("tmdb_to_tvdb_map", _id, from_id, to_id)
+        return self._query_map("tmdb_to_tvdb_map2", _id, from_id, to_id)
 
     def update_tmdb_to_tvdb_map(self, expired, tmdb_id, tvdb_id):
-        self._update_map("tmdb_to_tvdb_map", "tmdb_id", tmdb_id, "tvdb_id", tvdb_id, expired)
+        self._update_map("tmdb_to_tvdb_map2", "tmdb_id", tmdb_id, "tvdb_id", tvdb_id, expired)
 
     def query_letterboxd_map(self, letterboxd_id):
         return self._query_map("letterboxd_map", letterboxd_id, "letterboxd_id", "tmdb_id")

--- a/modules/config.py
+++ b/modules/config.py
@@ -138,6 +138,9 @@ class Config:
             elif data[attribute] is None:
                 if default_is_none is True:                                         return None
                 else:                                                               message = f"{text} is blank"
+            elif var_type == "url":
+                if data[attribute].endswith(("\\", "/")):                           return data[attribute][:-1]
+                else:                                                               return data[attribute]
             elif var_type == "bool":
                 if isinstance(data[attribute], bool):                               return data[attribute]
                 else:                                                               message = f"{text} must be either true or false"
@@ -279,7 +282,7 @@ class Config:
         logger.info("Connecting to Plex Libraries...")
 
         self.general["plex"] = {}
-        self.general["plex"]["url"] = check_for_attribute(self.data, "url", parent="plex", default_is_none=True)
+        self.general["plex"]["url"] = check_for_attribute(self.data, "url", parent="plex", var_type="url", default_is_none=True)
         self.general["plex"]["token"] = check_for_attribute(self.data, "token", parent="plex", default_is_none=True)
         self.general["plex"]["timeout"] = check_for_attribute(self.data, "timeout", parent="plex", var_type="int", default=60)
         self.general["plex"]["clean_bundles"] = check_for_attribute(self.data, "clean_bundles", parent="plex", var_type="bool", default=False)
@@ -287,7 +290,7 @@ class Config:
         self.general["plex"]["optimize"] = check_for_attribute(self.data, "optimize", parent="plex", var_type="bool", default=False)
 
         self.general["radarr"] = {}
-        self.general["radarr"]["url"] = check_for_attribute(self.data, "url", parent="radarr", default_is_none=True)
+        self.general["radarr"]["url"] = check_for_attribute(self.data, "url", parent="radarr", var_type="url", default_is_none=True)
         self.general["radarr"]["token"] = check_for_attribute(self.data, "token", parent="radarr", default_is_none=True)
         self.general["radarr"]["version"] = check_for_attribute(self.data, "version", parent="radarr", test_list=radarr_versions, default="v3")
         self.general["radarr"]["add"] = check_for_attribute(self.data, "add", parent="radarr", var_type="bool", default=False)
@@ -299,7 +302,7 @@ class Config:
         self.general["radarr"]["search"] = check_for_attribute(self.data, "search", parent="radarr", var_type="bool", default=False)
 
         self.general["sonarr"] = {}
-        self.general["sonarr"]["url"] = check_for_attribute(self.data, "url", parent="sonarr", default_is_none=True)
+        self.general["sonarr"]["url"] = check_for_attribute(self.data, "url", parent="sonarr", var_type="url", default_is_none=True)
         self.general["sonarr"]["token"] = check_for_attribute(self.data, "token", parent="sonarr", default_is_none=True)
         self.general["sonarr"]["version"] = check_for_attribute(self.data, "version", parent="sonarr", test_list=sonarr_versions, default="v3")
         self.general["sonarr"]["add"] = check_for_attribute(self.data, "add", parent="sonarr", var_type="bool", default=False)
@@ -314,7 +317,7 @@ class Config:
         self.general["sonarr"]["cutoff_search"] = check_for_attribute(self.data, "cutoff_search", parent="sonarr", var_type="bool", default=False)
 
         self.general["tautulli"] = {}
-        self.general["tautulli"]["url"] = check_for_attribute(self.data, "url", parent="tautulli", default_is_none=True)
+        self.general["tautulli"]["url"] = check_for_attribute(self.data, "url", parent="tautulli", var_type="url", default_is_none=True)
         self.general["tautulli"]["apikey"] = check_for_attribute(self.data, "apikey", parent="tautulli", default_is_none=True)
 
         self.libraries = []
@@ -440,7 +443,7 @@ class Config:
                     params["metadata_path"] = [("File", os.path.join(default_dir, f"{library_name}.yml"))]
                 params["default_dir"] = default_dir
                 params["plex"] = {}
-                params["plex"]["url"] = check_for_attribute(lib, "url", parent="plex", default=self.general["plex"]["url"], req_default=True, save=False)
+                params["plex"]["url"] = check_for_attribute(lib, "url", parent="plex", var_type="url", default=self.general["plex"]["url"], req_default=True, save=False)
                 params["plex"]["token"] = check_for_attribute(lib, "token", parent="plex", default=self.general["plex"]["token"], req_default=True, save=False)
                 params["plex"]["timeout"] = check_for_attribute(lib, "timeout", parent="plex", var_type="int", default=self.general["plex"]["timeout"], save=False)
                 params["plex"]["clean_bundles"] = check_for_attribute(lib, "clean_bundles", parent="plex", var_type="bool", default=self.general["plex"]["clean_bundles"], save=False)
@@ -462,7 +465,7 @@ class Config:
                 logger.info("")
                 radarr_params = {}
                 try:
-                    radarr_params["url"] = check_for_attribute(lib, "url", parent="radarr", default=self.general["radarr"]["url"], req_default=True, save=False)
+                    radarr_params["url"] = check_for_attribute(lib, "url", parent="radarr", var_type="url", default=self.general["radarr"]["url"], req_default=True, save=False)
                     radarr_params["token"] = check_for_attribute(lib, "token", parent="radarr", default=self.general["radarr"]["token"], req_default=True, save=False)
                     radarr_params["version"] = check_for_attribute(lib, "version", parent="radarr", test_list=radarr_versions, default=self.general["radarr"]["version"], save=False)
                     radarr_params["add"] = check_for_attribute(lib, "add", parent="radarr", var_type="bool", default=self.general["radarr"]["add"], save=False)
@@ -486,7 +489,7 @@ class Config:
                 logger.info("")
                 sonarr_params = {}
                 try:
-                    sonarr_params["url"] = check_for_attribute(lib, "url", parent="sonarr", default=self.general["sonarr"]["url"], req_default=True, save=False)
+                    sonarr_params["url"] = check_for_attribute(lib, "url", parent="sonarr", var_type="url", default=self.general["sonarr"]["url"], req_default=True, save=False)
                     sonarr_params["token"] = check_for_attribute(lib, "token", parent="sonarr", default=self.general["sonarr"]["token"], req_default=True, save=False)
                     sonarr_params["version"] = check_for_attribute(lib, "version", parent="sonarr", test_list=sonarr_versions, default=self.general["sonarr"]["version"], save=False)
                     sonarr_params["add"] = check_for_attribute(lib, "add", parent="sonarr", var_type="bool", default=self.general["sonarr"]["add"], save=False)
@@ -516,7 +519,7 @@ class Config:
                 logger.info("")
                 tautulli_params = {}
                 try:
-                    tautulli_params["url"] = check_for_attribute(lib, "url", parent="tautulli", default=self.general["tautulli"]["url"], req_default=True, save=False)
+                    tautulli_params["url"] = check_for_attribute(lib, "url", parent="tautulli", var_type="url", default=self.general["tautulli"]["url"], req_default=True, save=False)
                     tautulli_params["apikey"] = check_for_attribute(lib, "apikey", parent="tautulli", default=self.general["tautulli"]["apikey"], req_default=True, save=False)
                     library.Tautulli = TautulliAPI(tautulli_params)
                 except Failed as e:

--- a/modules/config.py
+++ b/modules/config.py
@@ -446,7 +446,7 @@ class Config:
                 params["plex"]["clean_bundles"] = check_for_attribute(lib, "clean_bundles", parent="plex", var_type="bool", default=self.general["plex"]["clean_bundles"], save=False)
                 params["plex"]["empty_trash"] = check_for_attribute(lib, "empty_trash", parent="plex", var_type="bool", default=self.general["plex"]["empty_trash"], save=False)
                 params["plex"]["optimize"] = check_for_attribute(lib, "optimize", parent="plex", var_type="bool", default=self.general["plex"]["optimize"], save=False)
-                library = PlexAPI(params, self.TMDb, self.TVDb)
+                library = PlexAPI(params)
                 logger.info("")
                 logger.info(f"{display_name} Library Connection Successful")
             except Failed as e:

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -248,7 +248,7 @@ class Convert:
             self.config.Cache.update_imdb_to_tvdb_map(expired, imdb_id, tvdb_id)
         return tvdb_id
 
-    def get_id(self, item, library, length):
+    def get_id(self, item, library):
         expired = None
         if self.config.Cache:
             cache_id, media_type, expired = self.config.Cache.query_guid_map(item.guid)
@@ -344,7 +344,7 @@ class Convert:
             def update_cache(cache_ids, id_type, guid_type):
                 if self.config.Cache:
                     cache_ids = util.compile_list(cache_ids)
-                    logger.info(util.adjust_space(length, f" Cache  |  {'^' if expired else '+'}  | {item.guid:<46} | {id_type} ID: {cache_ids:<6} | {item.title}"))
+                    logger.info(util.adjust_space(f" Cache  |  {'^' if expired else '+'}  | {item.guid:<46} | {id_type} ID: {cache_ids:<6} | {item.title}"))
                     self.config.Cache.update_guid_map(guid_type, item.guid, cache_ids, expired)
 
             if tmdb_id and library.is_movie:
@@ -359,8 +359,8 @@ class Convert:
             else:
                 raise Failed(f"No ID to convert")
         except Failed as e:
-            logger.info(util.adjust_space(length, f"Mapping Error | {item.guid:<46} | {e} for {item.title}"))
+            logger.info(util.adjust_space(f"Mapping Error | {item.guid:<46} | {e} for {item.title}"))
         except BadRequest:
             util.print_stacktrace()
-            logger.info(util.adjust_space(length, f"Mapping Error | {item.guid:<46} | Bad Request for {item.title}"))
+            logger.info(util.adjust_space(f"Mapping Error | {item.guid:<46} | Bad Request for {item.title}"))
         return None, None

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -62,7 +62,6 @@ class IMDbAPI:
         current_url = self._fix_url(imdb_url)
         total, item_count = self._total(current_url, language)
         header = {"Accept-Language": language}
-        length = 0
         imdb_ids = []
         if "&start=" in current_url:        current_url = re.sub("&start=\\d+", "", current_url)
         if "&count=" in current_url:        current_url = re.sub("&count=\\d+", "", current_url)
@@ -74,7 +73,7 @@ class IMDbAPI:
         num_of_pages = math.ceil(int(limit) / item_count)
         for i in range(1, num_of_pages + 1):
             start_num = (i - 1) * item_count + 1
-            length = util.print_return(length, f"Parsing Page {i}/{num_of_pages} {start_num}-{limit if i == num_of_pages else i * item_count}")
+            util.print_return(f"Parsing Page {i}/{num_of_pages} {start_num}-{limit if i == num_of_pages else i * item_count}")
             if imdb_url.startswith(self.urls["keyword"]):
                 response = self._request(f"{current_url}&page={i}", header)
             else:
@@ -83,7 +82,7 @@ class IMDbAPI:
                 imdb_ids.extend(response.xpath("//div[contains(@class, 'lister-item-image')]//a/img//@data-tconst")[:remainder])
             else:
                 imdb_ids.extend(response.xpath("//div[contains(@class, 'lister-item-image')]//a/img//@data-tconst"))
-        util.print_end(length)
+        util.print_end()
         if imdb_ids:                        return imdb_ids
         else:                               raise Failed(f"IMDb Error: No IMDb IDs Found at {imdb_url}")
 
@@ -111,11 +110,10 @@ class IMDbAPI:
             logger.info(f"Processing {pretty}: {status}{data['url']}")
             imdb_ids = self._ids_from_url(data["url"], language, data["limit"])
             total_ids = len(imdb_ids)
-            length = 0
             for i, imdb in enumerate(imdb_ids, 1):
-                length = util.print_return(length, f"Converting IMDb ID {i}/{total_ids}")
+                util.print_return(f"Converting IMDb ID {i}/{total_ids}")
                 run_convert(imdb)
-            logger.info(util.adjust_space(length, f"Processed {total_ids} IMDb IDs"))
+            logger.info(util.adjust_space(f"Processed {total_ids} IMDb IDs"))
         else:
             raise Failed(f"IMDb Error: Method {method} not supported")
         logger.debug("")

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -49,10 +49,9 @@ class LetterboxdAPI:
         items = self._parse_list(data, language)
         total_items = len(items)
         if total_items > 0:
-            length = 0
             for i, item in enumerate(items, 1):
                 letterboxd_id, slug = item
-                length = util.print_return(length, f"Finding TMDb ID {i}/{total_items}")
+                util.print_return(f"Finding TMDb ID {i}/{total_items}")
                 tmdb_id = None
                 expired = None
                 if self.config.Cache:
@@ -66,7 +65,7 @@ class LetterboxdAPI:
                     if self.config.Cache:
                         self.config.Cache.update_letterboxd_map(expired, letterboxd_id, tmdb_id)
                 movie_ids.append(tmdb_id)
-            logger.info(util.adjust_space(length, f"Processed {total_items} TMDb IDs"))
+            logger.info(util.adjust_space(f"Processed {total_items} TMDb IDs"))
         else:
             logger.error(f"Letterboxd Error: No List Items found in {data}")
         logger.debug("")

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -118,7 +118,7 @@ class Metadata:
                     else:
                         logger.error(f"Metadata Error: {attr} attribute is blank")
 
-            def edit_tags(attr, obj, group, alias, key=None, extra=None, movie_library=False):
+            def edit_tags(attr, obj, group, alias, extra=None, movie_library=False):
                 if movie_library and not self.library.is_movie and (attr in alias or f"{attr}.sync" in alias or f"{attr}.remove" in alias):
                     logger.error(f"Metadata Error: {attr} attribute only works for movie libraries")
                 elif attr in alias and f"{attr}.sync" in alias:
@@ -137,7 +137,7 @@ class Metadata:
                         add_tags.extend(extra)
                     remove_tags = util.get_list(group[alias[f"{attr}.remove"]]) if f"{attr}.remove" in alias else None
                     sync_tags = util.get_list(group[alias[f"{attr}.sync"]]) if f"{attr}.sync" in alias else None
-                    return self.library.edit_tags(attr, obj, add_tags=add_tags, remove_tags=remove_tags, sync_tags=sync_tags, key=key)
+                    return self.library.edit_tags(attr, obj, add_tags=add_tags, remove_tags=remove_tags, sync_tags=sync_tags)
                 return False
 
             def set_image(attr, obj, group, alias, poster=True, url=True):
@@ -252,30 +252,18 @@ class Metadata:
                 updated = True
 
             advance_edits = {}
-            add_advanced_edit("episode_sorting", item, meta, methods, show_library=True)
-            add_advanced_edit("keep_episodes", item, meta, methods, show_library=True)
-            add_advanced_edit("delete_episodes", item, meta, methods, show_library=True)
-            add_advanced_edit("season_display", item, meta, methods, show_library=True)
-            add_advanced_edit("episode_ordering", item, meta, methods, show_library=True)
-            add_advanced_edit("metadata_language", item, meta, methods, new_agent=True)
-            add_advanced_edit("use_original_title", item, meta, methods, new_agent=True)
+            for advance_edit in ["episode_sorting", "keep_episodes", "delete_episodes", "season_display", "episode_ordering", "metadata_language", "use_original_title"]:
+                is_show = advance_edit in ["episode_sorting", "keep_episodes", "delete_episodes", "season_display", "episode_ordering"]
+                is_new_agent = advance_edit in ["metadata_language", "use_original_title"]
+                add_advanced_edit(advance_edit, item, meta, methods, show_library=is_show, new_agent=is_new_agent)
             if self.library.edit_item(item, mapping_name, item_type, advance_edits, advanced=True):
                 updated = True
 
-            if edit_tags("genre", item, meta, methods, extra=genres):
-                updated = True
-            if edit_tags("label", item, meta, methods):
-                updated = True
-            if edit_tags("collection", item, meta, methods):
-                updated = True
-            if edit_tags("country", item, meta, methods, key="countries", movie_library=True):
-                updated = True
-            if edit_tags("director", item, meta, methods, movie_library=True):
-                updated = True
-            if edit_tags("producer", item, meta, methods, movie_library=True):
-                updated = True
-            if edit_tags("writer", item, meta, methods, movie_library=True):
-                updated = True
+            for tag_edit in ["genre", "label", "collection", "country", "director", "producer", "writer"]:
+                is_movie = tag_edit in ["country", "director", "producer", "writer"]
+                has_extra = genres if tag_edit == "genre" else None
+                if edit_tags(tag_edit, item, meta, methods, movie_library=is_movie, extra=has_extra):
+                    updated = True
 
             logger.info(f"{item_type}: {mapping_name} Details Update {'Complete' if updated else 'Not Needed'}")
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -612,9 +612,8 @@ class PlexAPI:
                 logger.info(col.title)
             collection_indexes = [c.index for c in good_collections]
             all_items = self.get_all()
-            length = 0
             for i, item in enumerate(all_items, 1):
-                length = util.print_return(length, f"Processing: {i}/{len(all_items)} {item.title}")
+                util.print_return(f"Processing: {i}/{len(all_items)} {item.title}")
                 add_item = True
                 self.query(item.reload)
                 for collection in item.collections:
@@ -623,7 +622,7 @@ class PlexAPI:
                         break
                 if add_item:
                     items.append(item)
-            logger.info(util.adjust_space(length, f"Processed {len(all_items)} {'Movies' if self.is_movie else 'Shows'}"))
+            logger.info(util.adjust_space(f"Processed {len(all_items)} {'Movies' if self.is_movie else 'Shows'}"))
         else:
             raise Failed(f"Plex Error: Method {method} not supported")
         if len(items) > 0:

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -129,17 +129,14 @@ show_only_searches = [
     "episode_user_rating.gt", "episode_user_rating.gte", "episode_user_rating.lt", "episode_user_rating.lte",
     "episode_year", "episode_year.not", "episode_year.gt", "episode_year.gte", "episode_year.lt", "episode_year.lte"
 ]
-tmdb_searches = [
-    "actor", "actor.and", "actor.not",
-    "director", "director.and", "director.not",
-    "producer", "producer.and", "producer.not",
-    "writer", "writer.and", "writer.not"
-]
-boolean_searches = [
+number_attributes = ["plays", "episode_plays", "added", "episode_added", "release", "episode_air_date", "duration", "tmdb_vote_count"]
+float_attributes = ["user_rating", "episode_user_rating", "critic_rating", "audience_rating"]
+boolean_attributes = [
     "hdr", "unmatched", "duplicate", "unplayed", "progress", "trash",
     "unplayed_episodes", "episode_unplayed", "episode_duplicate", "episode_progress", "episode_unmatched",
 ]
-date_searches = ["added", "episode_added", "release", "episode_air_date", "last_played", "episode_last_played"]
+tmdb_attributes = ["actor", "director", "producer", "writer"]
+date_attributes = ["added", "episode_added", "release", "episode_air_date", "last_played", "episode_last_played"]
 search_display = {
     "added": "Date Added",
     "release": "Release Date",
@@ -530,9 +527,9 @@ class PlexAPI:
                 else:
                     search, modifier = os.path.splitext(str(search_method).lower())
                     final_search = search_translation[search] if search in search_translation else search
-                    if search in date_searches and modifier == "":
+                    if search in date_attributes and modifier == "":
                         final_mod = ">>"
-                    elif search in date_searches and modifier == ".not":
+                    elif search in date_attributes and modifier == ".not":
                         final_mod = "<<"
                     elif search in ["critic_rating", "audience_rating"] and modifier == ".gt":
                         final_mod = "__gt"
@@ -544,7 +541,7 @@ class PlexAPI:
 
                     if search == "duration":
                         search_terms[final_method] = search_data * 60000
-                    elif search in date_searches and modifier in ["", ".not"]:
+                    elif search in date_attributes and modifier in ["", ".not"]:
                         search_terms[final_method] = f"{search_data}d"
                     else:
                         search_terms[final_method] = search_data

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -77,20 +77,20 @@ item_advance_keys = {
 }
 new_plex_agents = ["tv.plex.agents.movie", "tv.plex.agents.series"]
 searches = [
-    "title", "title.and", "title.not", "title.begins", "title.ends",
-    "studio", "studio.and", "studio.not", "studio.begins", "studio.ends",
-    "actor", "actor.and", "actor.not",
-    "audio_language", "audio_language.and", "audio_language.not",
-    "collection", "collection.and", "collection.not",
-    "content_rating", "content_rating.and", "content_rating.not",
-    "country", "country.and", "country.not",
-    "director", "director.and", "director.not",
-    "genre", "genre.and", "genre.not",
-    "label", "label.and", "label.not",
-    "network", "network.and", "network.not",
-    "producer", "producer.and", "producer.not",
-    "subtitle_language", "subtitle_language.and", "subtitle_language.not",
-    "writer", "writer.and", "writer.not",
+    "title", "title.not", "title.begins", "title.ends",
+    "studio", "studio.not", "studio.begins", "studio.ends",
+    "actor", "actor.not",
+    "audio_language", "audio_language.not",
+    "collection", "collection.not",
+    "content_rating", "content_rating.not",
+    "country", "country.not",
+    "director", "director.not",
+    "genre", "genre.not",
+    "label", "label.not",
+    "network", "network.not",
+    "producer", "producer.not",
+    "subtitle_language", "subtitle_language.not",
+    "writer", "writer.not",
     "decade", "resolution", "hdr", "unmatched", "duplicate", "unplayed", "progress", "trash",
     "last_played", "last_played.not", "last_played.before", "last_played.after",
     "added", "added.not", "added.before", "added.after",
@@ -102,7 +102,7 @@ searches = [
     "audience_rating.gt", "audience_rating.gte", "audience_rating.lt", "audience_rating.lte",
     "year", "year.not", "year.gt", "year.gte", "year.lt", "year.lte",
     "unplayed_episodes", "episode_unplayed", "episode_duplicate", "episode_progress", "episode_unmatched",
-    "episode_title", "episode_title.and", "episode_title.not", "episode_title.begins", "episode_title.ends",
+    "episode_title", "episode_title.not", "episode_title.begins", "episode_title.ends",
     "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
     "episode_air_date", "episode_air_date.not", "episode_air_date.before", "episode_air_date.after",
     "episode_last_played", "episode_last_played.not", "episode_last_played.before", "episode_last_played.after",
@@ -111,17 +111,17 @@ searches = [
     "episode_year", "episode_year.not", "episode_year.gt", "episode_year.gte", "episode_year.lt", "episode_year.lte"
 ]
 movie_only_searches = [
-    "country", "country.and", "country.not",
-    "director", "director.and", "director.not",
-    "producer", "producer.and", "producer.not",
-    "writer", "writer.and", "writer.not",
+    "country", "country.not",
+    "director", "director.not",
+    "producer", "producer.not",
+    "writer", "writer.not",
     "decade", "duplicate", "unplayed", "progress", "trash",
     "plays.gt", "plays.gte", "plays.lt", "plays.lte",
     "duration.gt", "duration.gte", "duration.lt", "duration.lte"
 ]
 show_only_searches = [
-    "network", "network.and", "network.not",
-    "episode_title", "episode_title.and", "episode_title.not", "episode_title.begins", "episode_title.ends",
+    "network", "network.not",
+    "episode_title", "episode_title.not", "episode_title.begins", "episode_title.ends",
     "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
     "episode_air_date", "episode_air_date.not",
     "episode_air_date.before", "episode_air_date.after",
@@ -155,7 +155,6 @@ sorts = {
     "added.asc": "addedAt:asc", "added.desc": "addedAt:desc"
 }
 modifiers = {
-    ".and": "&",
     ".not": "!",
     ".begins": "<",
     ".ends": ">",

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -91,20 +91,21 @@ searches = [
     "producer", "producer.and", "producer.not",
     "subtitle_language", "subtitle_language.and", "subtitle_language.not",
     "writer", "writer.and", "writer.not",
-    "decade", "resolution", "hdr",
+    "decade", "resolution", "hdr", "unmatched", "duplicate", "unplayed", "progress", "trash",
+    "last_played", "last_played.not", "last_played.before", "last_played.after",
     "added", "added.not", "added.before", "added.after",
-    "release", "release.not",
-    "release.before", "release.after",
+    "release", "release.not", "release.before", "release.after",
     "duration.gt", "duration.gte", "duration.lt", "duration.lte",
     "plays.gt", "plays.gte", "plays.lt", "plays.lte",
     "user_rating.gt", "user_rating.gte", "user_rating.lt", "user_rating.lte",
     "critic_rating.gt", "critic_rating.gte", "critic_rating.lt", "critic_rating.lte",
     "audience_rating.gt", "audience_rating.gte", "audience_rating.lt", "audience_rating.lte",
     "year", "year.not", "year.gt", "year.gte", "year.lt", "year.lte",
+    "unplayed_episodes", "episode_unplayed", "episode_duplicate", "episode_progress", "episode_unmatched",
     "episode_title", "episode_title.and", "episode_title.not", "episode_title.begins", "episode_title.ends",
     "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
-    "episode_air_date", "episode_air_date.not",
-    "episode_air_date.before", "episode_air_date.after",
+    "episode_air_date", "episode_air_date.not", "episode_air_date.before", "episode_air_date.after",
+    "episode_last_played", "episode_last_played.not", "episode_last_played.before", "episode_last_played.after",
     "episode_plays.gt", "episode_plays.gte", "episode_plays.lt", "episode_plays.lte",
     "episode_user_rating.gt", "episode_user_rating.gte", "episode_user_rating.lt", "episode_user_rating.lte",
     "episode_year", "episode_year.not", "episode_year.gt", "episode_year.gte", "episode_year.lt", "episode_year.lte"
@@ -114,7 +115,8 @@ movie_only_searches = [
     "director", "director.and", "director.not",
     "producer", "producer.and", "producer.not",
     "writer", "writer.and", "writer.not",
-    "decade", "resolution",
+    "decade", "duplicate", "unplayed", "progress", "trash",
+    "plays.gt", "plays.gte", "plays.lt", "plays.lte",
     "duration.gt", "duration.gte", "duration.lt", "duration.lte"
 ]
 show_only_searches = [
@@ -133,6 +135,18 @@ tmdb_searches = [
     "producer", "producer.and", "producer.not",
     "writer", "writer.and", "writer.not"
 ]
+boolean_searches = [
+    "hdr", "unmatched", "duplicate", "unplayed", "progress", "trash",
+    "unplayed_episodes", "episode_unplayed", "episode_duplicate", "episode_progress", "episode_unmatched",
+]
+date_searches = ["added", "episode_added", "release", "episode_air_date", "last_played", "episode_last_played"]
+search_display = {
+    "added": "Date Added",
+    "release": "Release Date",
+    "hdr": "HDR",
+    "progress": "In Progress",
+    "episode_progress": "Episode In Progress"
+}
 sorts = {
     None: None,
     "title.asc": "titleSort:asc", "title.desc": "titleSort:desc",
@@ -182,59 +196,6 @@ tags = [
     "studio",
     "subtitle_language",
     "writer"
-]
-smart_searches = [
-    "all", "any",
-    "title", "title.not", "title.begins", "title.ends",
-    "studio", "studio.not", "studio.begins", "studio.ends",
-    "actor", "actor.not",
-    "audio_language", "audio_language.not",
-    "collection", "collection.not",
-    "content_rating", "content_rating.not",
-    "country", "country.not",
-    "director", "director.not",
-    "genre", "genre.not",
-    "label", "label.not",
-    "network", "network.not",
-    "producer", "producer.not",
-    "subtitle_language", "subtitle_language.not",
-    "writer", "writer.not",
-    "decade", "resolution", "hdr",
-    "added", "added.not", "added.before", "added.after",
-    "release", "release.not",
-    "release.before", "release.after",
-    "plays.gt", "plays.gte", "plays.lt", "plays.lte",
-    "duration.gt", "duration.gte", "duration.lt", "duration.lte",
-    "user_rating.gt", "user_rating.gte", "user_rating.lt", "user_rating.lte",
-    "audience_rating.gt", "audience_rating.gte", "audience_rating.lt","audience_rating.lte",
-    "critic_rating.gt", "critic_rating.gte", "critic_rating.lt","critic_rating.lte",
-    "year", "year.not", "year.gt", "year.gte", "year.lt","year.lte",
-    "episode_title", "episode_title.not", "episode_title.begins", "episode_title.ends",
-    "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
-    "episode_air_date", "episode_air_date.not",
-    "episode_air_date.before", "episode_air_date.after",
-    "episode_year", "episode_year.not", "episode_year.gt", "episode_year.gte", "episode_year.lt","episode_year.lte",
-    "episode_user_rating.gt", "episode_user_rating.gte", "episode_user_rating.lt","episode_user_rating.lte",
-    "episode_plays.gt", "episode_plays.gte", "episode_plays.lt", "episode_plays.lte"
-]
-movie_only_smart_searches = [
-    "country", "country.not",
-    "director", "director.not",
-    "producer", "producer.not",
-    "writer", "writer.not",
-    "decade",
-    "plays.gt", "plays.gte", "plays.lt", "plays.lte",
-    "duration.gt", "duration.gte", "duration.lt", "duration.lte"
-]
-show_only_smart_searches = [
-    "network", "network.not",
-    "episode_title", "episode_title.not", "episode_title.begins", "episode_title.ends",
-    "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
-    "episode_air_date", "episode_air_date.not",
-    "episode_air_date.before", "episode_air_date.after",
-    "episode_year", "episode_year.not", "episode_year.gt", "episode_year.gte", "episode_year.lt","episode_year.lte",
-    "episode_user_rating.gt", "episode_user_rating.gte", "episode_user_rating.lt","episode_user_rating.lte",
-    "episode_plays.gt", "episode_plays.gte", "episode_plays.lt", "episode_plays.lte"
 ]
 movie_smart_sorts = {
     "title.asc": "titleSort", "title.desc": "titleSort%3Adesc",
@@ -569,9 +530,9 @@ class PlexAPI:
                 else:
                     search, modifier = os.path.splitext(str(search_method).lower())
                     final_search = search_translation[search] if search in search_translation else search
-                    if search in ["added", "release", "episode_air_date"] and modifier == "":
+                    if search in date_searches and modifier == "":
                         final_mod = ">>"
-                    elif search in ["added", "release", "episode_air_date"] and modifier == ".not":
+                    elif search in date_searches and modifier == ".not":
                         final_mod = "<<"
                     elif search in ["critic_rating", "audience_rating"] and modifier == ".gt":
                         final_mod = "__gt"
@@ -583,7 +544,7 @@ class PlexAPI:
 
                     if search == "duration":
                         search_terms[final_method] = search_data * 60000
-                    elif search in ["added", "release", "episode_air_date"] and modifier in ["", ".not"]:
+                    elif search in date_searches and modifier in ["", ".not"]:
                         search_terms[final_method] = f"{search_data}d"
                     else:
                         search_terms[final_method] = search_data

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -110,6 +110,16 @@ searches = [
     "episode_user_rating.gt", "episode_user_rating.gte", "episode_user_rating.lt", "episode_user_rating.lte",
     "episode_year", "episode_year.not", "episode_year.gt", "episode_year.gte", "episode_year.lt", "episode_year.lte"
 ]
+and_searches = [
+    "title.and", "studio.and", "actor.and", "audio_language.and", "collection.and",
+    "content_rating.and", "country.and",  "director.and", "genre.and", "label.and",
+    "network.and", "producer.and", "subtitle_language.and", "writer.and"
+]
+or_searches = [
+    "title", "studio", "actor", "audio_language", "collection", "content_rating",
+    "country", "director", "genre", "label", "network", "producer", "subtitle_language",
+    "writer", "decade", "resolution", "year", "episode_title", "episode_year"
+]
 movie_only_searches = [
     "country", "country.not",
     "director", "director.not",

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -10,15 +10,15 @@ builders = ["tautulli_popular", "tautulli_watched"]
 
 class TautulliAPI:
     def __init__(self, params):
+        self.url = params["url"]
+        self.apikey = params["apikey"]
         try:
-            response = self._request(f"{params['url']}/api/v2?apikey={params['apikey']}&cmd=get_library_names")
+            response = self._request(f"{self.url}/api/v2?apikey={self.apikey}&cmd=get_library_names")
         except Exception:
             util.print_stacktrace()
             raise Failed("Tautulli Error: Invalid url")
         if response["response"]["result"] != "success":
             raise Failed(f"Tautulli Error: {response['response']['message']}")
-        self.url = params["url"]
-        self.apikey = params["apikey"]
 
     def get_items(self, library, params):
         query_size = int(params["list_size"]) + int(params["list_buffer"])

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -2,7 +2,6 @@ import logging, requests
 from modules import util
 from modules.util import Failed
 from plexapi.exceptions import BadRequest, NotFound
-from plexapi.video import Movie, Show
 from retrying import retry
 
 logger = logging.getLogger("Plex Meta Manager")
@@ -12,7 +11,7 @@ builders = ["tautulli_popular", "tautulli_watched"]
 class TautulliAPI:
     def __init__(self, params):
         try:
-            response = requests.get(f"{params['url']}/api/v2?apikey={params['apikey']}&cmd=get_library_names").json()
+            response = self._request(f"{params['url']}/api/v2?apikey={params['apikey']}&cmd=get_library_names")
         except Exception:
             util.print_stacktrace()
             raise Failed("Tautulli Error: Invalid url")
@@ -65,5 +64,5 @@ class TautulliAPI:
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000)
     def _request(self, url):
-        logger.debug(f"Tautulli URL: {url.replace(self.apikey, '################################')}")
+        logger.debug(f"Tautulli URL: {url.replace(self.apikey, '###############')}")
         return requests.get(url).json()

--- a/modules/util.py
+++ b/modules/util.py
@@ -26,6 +26,7 @@ def retry_if_not_plex(exception):
 
 separating_character = "="
 screen_width = 100
+spacing = 0
 
 days_alias = {
     "monday": 0, "mon": 0, "m": 0,
@@ -154,13 +155,6 @@ pretty_ids = {
 
 def tab_new_lines(data):
     return str(data).replace("\n", "\n|\t      ") if "\n" in str(data) else str(data)
-
-def adjust_space(old_length, display_title):
-    display_title = str(display_title)
-    space_length = old_length - len(display_title)
-    if space_length > 0:
-        display_title += " " * space_length
-    return display_title
 
 def make_ordinal(n):
     n = int(n)
@@ -391,12 +385,22 @@ def apply_formatter(handler, border=True):
         text = f"[%(asctime)s] %(filename)-27s %(levelname)-10s {text}"
     handler.setFormatter(logging.Formatter(text))
 
-def print_return(length, text):
-    print(adjust_space(length, f"| {text}"), end="\r")
-    return len(text) + 2
+def adjust_space(display_title):
+    display_title = str(display_title)
+    space_length = spacing - len(display_title)
+    if space_length > 0:
+        display_title += " " * space_length
+    return display_title
 
-def print_end(length):
-    print(adjust_space(length, " "), end="\r")
+def print_return(text):
+    print(adjust_space(f"| {text}"), end="\r")
+    global spacing
+    spacing = len(text) + 2
+
+def print_end():
+    print(adjust_space(" "), end="\r")
+    global spacing
+    spacing = 0
 
 def validate_filename(filename):
     if is_valid_filename(filename):

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -105,7 +105,7 @@ def start(config_path, is_test=False, time_scheduled=None, requested_collections
     logger.info(util.centered("|  __/| |  __/>  <  | |  | |  __/ || (_| | | |  | | (_| | | | | (_| | (_| |  __/ |   "))
     logger.info(util.centered("|_|   |_|\\___/_/\\_\\ |_|  |_|\\___|\\__\\__,_| |_|  |_|\\__,_|_| |_|\\__,_|\\__, |\\___|_|   "))
     logger.info(util.centered("                                                                     |___/           "))
-    logger.info(util.centered("    Version: 1.10.0-beta1                                                            "))
+    logger.info(util.centered("    Version: 1.10.0-beta2                                                            "))
     if time_scheduled:              start_type = f"{time_scheduled} "
     elif is_test:                   start_type = "Test "
     elif requested_collections:     start_type = "Collections "

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -257,7 +257,7 @@ def mass_metadata(config, library):
         tvdb_id = None
         imdb_id = None
         if config.Cache:
-            t_id, guid_media_type, _ = config.Cache.config.Cache.query_guid_map(item.guid)
+            t_id, guid_media_type, _ = config.Cache.query_guid_map(item.guid)
             if t_id:
                 if "movie" in guid_media_type:
                     tmdb_id = t_id

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -413,6 +413,7 @@ def run_collection(config, library, metadata, requested_collections):
                 util.print_multiline(builder.schedule, info=True)
 
             if len(builder.smart_filter_details) > 0:
+                logger.info("")
                 util.print_multiline(builder.smart_filter_details, info=True)
 
             if not builder.smart_url:

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -105,7 +105,7 @@ def start(config_path, is_test=False, time_scheduled=None, requested_collections
     logger.info(util.centered("|  __/| |  __/>  <  | |  | |  __/ || (_| | | |  | | (_| | | | | (_| | (_| |  __/ |   "))
     logger.info(util.centered("|_|   |_|\\___/_/\\_\\ |_|  |_|\\___|\\__\\__,_| |_|  |_|\\__,_|_| |_|\\__,_|\\__, |\\___|_|   "))
     logger.info(util.centered("                                                                     |___/           "))
-    logger.info(util.centered("    Version: 1.10.0-beta2                                                            "))
+    logger.info(util.centered("    Version: 1.10.0                                                                  "))
     if time_scheduled:              start_type = f"{time_scheduled} "
     elif is_test:                   start_type = "Test "
     elif requested_collections:     start_type = "Collections "

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -445,6 +445,12 @@ def run_collection(config, library, metadata, requested_collections):
                 logger.info("")
                 builder.update_details()
 
+            if len(builder.item_details) > 0:
+                logger.info("")
+                util.separator(f"Updating Details of the Items in  {mapping_name} Collection", space=False, border=False)
+                logger.info("")
+                builder.update_item_details()
+
             if builder.run_again and (len(builder.run_again_movies) > 0 or len(builder.run_again_shows) > 0):
                 library.run_again.append(builder)
 

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -105,7 +105,7 @@ def start(config_path, is_test=False, time_scheduled=None, requested_collections
     logger.info(util.centered("|  __/| |  __/>  <  | |  | |  __/ || (_| | | |  | | (_| | | | | (_| | (_| |  __/ |   "))
     logger.info(util.centered("|_|   |_|\\___/_/\\_\\ |_|  |_|\\___|\\__\\__,_| |_|  |_|\\__,_|_| |_|\\__,_|\\__, |\\___|_|   "))
     logger.info(util.centered("                                                                     |___/           "))
-    logger.info(util.centered("    Version: 1.9.3                                                                   "))
+    logger.info(util.centered("    Version: 1.10.0-beta1                                                            "))
     if time_scheduled:              start_type = f"{time_scheduled} "
     elif is_test:                   start_type = "Test "
     elif requested_collections:     start_type = "Collections "

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -205,12 +205,11 @@ def update_libraries(config):
         logger.info("")
         util.separator("Run Again")
         logger.info("")
-        length = 0
         for x in range(1, config.general["run_again_delay"] + 1):
-            length = util.print_return(length, f"Waiting to run again in {config.general['run_again_delay'] - x + 1} minutes")
+            util.print_return(f"Waiting to run again in {config.general['run_again_delay'] - x + 1} minutes")
             for y in range(60):
                 time.sleep(1)
-        util.print_end(length)
+        util.print_end()
         for library in config.libraries:
             if library.run_again:
                 col_file_logger = os.path.join(default_dir, "logs", library.mapping_name, f"library.log")
@@ -248,15 +247,14 @@ def update_libraries(config):
 def map_guids(config, library):
     movie_map = {}
     show_map = {}
-    length = 0
     logger.info(f"Loading {'Movie' if library.is_movie else 'Show'} Library: {library.name}")
     logger.info("")
     items = library.Plex.all()
     logger.info(f"Mapping {'Movie' if library.is_movie else 'Show'} Library: {library.name}")
     logger.info("")
     for i, item in enumerate(items, 1):
-        length = util.print_return(length, f"Processing: {i}/{len(items)} {item.title}")
-        id_type, main_id = config.Convert.get_id(item, library, length)
+        util.print_return(f"Processing: {i}/{len(items)} {item.title}")
+        id_type, main_id = config.Convert.get_id(item, library)
         if main_id:
             if not isinstance(main_id, list):
                 main_id = [main_id]
@@ -269,11 +267,10 @@ def map_guids(config, library):
                     if m in show_map:               show_map[m].append(item.ratingKey)
                     else:                           show_map[m] = [item.ratingKey]
     logger.info("")
-    logger.info(util.adjust_space(length, f"Processed {len(items)} {'Movies' if library.is_movie else 'Shows'}"))
+    logger.info(util.adjust_space(f"Processed {len(items)} {'Movies' if library.is_movie else 'Shows'}"))
     return movie_map, show_map
 
 def mass_metadata(config, library, movie_map, show_map):
-    length = 0
     logger.info("")
     util.separator(f"Mass Editing {'Movie' if library.is_movie else 'Show'} Library: {library.name}")
     logger.info("")
@@ -281,7 +278,7 @@ def mass_metadata(config, library, movie_map, show_map):
     sonarr_adds = []
     items = library.Plex.all()
     for i, item in enumerate(items, 1):
-        length = util.print_return(length, f"Processing: {i}/{len(items)} {item.title}")
+        util.print_return(f"Processing: {i}/{len(items)} {item.title}")
         tmdb_id = None
         tvdb_id = None
         imdb_id = None
@@ -316,9 +313,9 @@ def mass_metadata(config, library, movie_map, show_map):
                 try:
                     tmdb_item = config.TMDb.get_movie(tmdb_id) if library.is_movie else config.TMDb.get_show(tmdb_id)
                 except Failed as e:
-                    logger.info(util.adjust_space(length, str(e)))
+                    logger.info(util.adjust_space(str(e)))
             else:
-                logger.info(util.adjust_space(length, f"{item.title[:25]:<25} | No TMDb ID for Guid: {item.guid}"))
+                logger.info(util.adjust_space(f"{item.title[:25]:<25} | No TMDb ID for Guid: {item.guid}"))
 
         omdb_item = None
         if library.mass_genre_update in ["omdb", "imdb"] or library.mass_audience_rating_update in ["omdb", "imdb"] or library.mass_critic_rating_update in ["omdb", "imdb"]:
@@ -331,9 +328,9 @@ def mass_metadata(config, library, movie_map, show_map):
                     try:
                         omdb_item = config.OMDb.get_omdb(imdb_id)
                     except Failed as e:
-                        logger.info(util.adjust_space(length, str(e)))
+                        logger.info(util.adjust_space(str(e)))
                 else:
-                    logger.info(util.adjust_space(length, f"{item.title[:25]:<25} | No IMDb ID for Guid: {item.guid}"))
+                    logger.info(util.adjust_space(f"{item.title[:25]:<25} | No IMDb ID for Guid: {item.guid}"))
 
         if not tmdb_item and not omdb_item:
             continue
@@ -355,7 +352,7 @@ def mass_metadata(config, library, movie_map, show_map):
                     library.query_data(item.addGenre, genre)
                     display_str += f"{', ' if len(display_str) > 0 else ''}+{genre}"
                 if len(display_str) > 0:
-                    logger.info(util.adjust_space(length, f"{item.title[:25]:<25} | Genres | {display_str}"))
+                    logger.info(util.adjust_space(f"{item.title[:25]:<25} | Genres | {display_str}"))
             except Failed:
                 pass
         if library.mass_audience_rating_update or library.mass_critic_rating_update:
@@ -367,14 +364,14 @@ def mass_metadata(config, library, movie_map, show_map):
                 else:
                     raise Failed
                 if new_rating is None:
-                    logger.info(util.adjust_space(length, f"{item.title[:25]:<25} | No Rating Found"))
+                    logger.info(util.adjust_space(f"{item.title[:25]:<25} | No Rating Found"))
                 else:
                     if library.mass_audience_rating_update and str(item.audienceRating) != str(new_rating):
                         library.edit_query(item, {"audienceRating.value": new_rating, "audienceRating.locked": 1})
-                        logger.info(util.adjust_space(length, f"{item.title[:25]:<25} | Audience Rating | {new_rating}"))
+                        logger.info(util.adjust_space(f"{item.title[:25]:<25} | Audience Rating | {new_rating}"))
                     if library.mass_critic_rating_update and str(item.rating) != str(new_rating):
                         library.edit_query(item, {"rating.value": new_rating, "rating.locked": 1})
-                        logger.info(util.adjust_space(length, f"{item.title[:25]:<25} | Critic Rating | {new_rating}"))
+                        logger.info(util.adjust_space(f"{item.title[:25]:<25} | Critic Rating | {new_rating}"))
             except Failed:
                 pass
 
@@ -497,7 +494,6 @@ try:
     if run or test or collections or libraries or resume:
         start(config_file, is_test=test, requested_collections=collections, requested_libraries=libraries, resume_from=resume)
     else:
-        time_length = 0
         for time_to_run in times_to_run:
             schedule.every().day.at(time_to_run).do(start, config_file, time_scheduled=time_to_run)
         while True:
@@ -517,7 +513,7 @@ try:
                 minutes = int((seconds % 3600) // 60)
                 time_str = f"{hours} Hour{'s' if hours > 1 else ''} and " if hours > 0 else ""
                 time_str += f"{minutes} Minute{'s' if minutes > 1 else ''}"
-                time_length = util.print_return(time_length, f"Current Time: {current} | {time_str} until the next run at {og_time_str} {times_to_run}")
+                util.print_return(f"Current Time: {current} | {time_str} until the next run at {og_time_str} {times_to_run}")
             time.sleep(60)
 except KeyboardInterrupt:
     util.separator("Exiting Plex Meta Manager")


### PR DESCRIPTION
# New Features
Item edits can be done while using `build_collection: false`
Adds more options to [Smart Filter](https://github.com/meisnate12/Plex-Meta-Manager/wiki/Smart-Builders#smart-filter) and [Plex Search](https://github.com/meisnate12/Plex-Meta-Manager/wiki/Plex-Builders#plex-search). `smart_filter` and `plex_search` now have all the same attributes and `plex_search` now uses `and` and `all` to match [Plex's Advance Filters](https://support.plex.tv/articles/201273953-collections/)
Adds more options to [Collection Filters](https://github.com/meisnate12/Plex-Meta-Manager/wiki/Collection-Filters).

# Bug Fixes
Fixes #278: `mass_update` fix
Fixes #280: blank smart searches fail instead of corrupting your plex DB
Various other small fixes