### PR TITLE
Episode Collection Matching Enhancement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+Pipfile
+Pipfile.lock
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -80,7 +80,10 @@ class Cache:
                     imdb_votes INTEGER,
                     metacritic_rating INTEGER,
                     type TEXT,
-                    expiration_date TEXT)"""
+                    expiration_date TEXT,
+                    series_id TEXT,
+                    season_num INTEGER,
+                    episode_num INTEGER)"""
                 )
                 cursor.execute(
                     """CREATE TABLE IF NOT EXISTS anime_map (

--- a/modules/omdb.py
+++ b/modules/omdb.py
@@ -34,6 +34,18 @@ class OMDbObj:
             self.metacritic_rating = None
         self.imdb_id = data["imdbID"]
         self.type = data["Type"]
+        try:
+            self.season_num = int(data["Season"])
+        except (ValueError, TypeError, KeyError):
+            self.season_num = None
+        try:
+            self.episode_num = int(data["Episode"])
+        except (ValueError, TypeError, KeyError):
+            self.episode_num = None
+        try:
+            self.series_id = data["seriesID"]
+        except (ValueError, TypeError, KeyError):
+            self.series_id = None
 
 class OMDb:
     def __init__(self, config, params):


### PR DESCRIPTION
## Description

I was trying to create an episode collection based on an imdb filmosearch for a somewhat obscure actor, and found that barely any of the episodes I have in my library made it into the collection. I played around with the code, and figured out that it's possible to go from the imdb id to the omdb item to get the episode information, rather than imdb id -> tmdb -> tvdb. There are still some episodes I have that should have been pulled into the collection but are missing, but I think that might be due to bad data returned from omdb.

`TV Shows.yml`

```yaml
collections:
  Berkeley Harris:
    collection_level: episode
    imdb_list:
      - https://www.imdb.com/filmosearch/?explore=title_type&role=nm0364473&ref_=filmo_ref_typ&sort=year,desc&mode=detail&page=1&title_type=tvEpisode
    sync_mode: sync
```

Before Changes

<img width="483" alt="Berkeley_Harris_TV_Episode_Collection_-_Before" src="https://user-images.githubusercontent.com/679017/148310175-28c6cbec-b41b-45d3-9c6d-bd7bcba0be2e.png">

After Changes

<img width="1210" alt="Berkeley_Harris_TV_Episode_Collection_-_After" src="https://user-images.githubusercontent.com/679017/148310197-af52e035-0e2a-42aa-b353-56d912860785.png">

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
