### PR TITLE
Assume square images as posters

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -898,7 +898,7 @@ class Plex(Library):
                         image = Image.open(file)
                         _w, _h = image.size
                         image.close()
-                        if not poster and _h > _w:
+                        if not poster and _h >= _w:
                             new_path = os.path.join(os.path.dirname(file), f"poster{os.path.splitext(file)[1].lower()}")
                             os.rename(file, new_path)
                             poster = ImageData("asset_directory", os.path.abspath(new_path), prefix=f"{item.title}'s ", is_url=False)


### PR DESCRIPTION
## Description

For dimensional asset renaming, assume square images are also posters. Artist posters are almost always square images.

### Issues Fixed or Closed

- None

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
