### PR TITLE
fix(trakt): personal recommendations api response is typeless

### DIFF
--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -234,7 +234,7 @@ class Trakt:
             raise Failed(f"Trakt Error: failed to fetch {media_type} Recommendations")
         if len(items) == 0:
             raise Failed(f"Trakt Error: no {media_type} Recommendations were found")
-        return self._parse(items, item_type="movie" if is_movie else "show")
+        return self._parse(items, typeless=True, item_type="movie" if is_movie else "show")
 
     def _pagenation(self, pagenation, amount, is_movie):
         items = self._request(f"/{'movies' if is_movie else 'shows'}/{pagenation}?limit={amount}")


### PR DESCRIPTION
## Description

The api call to fetch personal recommendations for the user returns items without "type".
In my previous PR #745 , I hadn't noticed the `typeless` option for the `Trakt._parse` function.

Thank you for accepting my PRs. It's really nice to have my personal recommendations as a collection now 😃 

![image](https://user-images.githubusercontent.com/9202748/156916304-8034b865-e9d0-4d8b-b114-2a20dd24a935.png)


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
