### PR TITLE
v1.12.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "develop"

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -120,7 +120,12 @@ class AniList:
                 if attr in ["start", "end"]:
                     value = int(util.validate_date(value, f"anilist_search {key}", return_as="%Y%m%d"))
                 elif attr in ["format", "status", "genre", "tag", "tag_category"]:
-                    value = f"[{', '.join([self.options[attr.replace('_', ' ').title()][v.lower().replace(' / ', '-').replace(' ', '-')] for v in value])}]"
+                    temp_value = [self.options[attr.replace('_', ' ').title()][v.lower().replace(' / ', '-').replace(' ', '-')] for v in value]
+                    if attr in ["format", "status"]:
+                        value = f"[{', '.join(temp_value)}]"
+                    else:
+                        temp = '", "'.join(temp_value)
+                        value = f'["{temp}"]'
                 elif attr in ["season", "source", "country"]:
                     value = self.options[attr.replace("_", " ").title()][value]
                 if mod == "gte":

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -102,7 +102,7 @@ class AniList:
                 if attr in ["start", "end"]:
                     value = int(util.validate_date(value, f"anilist_search {key}", return_as="%Y%m%d"))
                 elif attr in ["season", "format", "status", "genre", "tag", "tag_category"]:
-                    value = self.options[attr.replace("_", " ").title()][value.lower().replace(" / ", "-").replace(" ", "-")]
+                    value = [self.options[attr.replace("_", " ").title()][v.lower().replace(" / ", "-").replace(" ", "-")] for v in value]
                 if mod == "gte":
                     value -= 1
                 elif mod == "lte":
@@ -178,8 +178,7 @@ class AniList:
     def validate(self, name, data):
         valid = []
         for d in util.get_list(data):
-            data_check = d.lower().replace(" / ", "-").replace(" ", "-")
-            if data_check in self.options[name]:
+            if d.lower().replace(" / ", "-").replace(" ", "-") in self.options[name]:
                 valid.append(d)
         if len(valid) > 0:
             return valid

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -4,9 +4,12 @@ from modules.util import Failed
 
 logger = logging.getLogger("Plex Meta Manager")
 
