### PR TITLE
Add watch provider attributes for tmdb discover

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -992,7 +992,8 @@ class CollectionBuilder:
                         new_dictionary[discover_attr] = util.parse(discover_attr, discover_data, datatype="int", parent=method_name, minimum=1800, maximum=self.current_year + 1)
                     elif discover_attr in ["vote_count", "vote_average", "with_runtime"]:
                         new_dictionary[discover_final] = util.parse(discover_final, discover_data, datatype="int", parent=method_name)
-                    elif discover_final in ["with_cast", "with_crew", "with_people", "with_companies", "with_networks", "with_genres", "without_genres", "with_keywords", "without_keywords", "with_original_language", "timezone"]:
+                                                                    parent=method_name)
+                    elif discover_final in ["with_cast", "with_crew", "with_people", "with_companies", "with_networks", "with_genres", "without_genres", "with_keywords", "without_keywords", "with_original_language", "timezone", "watch_region", "with_watch_providers", "without_watch_providers", "with_watch_monetization_types"]:
                         new_dictionary[discover_final] = discover_data
                     elif discover_attr != "limit":
                         raise Failed(f"Collection Error: {method_name} {discover_final} attribute not supported")

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -29,7 +29,8 @@ discover_all = [
     "vote_average.gte", "vote_average.lte", "with_runtime.gte", "with_runtime.lte",
     "with_companies", "with_genres", "without_genres", "with_keywords", "without_keywords", "include_adult",
     "timezone", "screened_theatrically", "include_null_first_air_dates", "limit",
-    "air_date.gte", "air_date.lte", "first_air_date.gte", "first_air_date.lte", "first_air_date_year", "with_networks"
+    "air_date.gte", "air_date.lte", "first_air_date.gte", "first_air_date.lte", "first_air_date_year", "with_networks",
+    "watch_region", "with_watch_providers", "without_watch_providers", "with_watch_monetization_types"
 ]
 discover_movie_only = [
     "region", "with_cast", "with_crew", "with_people", "certification_country", "certification",


### PR DESCRIPTION
## Description

There are some missing attributes to the TMDb Discover builder. This PR is to add support for watch provider based filtering.

The Wiki will likely need to be updated as well, perhaps giving the example of use, like:
```YML
tmdb_discover:
  watch_region: US
  with_watch_provider: 8 #Netflix
  with_watch_monetization_type: flatrate
```

Additionally `without_watch_provider` seems to work, but is undocumented.

### Issues Fixed or Closed

- Fixes #430 

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
