### PR TITLE
call out two required elements

### DIFF
--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -37,14 +37,14 @@ webhooks:                                       # Can be individually specified 
   collection_creation:
   collection_addition:
   collection_removal:
-plex:                                           # Can be individually specified per library as well
+plex:                                           # Can be individually specified per library as well; REQUIRED for the script to run
   url: http://192.168.1.12:32400
   token: ####################
   timeout: 60
   clean_bundles: false
   empty_trash: false
   optimize: false
-tmdb:
+tmdb:                                           # REQUIRED for the script to run
   apikey: ################################
   language: en
 tautulli:                                       # Can be individually specified per library as well


### PR DESCRIPTION
## Description

There are two config elements that are required for the script to run.  I think it will be useful to call them out in the config file template so the info is right there when the user is editing the file.

### Issues Fixed or Closed

n/a

## Type of Change

This change doesn't really fit *any* of the stock categories, being just edit or creation of comments.

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas [change is in the comments]