-builders = ["anilist_id", "anilist_popular", "anilist_relations", "anilist_studio", "anilist_top_rated", "anilist_search"]
-pretty_names = {"score": "Average Score", "popular": "Popularity"}
-attr_translation = {"year": "seasonYear", "adult": "isAdult", "start": "startDate", "end": "endDate", "tag_category": "tagCategory", "score": "averageScore", "min_tag_percent": "minimumTagRank"}
+builders = ["anilist_id", "anilist_popular", "anilist_trending", "anilist_relations", "anilist_studio", "anilist_top_rated", "anilist_search"]
+pretty_names = {"score": "Average Score", "popular": "Popularity", "trending": "Trending"}
+attr_translation = {
+    "year": "seasonYear", "adult": "isAdult", "start": "startDate", "end": "endDate", "tag_category": "tagCategory",
+    "score": "averageScore", "min_tag_percent": "minimumTagRank", "country": "countryOfOrigin",
+}
 mod_translation = {"": "in", "not": "not_in", "before": "greater", "after": "lesser", "gt": "greater", "gte": "greater", "lt": "lesser", "lte": "lesser"}
 mod_searches = [
     "start.before", "start.after", "end.before", "end.after",
@@ -14,20 +17,41 @@ mod_searches = [
     "episodes.gt", "episodes.gte", "episodes.lt", "episodes.lte", "duration.gt", "duration.gte", "duration.lt", "duration.lte",
     "score.gt", "score.gte", "score.lt", "score.lte", "popularity.gt", "popularity.gte", "popularity.lt", "popularity.lte"
 ]
-no_mod_searches = ["search", "season", "year", "adult", "min_tag_percent", "limit", "sort_by"]
+no_mod_searches = ["search", "season", "year", "adult", "min_tag_percent", "limit", "sort_by", "source", "country"]
 searches = mod_searches + no_mod_searches
+sort_options = {"score": "SCORE_DESC", "popular": "POPULARITY_DESC", "trending": "TRENDING_DESC"}
 search_types = {
     "search": "String", "season": "MediaSeason", "seasonYear": "Int", "isAdult": "Boolean", "minimumTagRank": "Int",
     "startDate": "FuzzyDateInt", "endDate": "FuzzyDateInt", "format": "[MediaFormat]", "status": "[MediaStatus]",
-    "genre": "[String]", "tag": "[String]", "tagCategory": "[String]",
-    "episodes": "Int", "duration": "Int", "averageScore": "Int", "popularity": "Int"
+    "genre": "[String]", "tag": "[String]", "tagCategory": "[String]", "source": "MediaSource",
+    "countryOfOrigin": "CountryCode", "episodes": "Int", "duration": "Int", "averageScore": "Int", "popularity": "Int"
 }
 media_season = {"winter": "WINTER", "spring": "SPRING", "summer": "SUMMER", "fall": "FALL"}
 media_format = {"tv": "TV", "short": "TV_SHORT", "movie": "MOVIE", "special": "SPECIAL", "ova": "OVA", "ona": "ONA", "music": "MUSIC"}
 media_status = {"finished": "FINISHED", "airing": "RELEASING", "not_yet_aired": "NOT_YET_RELEASED", "cancelled": "CANCELLED", "hiatus": "HIATUS"}
+media_source = {
+    "original": "ORIGINAL", "manga": "MANGA", "light_novel": "LIGHT_NOVEL", "visual_novel": "VISUAL_NOVEL",
+    "video_game": "VIDEO_GAME", "other": "OTHER", "novel": "NOVEL", "doujinshi": "DOUJINSHI", "anime": "ANIME"
+}
 base_url = "https://graphql.anilist.co"
 tag_query = "query{MediaTagCollection {name, category}}"
 genre_query = "query{GenreCollection}"
+country_codes = [
+    "af", "ax", "al", "dz", "as", "ad", "ao", "ai", "aq", "ag", "ar", "am", "aw", "au", "at", "az", "bs", "bh", "bd",
+    "bb", "by", "be", "bz", "bj", "bm", "bt", "bo", "bq", "ba", "bw", "bv", "br", "io", "bn", "bg", "bf", "bi", "cv",
+    "kh", "cm", "ca", "ky", "cf", "td", "cl", "cn", "cx", "cc", "co", "km", "cg", "cd", "ck", "cr", "ci", "hr", "cu",
+    "cw", "cy", "cz", "dk", "dj", "dm", "do", "ec", "eg", "sv", "gq", "er", "ee", "sz", "et", "fk", "fo", "fj", "fi",
+    "fr", "gf", "pf", "tf", "ga", "gm", "ge", "de", "gh", "gi", "gr", "gl", "gd", "gp", "gu", "gt", "gg", "gn", "gw",
+    "gy", "ht", "hm", "va", "hn", "hk", "hu", "is", "in", "id", "ir", "iq", "ie", "im", "il", "it", "jm", "jp", "je",
+    "jo", "kz", "ke", "ki", "kp", "kr", "kw", "kg", "la", "lv", "lb", "ls", "lr", "ly", "li", "lt", "lu", "mo", "mg",
+    "mw", "my", "mv", "ml", "mt", "mh", "mq", "mr", "mu", "yt", "mx", "fm", "md", "mc", "mn", "me", "ms", "ma", "mz",
+    "mm", "na", "nr", "np", "nl", "nc", "nz", "ni", "ne", "ng", "nu", "nf", "mk", "mp", "no", "om", "pk", "pw", "ps",
+    "pa", "pg", "py", "pe", "ph", "pn", "pl", "pt", "pr", "qa", "re", "ro", "ru", "rw", "bl", "sh", "kn", "lc", "mf",
+    "pm", "vc", "ws", "sm", "st", "sa", "sn", "rs", "sc", "sl", "sg", "sx", "sk", "si", "sb", "so", "za", "gs", "ss",
+    "es", "lk", "sd", "sr", "sj", "se", "ch", "sy", "tw", "tj", "tz", "th", "tl", "tg", "tk", "to", "tt", "tn", "tr",
+    "tm", "tc", "tv", "ug", "ua", "ae", "gb", "us", "um", "uy", "uz", "vu", "ve", "vn", "vg", "vi", "wf", "eh", "ye",
+    "zm", "zw",
+]
 
 class AniList:
     def __init__(self, config):
@@ -35,7 +59,8 @@ class AniList:
         self.options = {
             "Tag": {}, "Tag Category": {},
             "Genre": {g.lower().replace(" ", "-"): g for g in self._request(genre_query, {})["data"]["GenreCollection"]},
-            "Season": media_season, "Format": media_format, "Status": media_status
+            "Country": {c: c.upper() for c in country_codes},
+            "Season": media_season, "Format": media_format, "Status": media_status, "Source": media_source,
         }
         for media_tag in self._request(tag_query, {})["data"]["MediaTagCollection"]:
             self.options["Tag"][media_tag["name"].lower().replace(" ", "-")] = media_tag["name"]
@@ -89,7 +114,7 @@ class AniList:
     def _search(self, **kwargs):
         query_vars = "$page: Int, $sort: [MediaSort]"
         media_vars = "sort: $sort, type: ANIME"
-        variables = {"sort": "SCORE_DESC" if kwargs['sort_by'] == "score" else "POPULARITY_DESC"}
+        variables = {"sort": sort_options[kwargs['sort_by']]}
         for key, value in kwargs.items():
             if key not in ["sort_by", "limit"]:
                 if "." in key:
@@ -101,8 +126,10 @@ class AniList:
                 final = ani_attr if attr in no_mod_searches else f"{ani_attr}_{mod_translation[mod]}"
                 if attr in ["start", "end"]:
                     value = int(util.validate_date(value, f"anilist_search {key}", return_as="%Y%m%d"))
-                elif attr in ["season", "format", "status", "genre", "tag", "tag_category"]:
+                elif attr in ["format", "status", "genre", "tag", "tag_category"]:
                     value = [self.options[attr.replace("_", " ").title()][v.lower().replace(" / ", "-").replace(" ", "-")] for v in value]
+                elif attr in ["season", "source", "country"]:
+                    value = self.options[attr.replace("_", " ").title()][value]
                 if mod == "gte":
                     value -= 1
                 elif mod == "lte":
@@ -211,20 +238,24 @@ class AniList:
         else:
             if method == "anilist_popular":
                 data = {"limit": data, "popularity.gt": 3, "sort_by": "popular"}
+            elif method == "anilist_trending":
+                data = {"limit": data, "sort_by": "trending"}
             elif method == "anilist_top_rated":
                 data = {"limit": data, "score.gt": 3, "sort_by": "score"}
             elif method not in builders:
                 raise Failed(f"AniList Error: Method {method} not supported")
-            message = f"Processing {method.replace('_', ' ').title().replace('Anilist', 'AniList')}:\nSort By: {pretty_names[data['sort_by']]}"
+            message = f"Processing {method.replace('_', ' ').title().replace('Anilist', 'AniList')}:\n\tSort By {pretty_names[data['sort_by']]}"
             if data['limit'] > 0:
-                message += f"\nLimit: {data['limit']}"
+                message += f"\n\tLimit to {data['limit']} Anime"
             for key, value in data.items():
-                if "." in key:
-                    attr, mod = key.split(".")
-                else:
-                    attr = key
-                    mod = ""
-                message += f"\n{attr.replace('_', ' ').title()} {util.mod_displays[mod]} {value}"
+                if key not in ["limit", "sort_by"]:
+                    if "." in key:
+                        attr, mod = key.split(".")
+                        mod = f".{mod}"
+                    else:
+                        attr = key
+                        mod = ""
+                    message += f"\n\t{attr.replace('_', ' ').title()} {util.mod_displays[mod]} {value}"
             util.print_multiline(message)
             anilist_ids = self._search(**data)
         logger.debug("")

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -80,7 +80,7 @@ boolean_details = ["visible_library", "visible_home", "visible_shared", "show_fi
 string_details = ["sort_title", "content_rating", "name_mapping"]
 ignored_details = [
     "smart_filter", "smart_label", "smart_url", "run_again", "schedule", "sync_mode", "template", "test",
-    "tmdb_person", "build_collection", "collection_order", "collection_level", "validate_builders"
+    "tmdb_person", "build_collection", "collection_order", "collection_level", "validate_builders", "collection_name"
 ]
 details = ["collection_mode", "collection_order", "collection_level", "label"] + boolean_details + string_details
 collectionless_details = ["collection_order", "plex_collectionless", "label", "label_sync_mode", "test"] + \
@@ -158,7 +158,7 @@ class CollectionBuilder:
         self.config = config
         self.library = library
         self.metadata = metadata
-        self.name = name
+        self.mapping_name = name
         self.no_missing = no_missing
         self.data = data
         self.language = self.library.Plex.language
@@ -191,6 +191,16 @@ class CollectionBuilder:
         self.current_year = self.current_time.year
 
         methods = {m.lower(): m for m in self.data}
+
+        if "collection_name" in methods:
+            logger.debug("")
+            logger.debug("Validating Method: collection_name")
+            if not self.data[methods["collection_name"]]:
+                raise Failed("Collection Error: collection_name attribute is blank")
+            logger.debug(f"Value: {self.data[methods['collection_name']]}")
+            self.name = self.data[methods["collection_name"]]
+        else:
+            self.name = self.mapping_name
 
         if "template" in methods:
             logger.debug("")

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1069,13 +1069,13 @@ class CollectionBuilder:
                 rating_keys = self.library.Tautulli.get_rating_keys(self.library, value)
             elif "anidb" in method:
                 anidb_ids = self.config.AniDB.get_anidb_ids(method, value, self.language)
-                ids = self.config.Convert.anidb_to_ids(anidb_ids)
+                ids = self.config.Convert.anidb_to_ids(anidb_ids, self.library)
             elif "anilist" in method:
                 anilist_ids = self.config.AniList.get_anilist_ids(method, value)
-                ids = self.config.Convert.anilist_to_ids(anilist_ids)
+                ids = self.config.Convert.anilist_to_ids(anilist_ids, self.library)
             elif "mal" in method:
                 mal_ids = self.config.MyAnimeList.get_mal_ids(method, value)
-                ids = self.config.Convert.myanimelist_to_ids(mal_ids)
+                ids = self.config.Convert.myanimelist_to_ids(mal_ids, self.library)
             elif "tvdb" in method:
                 ids = self.config.TVDb.get_tvdb_ids(method, value, self.language)
             elif "imdb" in method:
@@ -1101,7 +1101,9 @@ class CollectionBuilder:
                     for i, input_data in enumerate(ids, 1):
                         input_id, id_type = input_data
                         util.print_return(f"Parsing ID {i}/{total_ids}")
-                        if id_type == "tmdb" and not self.parts_collection:
+                        if id_type == "ratingKey":
+                            rating_keys.append(input_id)
+                        elif id_type == "tmdb" and not self.parts_collection:
                             if input_id in self.library.movie_map:
                                 rating_keys.append(self.library.movie_map[input_id][0])
                             elif input_id not in self.missing_movies:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -94,12 +94,12 @@ sonarr_details = [
 all_filters = [
     "actor", "actor.not",
     "audio_language", "audio_language.not",
-    "audio_track_title", "audio_track_title.not", "audio_track_title.begins", "audio_track_title.ends", "audio_track_title.regex",
+    "audio_track_title", "audio_track_title.not", "audio_track_title.is", "audio_track_title.isnot", "audio_track_title.begins", "audio_track_title.ends", "audio_track_title.regex",
     "collection", "collection.not",
     "content_rating", "content_rating.not",
     "country", "country.not",
     "director", "director.not",
-    "filepath", "filepath.not", "filepath.begins", "filepath.ends", "filepath.regex",
+    "filepath", "filepath.not", "filepath.is", "filepath.isnot", "filepath.begins", "filepath.ends", "filepath.regex",
     "genre", "genre.not",
     "label", "label.not",
     "producer", "producer.not",
@@ -108,7 +108,7 @@ all_filters = [
     "last_played", "last_played.not", "last_played.before", "last_played.after", "last_played.regex",
     "first_episode_aired", "first_episode_aired.not", "first_episode_aired.before", "first_episode_aired.after", "first_episode_aired.regex",
     "last_episode_aired", "last_episode_aired.not", "last_episode_aired.before", "last_episode_aired.after", "last_episode_aired.regex",
-    "title", "title.not", "title.begins", "title.ends", "title.regex",
+    "title", "title.not", "title.is", "title.isnot", "title.begins", "title.ends", "title.regex",
     "plays.gt", "plays.gte", "plays.lt", "plays.lte",
     "tmdb_vote_count.gt", "tmdb_vote_count.gte", "tmdb_vote_count.lt", "tmdb_vote_count.lte",
     "duration.gt", "duration.gte", "duration.lt", "duration.lte",
@@ -116,7 +116,7 @@ all_filters = [
     "user_rating.gt", "user_rating.gte", "user_rating.lt", "user_rating.lte",
     "audience_rating.gt", "audience_rating.gte", "audience_rating.lt", "audience_rating.lte",
     "critic_rating.gt", "critic_rating.gte", "critic_rating.lt", "critic_rating.lte",
-    "studio", "studio.not", "studio.begins", "studio.ends", "studio.regex",
+    "studio", "studio.not", "studio.is", "studio.isnot", "studio.begins", "studio.ends", "studio.regex",
     "subtitle_language", "subtitle_language.not",
     "resolution", "resolution.not",
     "writer", "writer.not",
@@ -126,7 +126,7 @@ all_filters = [
 tmdb_filters = ["original_language", "tmdb_vote_count", "tmdb_year", "first_episode_aired", "last_episode_aired"]
 movie_only_filters = [
     "audio_language", "audio_language.not",
-    "audio_track_title", "audio_track_title.not", "audio_track_title.begins", "audio_track_title.ends", "audio_track_title.regex",
+    "audio_track_title", "audio_track_title.not", "audio_track_title.is", "audio_track_title.isnot", "audio_track_title.begins", "audio_track_title.ends", "audio_track_title.regex",
     "country", "country.not",
     "director", "director.not",
     "duration.gt", "duration.gte", "duration.lt", "duration.lte",
@@ -1383,7 +1383,7 @@ class CollectionBuilder:
                     else:
                         logger.error(err)
             return valid_regex
-        elif attribute in ["title", "studio", "episode_title", "audio_track_title"] and modifier in ["", ".not", ".begins", ".ends"]:
+        elif attribute in ["title", "studio", "episode_title", "audio_track_title"] and modifier in ["", ".not", ".is", ".isnot", ".begins", ".ends"]:
             return smart_pair(util.get_list(data, split=False))
         elif attribute == "original_language":
             return util.get_list(data, lower=True)

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -774,7 +774,7 @@ class CollectionBuilder:
                 elif not dict_data[dict_methods["tag"]]:
                     raise Failed("Collection Error: anidb_tag tag attribute is blank")
                 else:
-                    new_dictionary["tag"] = util.regex_first_int(dict_data[dict_methods["username"]], "AniDB Tag ID")
+                    new_dictionary["tag"] = util.regex_first_int(dict_data[dict_methods["tag"]], "AniDB Tag ID")
                 new_dictionary["limit"] = util.parse("limit", dict_data, datatype="int", methods=dict_methods, default=0, parent=method_name, minimum=0)
                 self.builders.append((method_name, new_dictionary))
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1122,12 +1122,12 @@ class CollectionBuilder:
                             else:
                                 if self.do_missing:
                                     try:
-                                        tmdb_id, tmdb_type = self.config.Convert.imdb_to_tmdb(input_id)
+                                        tmdb_id, tmdb_type = self.config.Convert.imdb_to_tmdb(input_id, fail=True)
                                         if tmdb_type == "movie":
                                             if tmdb_id not in self.missing_movies:
                                                 self.missing_movies.append(tmdb_id)
                                         else:
-                                            tvdb_id = self.config.Convert.tmdb_to_tvdb(tmdb_id)
+                                            tvdb_id = self.config.Convert.tmdb_to_tvdb(tmdb_id, fail=True)
                                             if tvdb_id not in self.missing_shows:
                                                 self.missing_shows.append(tvdb_id)
                                     except Failed as e:
@@ -1135,26 +1135,28 @@ class CollectionBuilder:
                                         continue
                         elif id_type == "tvdb_season" and self.collection_level == "season":
                             show_id, season_num = input_id.split("_")
-                            if int(show_id) in self.library.show_map:
-                                show_item = self.library.fetchItem(self.library.show_map[int(show_id)][0])
+                            show_id = int(show_id)
+                            if show_id in self.library.show_map:
+                                show_item = self.library.fetchItem(self.library.show_map[show_id][0])
                                 try:
                                     episode_item = show_item.season(season=int(season_num))
                                     rating_keys.append(episode_item.ratingKey)
                                 except NotFound:
                                     self.missing_parts.append(f"{show_item.title} Season: {season_num} Missing")
-                            elif int(show_id) not in self.missing_shows:
-                                self.missing_shows.append(int(show_id))
+                            elif show_id not in self.missing_shows:
+                                self.missing_shows.append(show_id)
                         elif id_type == "tvdb_episode" and self.collection_level == "episode":
                             show_id, season_num, episode_num = input_id.split("_")
-                            if int(show_id) in self.library.show_map:
-                                show_item = self.library.fetchItem(self.library.show_map[int(show_id)][0])
+                            show_id = int(show_id)
+                            if show_id in self.library.show_map:
+                                show_item = self.library.fetchItem(self.library.show_map[show_id][0])
                                 try:
                                     episode_item = show_item.episode(season=int(season_num), episode=int(episode_num))
                                     rating_keys.append(episode_item.ratingKey)
                                 except NotFound:
                                     self.missing_parts.append(f"{show_item.title} Season: {season_num} Episode: {episode_num} Missing")
-                            elif int(show_id) not in self.missing_shows:
-                                self.missing_shows.append(int(show_id))
+                            elif show_id not in self.missing_shows:
+                                self.missing_shows.append(show_id)
                     util.print_end()
 
             if len(rating_keys) > 0:

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -782,7 +782,7 @@ class CollectionBuilder:
         if method_name in ["anilist_id", "anilist_relations", "anilist_studio"]:
             for anilist_id in self.config.AniList.validate_anilist_ids(method_data, studio=method_name == "anilist_studio"):
                 self.builders.append((method_name, anilist_id))
-        elif method_name in ["anilist_popular", "anilist_top_rated"]:
+        elif method_name in ["anilist_popular", "anilist_trending", "anilist_top_rated"]:
             self.builders.append((method_name, util.parse(method_name, method_data, datatype="int", default=10)))
         elif method_name == "anilist_search":
             if self.current_time.month in [12, 1, 2]:           current_season = "winter"
@@ -802,13 +802,14 @@ class CollectionBuilder:
                             new_dictionary["year"] = self.current_year
                     elif search_attr == "year":
                         new_dictionary[search_attr] = util.parse(search_attr, search_data, datatype="int", parent=method_name, default=self.current_year, minimum=1917, maximum=self.current_year + 1)
-                        if "season" not in dict_methods:
-                            logger.warning(f"Collection Warning: {method_name} season attribute not found using this season: {current_season} by default")
-                            new_dictionary["season"] = current_season
                     elif search_data is None:
                         raise Failed(f"Collection Error: {method_name} {search_final} attribute is blank")
                     elif search_attr == "adult":
                         new_dictionary[search_attr] = util.parse(search_attr, search_data, datatype="bool", parent=method_name)
+                    elif search_attr == "country":
+                        new_dictionary[search_attr] = util.parse(search_attr, search_data, options=anilist.country_codes, parent=method_name)
+                    elif search_attr == "source":
+                        new_dictionary[search_attr] = util.parse(search_attr, search_data, options=anilist.media_source, parent=method_name)
                     elif search_attr in ["episodes", "duration", "score", "popularity"]:
                         new_dictionary[search_final] = util.parse(search_final, search_data, datatype="int", parent=method_name)
                     elif search_attr in ["format", "status", "genre", "tag", "tag_category"]:
@@ -823,7 +824,7 @@ class CollectionBuilder:
                         raise Failed(f"Collection Error: {method_name} {search_final} attribute not supported")
                 if len(new_dictionary) == 0:
                     raise Failed(f"Collection Error: {method_name} must have at least one valid search option")
-                new_dictionary["sort_by"] = util.parse("sort_by", dict_data, methods=dict_methods, parent=method_name, default="score", options=["score", "popular"])
+                new_dictionary["sort_by"] = util.parse("sort_by", dict_data, methods=dict_methods, parent=method_name, default="score", options=anilist.sort_options)
                 new_dictionary["limit"] = util.parse("limit", dict_data, datatype="int", methods=dict_methods, default=0, parent=method_name)
                 self.builders.append((method_name, new_dictionary))
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -184,7 +184,9 @@ class Config:
             "show_missing": check_for_attribute(self.data, "show_missing", parent="settings", var_type="bool", default=True),
             "save_missing": check_for_attribute(self.data, "save_missing", parent="settings", var_type="bool", default=True),
             "missing_only_released": check_for_attribute(self.data, "missing_only_released", parent="settings", var_type="bool", default=False),
-            "create_asset_folders": check_for_attribute(self.data, "create_asset_folders", parent="settings", var_type="bool", default=False)
+            "create_asset_folders": check_for_attribute(self.data, "create_asset_folders", parent="settings", var_type="bool", default=False),
+            "collection_minimum": check_for_attribute(self.data, "collection_minimum", parent="settings", var_type="int", default=1),
+            "delete_below_minimum": check_for_attribute(self.data, "delete_below_minimum", parent="settings", var_type="bool", default=False)
         }
         if self.general["cache"]:
             util.separator()
@@ -353,6 +355,8 @@ class Config:
             params["save_missing"] = check_for_attribute(lib, "save_missing", parent="settings", var_type="bool", default=self.general["save_missing"], do_print=False, save=False)
             params["missing_only_released"] = check_for_attribute(lib, "missing_only_released", parent="settings", var_type="bool", default=self.general["missing_only_released"], do_print=False, save=False)
             params["create_asset_folders"] = check_for_attribute(lib, "create_asset_folders", parent="settings", var_type="bool", default=self.general["create_asset_folders"], do_print=False, save=False)
+            params["collection_minimum"] = check_for_attribute(lib, "collection_minimum", parent="settings", var_type="int", default=self.general["collection_minimum"], do_print=False, save=False)
+            params["delete_below_minimum"] = check_for_attribute(lib, "delete_below_minimum", parent="settings", var_type="bool", default=self.general["delete_below_minimum"], do_print=False, save=False)
 
             params["mass_genre_update"] = check_for_attribute(lib, "mass_genre_update", test_list=mass_update_options, default_is_none=True, save=False, do_print=lib and "mass_genre_update" in lib)
             if self.OMDb is None and params["mass_genre_update"] == "omdb":

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -18,19 +18,18 @@ class Metadata:
         logger.info("")
         logger.info(f"Loading Metadata {file_type}: {path}")
         def get_dict(attribute, attr_data, check_list=None):
+            if check_list is None:
+                check_list = []
             if attr_data and attribute in attr_data:
                 if attr_data[attribute]:
                     if isinstance(attr_data[attribute], dict):
-                        if check_list:
-                            new_dict = {}
-                            for a_name, a_data in attr_data[attribute].items():
-                                if a_name in check_list:
-                                    logger.error(f"Config Warning: Skipping duplicate {attribute[:-1] if attribute[-1] == 's' else attribute}: {a_name}")
-                                else:
-                                    new_dict[a_name] = a_data
-                            return new_dict
-                        else:
-                            return attr_data[attribute]
+                        new_dict = {}
+                        for a_name, a_data in attr_data[attribute].items():
+                            if a_name in check_list:
+                                logger.error(f"Config Warning: Skipping duplicate {attribute[:-1] if attribute[-1] == 's' else attribute}: {a_name}")
+                            else:
+                                new_dict[str(a_name)] = a_data
+                        return new_dict
                     else:
                         logger.warning(f"Config Warning: {attribute} must be a dictionary")
                 else:

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -340,6 +340,8 @@ class Plex:
         self.movie_map = {}
         self.show_map = {}
         self.imdb_map = {}
+        self.anidb_map = {}
+        self.mal_map = {}
         self.movie_rating_key_map = {}
         self.show_rating_key_map = {}
         self.run_again = []

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -66,7 +66,7 @@ show_translation = {
     "label": "show.label",
 }
 modifier_translation = {
-    "": "", ".not": "!", ".gt": "%3E%3E", ".gte": "%3E", ".lt": "%3C%3C", ".lte": "%3C",
+    "": "", ".not": "!", ".is": "%3D", ".isnot": "!%3D", ".gt": "%3E%3E", ".gte": "%3E", ".lt": "%3C%3C", ".lte": "%3C",
     ".before": "%3C%3C", ".after": "%3E%3E", ".begins": "%3C", ".ends": "%3E"
 }
 episode_sorting_options = {"default": "-1", "oldest": "0", "newest": "1"}
@@ -101,8 +101,8 @@ item_advance_keys = {
 }
 new_plex_agents = ["tv.plex.agents.movie", "tv.plex.agents.series"]
 searches = [
-    "title", "title.not", "title.begins", "title.ends",
-    "studio", "studio.not", "studio.begins", "studio.ends",
+    "title", "title.not", "title.is", "title.isnot", "title.begins", "title.ends",
+    "studio", "studio.not", "studio.is", "studio.isnot", "studio.begins", "studio.ends",
     "actor", "actor.not",
     "audio_language", "audio_language.not",
     "collection", "collection.not",
@@ -126,7 +126,7 @@ searches = [
     "audience_rating.gt", "audience_rating.gte", "audience_rating.lt", "audience_rating.lte",
     "year", "year.not", "year.gt", "year.gte", "year.lt", "year.lte",
     "unplayed_episodes", "episode_unplayed", "episode_duplicate", "episode_progress", "episode_unmatched",
-    "episode_title", "episode_title.not", "episode_title.begins", "episode_title.ends",
+    "episode_title", "episode_title.not", "episode_title.is", "episode_title.isnot", "episode_title.begins", "episode_title.ends",
     "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
     "episode_air_date", "episode_air_date.not", "episode_air_date.before", "episode_air_date.after",
     "episode_last_played", "episode_last_played.not", "episode_last_played.before", "episode_last_played.after",
@@ -151,7 +151,7 @@ movie_only_searches = [
 ]
 show_only_searches = [
     "network", "network.not",
-    "episode_title", "episode_title.not", "episode_title.begins", "episode_title.ends",
+    "episode_title", "episode_title.not", "episode_title.is", "episode_title.isnot", "episode_title.begins", "episode_title.ends",
     "episode_added", "episode_added.not", "episode_added.before", "episode_added.after",
     "episode_air_date", "episode_air_date.not",
     "episode_air_date.before", "episode_air_date.after",
@@ -170,17 +170,6 @@ tmdb_attributes = ["actor", "director", "producer", "writer"]
 date_attributes = ["added", "episode_added", "release", "episode_air_date", "last_played", "episode_last_played", "first_episode_aired", "last_episode_aired"]
 number_attributes = ["plays", "episode_plays", "duration", "tmdb_vote_count"] + date_attributes
 search_display = {"added": "Date Added", "release": "Release Date", "hdr": "HDR", "progress": "In Progress", "episode_progress": "Episode In Progress"}
-sorts = {
-    None: None,
-    "title.asc": "titleSort:asc", "title.desc": "titleSort:desc",
-    "originally_available.asc": "originallyAvailableAt:asc", "originally_available.desc": "originallyAvailableAt:desc",
-    "release.asc": "originallyAvailableAt:asc", "release.desc": "originallyAvailableAt:desc",
-    "critic_rating.asc": "rating:asc", "critic_rating.desc": "rating:desc",
-    "audience_rating.asc": "audienceRating:asc", "audience_rating.desc": "audienceRating:desc",
-    "duration.asc": "duration:asc", "duration.desc": "duration:desc",
-    "added.asc": "addedAt:asc", "added.desc": "addedAt:desc"
-}
-modifiers = {".not": "!", ".begins": "<", ".ends": ">", ".before": "<<", ".after": ">>", ".gt": ">>", ".gte": "__gte", ".lt": "<<", ".lte": "__lte"}
 tags = [
     "actor", "audio_language", "collection", "content_rating", "country", "director", "genre", "label",
     "network", "producer", "resolution", "studio", "subtitle_language", "writer"

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -756,7 +756,7 @@ class Plex:
             logger.debug(f"Details Update: {edits}")
             try:
                 self.edit_query(item, edits, advanced=advanced)
-                if advanced and "languageOverride" in edits:
+                if advanced and ("languageOverride" in edits or "useOriginalTitle" in edits):
                     self.query(item.refresh)
                 logger.info(f"{item_type}: {name}{' Advanced' if advanced else ''} Details Update Successful")
                 return True

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -313,6 +313,8 @@ class Plex:
             logger.info(output)
         self.image_table_name = self.config.Cache.get_image_table_name(self.original_mapping_name) if self.config.Cache else None
         self.missing_path = os.path.join(params["default_dir"], f"{self.name}_missing.yml")
+        self.collection_minimum = params["collection_minimum"]
+        self.delete_below_minimum = params["delete_below_minimum"]
         self.metadata_path = params["metadata_path"]
         self.asset_directory = params["asset_directory"]
         self.asset_folders = params["asset_folders"]

--- a/modules/radarr.py
+++ b/modules/radarr.py
@@ -40,7 +40,7 @@ class Radarr:
         tags = options["tag"] if "tag" in options else self.tag
         search = options["search"] if "search" in options else self.search
         try:
-            added, exists, invalid = self.api.add_multiple_movies(tmdb_ids, folder, quality_profile, monitor, search, availability, tags)
+            added, exists, invalid = self.api.add_multiple_movies(tmdb_ids, folder, quality_profile, monitor, search, availability, tags, per_request=100)
         except Invalid as e:
             raise Failed(f"Radarr Error: {e}")
 
@@ -65,7 +65,7 @@ class Radarr:
         logger.info("")
         logger.info(f"{apply_tags_translation[apply_tags].capitalize()} Radarr Tags: {tags}")
 
-        edited, not_exists = self.api.edit_multiple_movies(tmdb_ids, tags=tags, apply_tags=apply_tags_translation[apply_tags])
+        edited, not_exists = self.api.edit_multiple_movies(tmdb_ids, tags=tags, apply_tags=apply_tags_translation[apply_tags], per_request=100)
 
         if len(edited) > 0:
             logger.info("")

--- a/modules/sonarr.py
+++ b/modules/sonarr.py
@@ -66,7 +66,7 @@ class Sonarr:
         search = options["search"] if "search" in options else self.search
         cutoff_search = options["cutoff_search"] if "cutoff_search" in options else self.cutoff_search
         try:
-            added, exists, invalid = self.api.add_multiple_series(tvdb_ids, folder, quality_profile, language_profile, monitor, season, search, cutoff_search, series, tags)
+            added, exists, invalid = self.api.add_multiple_series(tvdb_ids, folder, quality_profile, language_profile, monitor, season, search, cutoff_search, series, tags, per_request=100)
         except Invalid as e:
             raise Failed(f"Sonarr Error: {e}")
 
@@ -91,7 +91,7 @@ class Sonarr:
         logger.info("")
         logger.info(f"{apply_tags_translation[apply_tags].capitalize()} Sonarr Tags: {tags}")
 
-        edited, not_exists = self.api.edit_multiple_series(tvdb_ids, tags=tags, apply_tags=apply_tags_translation[apply_tags])
+        edited, not_exists = self.api.edit_multiple_series(tvdb_ids, tags=tags, apply_tags=apply_tags_translation[apply_tags], per_request=100)
 
         if len(edited) > 0:
             logger.info("")

--- a/modules/util.py
+++ b/modules/util.py
@@ -49,7 +49,7 @@ days_alias = {
     "sunday": 6, "sun": 6, "su": 6, "u": 6
 }
 mod_displays = {
-    "": "is", ".not": "is not", ".begins": "begins with", ".ends": "ends with", ".before": "is before", ".after": "is after",
+    "": "is", ".not": "is not", ".is": "is", ".isnot": "is not", ".begins": "begins with", ".ends": "ends with", ".before": "is before", ".after": "is after",
     ".gt": "is greater than", ".gte": "is greater than or equal", ".lt": "is less than", ".lte": "is less than or equal"
 }
 pretty_days = {0: "Monday", 1: "Tuesday", 2: "Wednesday", 3: "Thursday", 4: "Friday", 5: "Saturday", 6: "Sunday"}
@@ -282,13 +282,14 @@ def is_string_filter(values, modifier, data):
     for value in values:
         for check_value in data:
             if (modifier in ["", ".not"] and check_value.lower() in value.lower()) \
+                    or (modifier in [".is", ".isnot"] and value.lower() == check_value.lower()) \
                     or (modifier == ".begins" and value.lower().startswith(check_value.lower())) \
                     or (modifier == ".ends" and value.lower().endswith(check_value.lower())) \
                     or (modifier == ".regex" and re.compile(check_value).match(value)):
                 jailbreak = True
                 break
         if jailbreak: break
-    return (jailbreak and modifier == ".not") or (not jailbreak and modifier in ["", ".begins", ".ends", ".regex"])
+    return (jailbreak and modifier in [".not", ".isnot"]) or (not jailbreak and modifier in ["", ".is", ".begins", ".ends", ".regex"])
 
 def parse(attribute, data, datatype=None, methods=None, parent=None, default=None, options=None, translation=None, minimum=1, maximum=None, regex=None):
     display = f"{parent + ' ' if parent else ''}{attribute} attribute"

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -115,7 +115,7 @@ def start(config_path, is_test=False, time_scheduled=None, requested_collections
     logger.info(util.centered("|  __/| |  __/>  <  | |  | |  __/ || (_| | | |  | | (_| | | | | (_| | (_| |  __/ |   "))
     logger.info(util.centered("|_|   |_|\\___/_/\\_\\ |_|  |_|\\___|\\__\\__,_| |_|  |_|\\__,_|_| |_|\\__,_|\\__, |\\___|_|   "))
     logger.info(util.centered("                                                                     |___/           "))
-    logger.info(util.centered("    Version: 1.12.1                                                                  "))
+    logger.info(util.centered("    Version: 1.12.2                                                                  "))
     if time_scheduled:              start_type = f"{time_scheduled} "
     elif is_test:                   start_type = "Test "
     elif requested_collections:     start_type = "Collections "

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -497,11 +497,18 @@ def run_collection(config, library, metadata, requested_collections):
 
                 builder.find_rating_keys()
 
-                if len(builder.rating_keys) > 0 and builder.build_collection:
+                if len(builder.rating_keys) >= builder.minimum and builder.build_collection:
                     logger.info("")
                     util.separator(f"Adding to {mapping_name} Collection", space=False, border=False)
                     logger.info("")
                     builder.add_to_collection()
+                elif len(builder.rating_keys) < builder.minimum and builder.build_collection:
+                    logger.info("")
+                    logger.info(f"Collection minimum: {builder.minimum} not met for {mapping_name} Collection")
+                    logger.info("")
+                    if library.delete_below_minimum and builder.obj:
+                        builder.delete_collection()
+                        logger.info(f"Collection {builder.obj.title} deleted")
                 if builder.do_missing and (len(builder.missing_movies) > 0 or len(builder.missing_shows) > 0):
                     if builder.details["show_missing"] is True:
                         logger.info("")

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -1,4 +1,4 @@
-import argparse, logging, os, re, sys, time
+import argparse, logging, os, sys, time
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
 try:
@@ -18,7 +18,7 @@ if sys.version_info[0] != 3 or sys.version_info[1] < 6:
 parser = argparse.ArgumentParser()
 parser.add_argument("-db", "--debug", dest="debug", help=argparse.SUPPRESS, action="store_true", default=False)
 parser.add_argument("-c", "--config", dest="config", help="Run with desired *.yml file", type=str)
-parser.add_argument("-t", "--time", dest="time", help="Times to update each day use format HH:MM (Default: 03:00) (comma-separated list)", default="03:00", type=str)
+parser.add_argument("-t", "--time", "--times", dest="times", help="Times to update each day use format HH:MM (Default: 03:00) (comma-separated list)", default="03:00", type=str)
 parser.add_argument("-re", "--resume", dest="resume", help="Resume collection run from a specific collection", type=str)
 parser.add_argument("-r", "--run", dest="run", help="Run without the scheduler", action="store_true", default=False)
 parser.add_argument("-rt", "--test", "--tests", "--run-test", "--run-tests", dest="test", help="Run in debug mode with only collections that have test: true", action="store_true", default=False)
@@ -32,47 +32,54 @@ parser.add_argument("-d", "--divider", dest="divider", help="Character that divi
 parser.add_argument("-w", "--width", dest="width", help="Screen Width (Default: 100)", default=100, type=int)
 args = parser.parse_args()
 
-def check_bool(env_str, default):
+def get_arg(env_str, default, arg_bool=False, arg_int=False):
     env_var = os.environ.get(env_str)
-    if env_var is not None:
-        if env_var is True or env_var is False:
-            return env_var
-        elif env_var.lower() in ["t", "true"]:
-            return True
+    if env_var:
+        if arg_bool:
+            if env_var is True or env_var is False:
+                return env_var
+            elif env_var.lower() in ["t", "true"]:
+                return True
+            else:
+                return False
+        elif arg_int:
+            return int(env_var)
         else:
-            return False
+            return str(env_var)
     else:
         return default
 
-test = check_bool("PMM_TEST", args.test)
-debug = check_bool("PMM_DEBUG", args.debug)
-run = check_bool("PMM_RUN", args.run)
-no_countdown = check_bool("PMM_NO_COUNTDOWN", args.no_countdown)
-no_missing = check_bool("PMM_NO_MISSING", args.no_missing)
-library_only = check_bool("PMM_LIBRARIES_ONLY", args.library_only)
-collection_only = check_bool("PMM_COLLECTIONS_ONLY", args.collection_only)
-collections = os.environ.get("PMM_COLLECTIONS") if os.environ.get("PMM_COLLECTIONS") else args.collections
-libraries = os.environ.get("PMM_LIBRARIES") if os.environ.get("PMM_LIBRARIES") else args.libraries
-resume = os.environ.get("PMM_RESUME") if os.environ.get("PMM_RESUME") else args.resume
+test = get_arg("PMM_TEST", args.test, arg_bool=True)
+debug = get_arg("PMM_DEBUG", args.debug, arg_bool=True)
+run = get_arg("PMM_RUN", args.run, arg_bool=True)
+no_countdown = get_arg("PMM_NO_COUNTDOWN", args.no_countdown, arg_bool=True)
+no_missing = get_arg("PMM_NO_MISSING", args.no_missing, arg_bool=True)
+library_only = get_arg("PMM_LIBRARIES_ONLY", args.library_only, arg_bool=True)
+collection_only = get_arg("PMM_COLLECTIONS_ONLY", args.collection_only, arg_bool=True)
+collections = get_arg("PMM_COLLECTIONS", args.collections)
+libraries = get_arg("PMM_LIBRARIES", args.libraries)
+resume = get_arg("PMM_RESUME", args.resume)
+times = get_arg("PMM_TIME", args.times)
+divider = get_arg("PMM_DIVIDER", args.divider)
+screen_width = get_arg("PMM_WIDTH", args.width)
+config_file = get_arg("PMM_CONFIG", args.config)
 
-times_to_run = util.get_list(os.environ.get("PMM_TIME") if os.environ.get("PMM_TIME") else args.time)
-for time_to_run in times_to_run:
-    if not re.match("^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$", time_to_run):
-        raise util.Failed(f"Argument Error: time argument invalid: {time_to_run} must be in the HH:MM format")
+util.separating_character = divider[0]
 
-util.separating_character = os.environ.get("PMM_DIVIDER")[0] if os.environ.get("PMM_DIVIDER") else args.divider[0]
+if screen_width < 90 or screen_width > 300:
+    print(f"Argument Error: width argument invalid: {screen_width} must be an integer between 90 and 300 using the default 100")
+    screen_width = 100
+util.screen_width = screen_width
 
-screen_width = int(os.environ.get("PMM_WIDTH")) if os.environ.get("PMM_WIDTH") else args.width
-if 90 <= screen_width <= 300:
-    util.screen_width = screen_width
-else:
-    raise util.Failed(f"Argument Error: width argument invalid: {screen_width} must be an integer between 90 and 300")
-
-config_file = os.environ.get("PMM_CONFIG") if os.environ.get("PMM_CONFIG") else args.config
 default_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config")
-if config_file and os.path.exists(config_file):                     default_dir = os.path.join(os.path.dirname(os.path.abspath(config_file)))
-elif config_file and not os.path.exists(config_file):               raise util.Failed(f"Config Error: config not found at {os.path.abspath(config_file)}")
-elif not os.path.exists(os.path.join(default_dir, "config.yml")):   raise util.Failed(f"Config Error: config not found at {os.path.abspath(default_dir)}")
+if config_file and os.path.exists(config_file):
+    default_dir = os.path.join(os.path.dirname(os.path.abspath(config_file)))
+elif config_file and not os.path.exists(config_file):
+    print(f"Config Error: config not found at {os.path.abspath(config_file)}")
+    sys.exit(0)
+elif not os.path.exists(os.path.join(default_dir, "config.yml")):
+    print(f"Config Error: config not found at {os.path.abspath(default_dir)}")
+    sys.exit(0)
 
 os.makedirs(os.path.join(default_dir, "logs"), exist_ok=True)
 
@@ -536,7 +543,17 @@ try:
     if run or test or collections or libraries or resume:
         start(config_file, is_test=test, requested_collections=collections, requested_libraries=libraries, resume_from=resume)
     else:
+        times_to_run = util.get_list(times)
+        valid_times = []
         for time_to_run in times_to_run:
+            try:
+                valid_times.append(datetime.strftime(datetime.strptime(time_to_run, "%H:%M"), "%H:%M"))
+            except ValueError:
+                if time_to_run:
+                    raise Failed(f"Argument Error: time argument invalid: {time_to_run} must be in the HH:MM format")
+                else:
+                    raise Failed(f"Argument Error: blank time argument")
+        for time_to_run in valid_times:
             schedule.every().day.at(time_to_run).do(start, config_file, time_scheduled=time_to_run)
         while True:
             schedule.run_pending()
@@ -544,7 +561,7 @@ try:
                 current = datetime.now().strftime("%H:%M")
                 seconds = None
                 og_time_str = ""
-                for time_to_run in times_to_run:
+                for time_to_run in valid_times:
                     new_seconds = (datetime.strptime(time_to_run, "%H:%M") - datetime.strptime(current, "%H:%M")).total_seconds()
                     if new_seconds < 0:
                         new_seconds += 86400

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PlexAPI==4.7.0
 tmdbv3api==1.7.6
-arrapi==1.1.2
+arrapi==1.1.3
 lxml==4.6.3
 requests==2.26.0
 ruamel.yaml==0.17.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ ruamel.yaml==0.17.10
 schedule==1.1.0
 retrying==1.3.3
 pathvalidate==2.4.1
-pillow==8.3.1
+pillow==8.3.2


### PR DESCRIPTION
# Requirments Update (requirements will need to be reinstalled)
Updated pillow requirement to 8.3.2

# New Features
Adds `anilist_trending` Collection Builder
Adds `country` and `source` as `anilist_search` attributes and `trending` as an `anilist_search` sort option
Adds `collection_name` Collection Detail to specify the collection name in plex as different than the mapping name
Close #356 Adds `collection_minimum` as a Setting and Collection Detail that will only add to a collection if the Collection Builders find at least as many items as the minimum.
Adds `delete_below_minimum` as a Setting and Collection Detail that will delete an existing collection if the Collection Builders do not find at least as many items as the minimum.
Closes #390 Adds `.is` and `.isnot` to as a String modifier for Searches and Collection Filters.

# Bug Fixes
Fixes #369 and Fixes #382 `anidb_search` fix
Fixes #380 time validation error
Fixes #381 Updated Support for MyAnimeList Agent and changed the anime-to-tv list
Fixes #387 numbered mapping names fix
