### PR TITLE
add if conditional to check if float is a duration attribute

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1640,6 +1640,8 @@ class CollectionBuilder:
                 or (attribute in plex.tag_attributes and modifier in [".count_gt", ".count_gte", ".count_lt", ".count_lte"]):
             return util.parse(self.Type, final, data, datatype="int")
         elif attribute in plex.float_attributes and modifier in [".gt", ".gte", ".lt", ".lte"]:
+            if attribute == 'duration':
+                return util.parse(self.Type, final, data, datatype="float", minimum=0, maximum=None)
             return util.parse(self.Type, final, data, datatype="float", minimum=0, maximum=10)
         elif attribute in plex.boolean_attributes + boolean_filters:
             return util.parse(self.Type, attribute, data, datatype="bool")


### PR DESCRIPTION
## Description

add `if` conditional to check if float is a duration attribute in the `validate_attribute` function and change the maximum value to `None` if it is

### Issues Fixed or Closed

When using duration as part of a filter, if the value was greater than 10 it would throw an error due to float attributes having a hard-coded maximum. This bug was introduced in PR #652 when implementing feature in issue #607.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
