### PR TITLE
Fix Sonarr.edit_tags not using translation for apply_tags

### DIFF
--- a/modules/radarr.py
+++ b/modules/radarr.py
@@ -71,7 +71,7 @@ class Radarr:
         logger.info("")
         logger.info(f"{apply_tags_translation[apply_tags].capitalize()} Radarr Tags: {tags}")
 
-        edited, not_exists = self.api.edit_multiple_movies(tmdb_ids, tags=tags, apply_tags=apply_tags)
+        edited, not_exists = self.api.edit_multiple_movies(tmdb_ids, tags=tags, apply_tags=apply_tags_translation[apply_tags])
 
         if len(edited) > 0:
             logger.info("")

--- a/modules/sonarr.py
+++ b/modules/sonarr.py
@@ -84,7 +84,7 @@ class Sonarr:
         logger.info("")
         logger.info(f"{apply_tags_translation[apply_tags].capitalize()} Sonarr Tags: {tags}")
 
-        edited, not_exists = self.api.edit_multiple_series(tvdb_ids, tags=tags, apply_tags=apply_tags)
+        edited, not_exists = self.api.edit_multiple_series(tvdb_ids, tags=tags, apply_tags=apply_tags_translation[apply_tags])
 
         if len(edited) > 0:
             logger.info("")

--- a/modules/sonarr.py
+++ b/modules/sonarr.py
@@ -89,7 +89,7 @@ class Sonarr:
         if len(edited) > 0:
             logger.info("")
             for series in edited:
-                logger.info(f"Radarr Tags | {series.title:<25} | {series.tags}")
+                logger.info(f"Sonarr Tags | {series.title:<25} | {series.tags}")
             logger.info(f"{len(edited)} Series edited in Sonarr")
 
         if len(not_exists) > 0:


### PR DESCRIPTION
apply_tags wasn't being translated properly in Sonarr/Radarr edit_tags method, it would pass `sync` instead of `add` to arr api resulting in invalid behavior.