### PR TITLE
BUG - fix arithimetic typeerror

### DIFF
--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -59,7 +59,7 @@ for time_to_run in times_to_run:
 
 util.separating_character = os.environ.get("PMM_DIVIDER")[0] if os.environ.get("PMM_DIVIDER") else args.divider[0]
 
-screen_width = os.environ.get("PMM_WIDTH") if os.environ.get("PMM_WIDTH") else args.width
+screen_width = int(os.environ.get("PMM_WIDTH")) if os.environ.get("PMM_WIDTH") else args.width
 if 90 <= screen_width <= 300:
     util.screen_width = screen_width
 else:


### PR DESCRIPTION
Fixes TypeError. This program crashes when I set the `PMM_WIDTH` variable. Because I am using Unraid, I can't set this variable at the command line. And the script crashes with the default width of `100`.

I believe this is because I am using the `url` metadata_file attribute with this URL: 
https://raw.githubusercontent.com/ecarlson94/plex-meta-manager-configs/main/movies/movie-charts.yml

```
Traceback (most recent call last):
File "//plex_meta_manager.py", line 63, in <module>
if 90 <= screen_width <= 300:
TypeError: '<=' not supported between instances of 'int' and 'str'
```

I am using the [GitHub URL Shortener](https://git.io/) to bypass this issue for now.