### PR TITLE
Adds special album types to metadata update

### DIFF
--- a/modules/meta.py
+++ b/modules/meta.py
@@ -624,6 +624,11 @@ class MetadataFile(DataFile):
                     logger.error("Metadata Error: albums attribute must be a dictionary")
                 else:
                     albums = {album.title: album for album in item.albums()}
+                    special_albums = []
+                    for album_types in item.hubs()[:6]:
+                        if album_types.items:
+                            special_albums.extend(album_types.items)
+                    albums |= ({album.title: album for album in special_albums})
                     for album_name, album_dict in meta[methods["albums"]].items():
                         updated = False
                         title = None

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -626,6 +626,7 @@ class MetadataFile(DataFile):
                     albums = {album.title: album for album in item.albums()}
                     special_albums = []
                     for album_types in item.hubs()[:6]:
+                        album_types.reload()
                         if album_types.items:
                             special_albums.extend(album_types.items)
                     albums |= ({album.title: album for album in special_albums})


### PR DESCRIPTION
Fixes #670 
Special album types (Singles & EPs, Live Albums, Soundtracks, Compilations, Demos, Remixes) are found under python-plexapi's .hubs() instead of .albums().

## Description

Please include a summary of the changes.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
