### PR TITLE
Add item_lock_art, item_lock_poster item details

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -90,7 +90,7 @@ notification_details = ["collection_creation_webhooks", "collection_addition_web
 details = ["collection_mode", "collection_order", "collection_level", "collection_minimum", "label"] + boolean_details + string_details + notification_details
 collectionless_details = ["collection_order", "plex_collectionless", "label", "label_sync_mode", "test"] + \
                          poster_details + background_details + summary_details + string_details
-item_details = ["item_label", "item_radarr_tag", "item_sonarr_tag", "item_overlay", "item_assets", "revert_overlay", "item_lock_art", "item_lock_poster", "item_refresh"] + \
+item_details = ["item_label", "item_radarr_tag", "item_sonarr_tag", "item_overlay", "item_assets", "revert_overlay", "item_lock_background", "item_lock_poster", "item_refresh"] + \
                list(plex.item_advance_keys.keys())
 radarr_details = ["radarr_add", "radarr_add_existing", "radarr_folder", "radarr_monitor", "radarr_search", "radarr_availability", "radarr_quality", "radarr_tag"]
 sonarr_details = [
@@ -742,7 +742,7 @@ class CollectionBuilder:
                 raise Failed("Each Overlay can only be used once per Library")
             self.library.overlays.append(method_data)
             self.item_details[method_name] = method_data
-        elif method_name in ["item_assets", "revert_overlay", "item_lock_art", "item_lock_poster", "item_refresh"]:
+        elif method_name in ["item_assets", "revert_overlay", "item_lock_background", "item_lock_poster", "item_refresh"]:
             if util.parse(method_name, method_data, datatype="bool", default=False):
                 self.item_details[method_name] = True
         elif method_name in plex.item_advance_keys:
@@ -1835,9 +1835,10 @@ class CollectionBuilder:
                     if getattr(item, key) != options[method_data]:
                         advance_edits[key] = options[method_data]
             self.library.edit_item(item, item.title, self.collection_level.capitalize(), advance_edits, advanced=True)
-            # Locking art and poster should come before refreshing since refreshing can change art and poster (i.e. if
-            # specified to both lock art/poster and refresh, assume that the current art/poster should be kept)
-            if "item_lock_art" in self.item_details:
+            # Locking background and poster should come before refreshing since refreshing can change background/poster
+            # (i.e. if specified to both lock background/poster and refresh, assume that the current background/poster
+            # should be kept)
+            if "item_lock_background" in self.item_details:
                 item.lockArt()
             if "item_lock_poster" in self.item_details:
                 item.lockPoster()

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -90,7 +90,8 @@ notification_details = ["collection_creation_webhooks", "collection_addition_web
 details = ["collection_mode", "collection_order", "collection_level", "collection_minimum", "label"] + boolean_details + string_details + notification_details
 collectionless_details = ["collection_order", "plex_collectionless", "label", "label_sync_mode", "test"] + \
                          poster_details + background_details + summary_details + string_details
-item_details = ["item_label", "item_radarr_tag", "item_sonarr_tag", "item_overlay", "item_assets", "revert_overlay", "item_refresh"] + list(plex.item_advance_keys.keys())
+item_details = ["item_label", "item_radarr_tag", "item_sonarr_tag", "item_overlay", "item_assets", "revert_overlay", "item_lock_art", "item_lock_poster", "item_refresh"] + \
+               list(plex.item_advance_keys.keys())
 radarr_details = ["radarr_add", "radarr_add_existing", "radarr_folder", "radarr_monitor", "radarr_search", "radarr_availability", "radarr_quality", "radarr_tag"]
 sonarr_details = [
     "sonarr_add", "sonarr_add_existing", "sonarr_folder", "sonarr_monitor", "sonarr_language", "sonarr_series",
@@ -741,7 +742,7 @@ class CollectionBuilder:
                 raise Failed("Each Overlay can only be used once per Library")
             self.library.overlays.append(method_data)
             self.item_details[method_name] = method_data
-        elif method_name in ["item_assets", "revert_overlay", "item_refresh"]:
+        elif method_name in ["item_assets", "revert_overlay", "item_lock_art", "item_lock_poster", "item_refresh"]:
             if util.parse(method_name, method_data, datatype="bool", default=False):
                 self.item_details[method_name] = True
         elif method_name in plex.item_advance_keys:
@@ -1834,6 +1835,13 @@ class CollectionBuilder:
                     if getattr(item, key) != options[method_data]:
                         advance_edits[key] = options[method_data]
             self.library.edit_item(item, item.title, self.collection_level.capitalize(), advance_edits, advanced=True)
+            # Locking art and poster should come before refreshing since refreshing can change art and poster (i.e. if
+            # specified to both lock art/poster and refresh, assume that the current art/poster should be kept)
+            if "item_lock_art" in self.item_details:
+                item.lockArt()
+            if "item_lock_poster" in self.item_details:
+                item.lockPoster()
+
             if "item_refresh" in self.item_details:
                 item.refresh()
 


### PR DESCRIPTION
## Description

Support locking Plex art (background) and poster for all items within collection. Tested with this config which locks art and posters while also refreshing metadata for any movie released in the past 5 days.

```yaml
collections:
  'Recent':
    build_collection: false
    item_lock_art: true
    item_lock_poster: true
    item_refresh: true
    plex_search:
      release: 5
```

### Issues Fixed or Closed

None

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
