### PR TITLE
feat(trakt): add trakt_recommended_personal builder

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -172,7 +172,7 @@ custom_sort_builders = [
     "trakt_list", "trakt_watchlist", "trakt_collection", "trakt_trending", "trakt_popular", "trakt_boxoffice",
     "trakt_collected_daily", "trakt_collected_weekly", "trakt_collected_monthly", "trakt_collected_yearly", "trakt_collected_all",
     "flixpatrol_url", "flixpatrol_demographics", "flixpatrol_popular", "flixpatrol_top",
-    "trakt_recommended_daily", "trakt_recommended_weekly", "trakt_recommended_monthly", "trakt_recommended_yearly", "trakt_recommended_all",
+    "trakt_recommended_personal", "trakt_recommended_daily", "trakt_recommended_weekly", "trakt_recommended_monthly", "trakt_recommended_yearly", "trakt_recommended_all",
     "trakt_watched_daily", "trakt_watched_weekly", "trakt_watched_monthly", "trakt_watched_yearly", "trakt_watched_all",
     "tautulli_popular", "tautulli_watched", "mdblist_list", "letterboxd_list", "icheckmovies_list",
     "anilist_top_rated", "anilist_popular", "anilist_trending", "anilist_search",


### PR DESCRIPTION
## Description

Hi, I propose to add this Trakt builder that enables fetching Trakt's personal recommendations for the user (depending on his watch history and ratings).

The PR adds a new function `_user_recommendations` to `modules/trakt.py` that enables calling the specific API URL.

I made the changes after reading the existing code and having only a basic understanding of it, so please advise if I missed anything, thank you.

Related pull request for documentation: [https://github.com/meisnate12/Plex-Meta-Manager-Wiki/pull/49](https://github.com/meisnate12/Plex-Meta-Manager-Wiki/pull/49)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
