### PR TITLE
set PMM_WIDTH to int

### DIFF
--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -61,7 +61,7 @@ libraries = get_arg("PMM_LIBRARIES", args.libraries)
 resume = get_arg("PMM_RESUME", args.resume)
 times = get_arg("PMM_TIME", args.times)
 divider = get_arg("PMM_DIVIDER", args.divider)
-screen_width = get_arg("PMM_WIDTH", args.width)
+screen_width = get_arg("PMM_WIDTH", args.width, arg_int=True)
 config_file = get_arg("PMM_CONFIG", args.config)
 
 util.separating_character = divider[0]


### PR DESCRIPTION
set PMM_WIDTH to int to avoid TypeError: '<' not supported between instances of 'str' and 'int'
fixing bug #435

## Description

only one line changed to return PMM_WIDTH as INT

### Issues Fixed or Closed

- Fixes #435 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
