### PR TITLE
Fix variable type for Sort in AniList Userlist

### DIFF
--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -221,7 +221,7 @@ class AniList:
 
     def _userlist(self, username, list_name, sort_by):
         query = """
-            query ($user: String, $sort: MediaListStatus) {
+            query ($user: String, $sort: [MediaListSort]) {
               MediaListCollection (userName: $user, sort: $sort, type: ANIME) {
                 lists {
                   name 


### PR DESCRIPTION
## Description

Fixed the type name for the `$sort` variable for the `anilist_userlist` builder

### Issues Fixed or Closed

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
