### PR TITLE
Add special album types to metadata update

### DIFF
--- a/modules/meta.py
+++ b/modules/meta.py
@@ -748,6 +748,12 @@ class MetadataFile(DataFile):
                         updated = False
                         title = None
                         album_methods = {am.lower(): am for am in album_dict}
+                        special_albums = []
+                        for album_types in item.hubs()[:6]:
+                            album_types.reload()
+                            if album_types.items:
+                                special_albums.extend(album_types.items)
+                        albums = {**albums, **{album.title: album for album in special_albums}}
                         logger.info("")
                         logger.info(f"Updating album {album_name} of {mapping_name}...")
                         if album_name in albums:

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -744,16 +744,16 @@ class MetadataFile(DataFile):
                     logger.error("Metadata Error: albums attribute must be a dictionary")
                 else:
                     albums = {album.title: album for album in item.albums()}
+                    special_albums = []
+                    for album_types in item.hubs()[:6]:
+                        album_types.reload()
+                        if album_types.items:
+                            special_albums.extend(album_types.items)
+                    albums = {**albums, **{album.title: album for album in special_albums}}
                     for album_name, album_dict in meta[methods["albums"]].items():
                         updated = False
                         title = None
                         album_methods = {am.lower(): am for am in album_dict}
-                        special_albums = []
-                        for album_types in item.hubs()[:6]:
-                            album_types.reload()
-                            if album_types.items:
-                                special_albums.extend(album_types.items)
-                        albums = {**albums, **{album.title: album for album in special_albums}}
                         logger.info("")
                         logger.info(f"Updating album {album_name} of {mapping_name}...")
                         if album_name in albums:


### PR DESCRIPTION
## Description
Special album types (singles & eps, live albums, soundtracks, compilations, demos, remixes) are found under python-plexapi's .hubs() instead of .albums().

### Issues Fixed or Closed

- Fixes #670 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
