### PR TITLE
Corrected typo under ##Missing Path

### DIFF
--- a/docs/config/libraries.md
+++ b/docs/config/libraries.md
@@ -161,7 +161,7 @@ The default and recommended path is `/config/<<MAPPING_NAME>>_missing.yml` where
 ```yaml
 libraries:
   Movies:
-    missing_path: /config/Movies_movies.yml
+    missing_path: /config/Movies_missing.yml
 ```
 
 Alternatively, "missing items" YAML files can be placed in their own directory, as below:


### PR DESCRIPTION
The example for the missing path was listed as "/config/Movies_movies.yml" but earlier in the page on the table linking to this section the example is shown as "/config/<<MAPPING_NAME>>_missing.yml". Made the correction and submitting for approval.

## Description

Changed the word "movies" to "missing" to align with the proper format given in the example earlier in the page.

### Issues Fixed or Closed

- Fixes #(issue): N/A

## Type of Change

Typo

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
