### PR TITLE
Docker tutorial notes, typo fix in dynamic

### DIFF
--- a/docs/home/environmental.md
+++ b/docs/home/environmental.md
@@ -4,6 +4,7 @@ This table outlines the run commands and environment variables that can be utili
 
 If you run into a race condition where you have set an Environment Variable within your system and also use a Shell Command for the same attribute, then the Environment Variable will take priority.
 
+These docs are assuming you have a basic understanding of Docker concepts.  One place to get familiar with Docker would be the [official tutorial](https://www.docker.com/101-tutorial/).
 
 | Attribute                                             | Shell Command                      | Environment Variable     |
 |:------------------------------------------------------|:-----------------------------------|:-------------------------|
@@ -31,6 +32,8 @@ Further explanation and examples of each command can be found below.
 
 ## Run Command Attribute Examples
 
+Environment variables are expressed as `KEY=VALUE`  Depending on the context where you are specifying them, you may enter those two things in two different fields, or some other way.  The examples below show how you would specify the environment variable in a script or a `docker run` command.  Things like Portainer or a NAS Docker UI will have different ways to specify these things.
+
 ### Config
 
 Specify the location of the configuration YAML file.
@@ -39,7 +42,7 @@ Specify the location of the configuration YAML file.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -86,7 +89,7 @@ Specify the time of day that Plex Meta Manager will run.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -133,7 +136,7 @@ Perform a run immediately, bypassing the time to run flag.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -172,7 +175,7 @@ Run Plex Meta Manager in test/debug mode
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -213,7 +216,7 @@ Only run collection metadata/YAML files, skip library operations.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -252,7 +255,7 @@ Only run library operations, skip collections.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -291,7 +294,7 @@ Run only the pre-defined collections
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -334,7 +337,7 @@ Run only the pre-defined libraries
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -377,7 +380,7 @@ Run only the pre-defined metadata files
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -421,7 +424,7 @@ Run library operations prior to running collections.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -460,7 +463,7 @@ Ignore all schedules for the run.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -500,7 +503,7 @@ Ignore all ghost logging for the run. A ghost log is what's printed to the conso
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -539,7 +542,7 @@ Delete all collections in a Library prior to running collections/operations.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -577,7 +580,7 @@ Resume a run from a specific collection use the `--resume` option.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -620,7 +623,7 @@ Run without displaying a countdown to the next scheduled run.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -659,7 +662,7 @@ Run without utilizing the missing movie/show functions.
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -698,7 +701,7 @@ Run without writing to the configuration file
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -739,7 +742,7 @@ Change the terminal output divider character or width
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>
@@ -767,7 +770,7 @@ Change the terminal output divider character or width
   <tr>
     <th style="background-color: #222;"></th>
     <th>Shell</th>
-    <th>Environmental</th>
+    <th>Environment</th>
   </tr>
   <tr>
     <th>Flags</th>

--- a/docs/home/guides/docker.md
+++ b/docs/home/guides/docker.md
@@ -23,6 +23,10 @@ This walkthrough is going to be pretty pedantic.  I’m assuming you’re readin
 
 I am assuming you do not have any of these tools already installed.  When writing this up I started with a brand new Windows 10 install.
 
+I'm also assuming you are doing this on a computer, not through a NAS interface or the like.  You can do all this through something like the Synology NAS UI or Portainer or the like, but those aren't documented here.  This uses the docker command line because it works the same on all platforms.
+
+You may want to take an hour to get familiar with Docker fundamentals with the [official tutorial](https://www.docker.com/101-tutorial/).
+
 ### Installing Docker.
 
 The Docker install is discussed here: [Installing Docker](https://docs.docker.com/engine/install/)

--- a/docs/home/installation.md
+++ b/docs/home/installation.md
@@ -54,6 +54,8 @@ docker run -it -v <PATH_TO_CONFIG>:/config:rw meisnate12/plex-meta-manager
 
 Example Docker Run command:
 
+These docs are assuming you have a basic understanding of Docker concepts.  One place to get familiar with Docker would be the [official tutorial](https://www.docker.com/101-tutorial/).
+
 ```shell
 docker run -it -v "X:\Media\Plex Meta Manager\config:/config:rw" meisnate12/plex-meta-manager
 ```

--- a/docs/metadata/dynamic.md
+++ b/docs/metadata/dynamic.md
@@ -16,7 +16,7 @@ This example will create a collection for every TMDb Collection associated with 
 ```yaml
 dynamic_collections:
   TMDb Collections:          # This name is the mapping name
-    type: tmdb_collections
+    type: tmdb_collection
     remove_suffix: "Collection"
 ```
 
@@ -32,7 +32,7 @@ A `dynamic key` or `key` for short is used to refer to a specific value/result f
 
 A `key_name` is the name that replaces `<<key_name>>` in `title_format` to create the collection titles for each key.
 
-An example of some keys and their names that would be generated from a `tmdb_collections` dynamic collection are
+An example of some keys and their names that would be generated from a `tmdb_collection` dynamic collection are
 * `key`: "10"
   * `key_name`: Star Wars Collection
 * `key`: "1241"
@@ -172,7 +172,7 @@ default_template:
 ```yaml
 dynamic_collections:
   TMDb Collections:          # This name is the mapping name
-    type: tmdb_collections
+    type: tmdb_collection
     remove_suffix: Collection
     remove_prefix: The
 ```
@@ -916,7 +916,7 @@ dynamic_collections:
     template: genre collection
 ```
 
-### Content Rating 
+### Content Rating
 
 Create a collection for each content rating found in the library.
 
@@ -1204,7 +1204,7 @@ dynamic_collections:
   Resolutions:         # mapping name does not matter just needs to be unique
     type: resolution
     addons:
-      480p: 
+      480p:
         - 576p
         - SD
     title_override:
@@ -1365,9 +1365,9 @@ default_template:
 ```yaml
 templates:
   network collection:
-    smart_filter: 
+    smart_filter:
       sort_by: critic_rating.desc
-      all: 
+      all:
         network: <<value>>
 dynamic_collections:
   Networks:         # mapping name does not matter just needs to be unique
@@ -1528,7 +1528,7 @@ dynamic_collections:
   networks:
     type: network
     addons:
-      MTV: 
+      MTV:
         - MTV2
         - MTV3
         - MTV (UK)
@@ -1548,9 +1548,9 @@ For example, the template below removes the limit on the `smart_filter` so it sh
 ```yaml
 templates:
   network collection:
-    smart_filter: 
+    smart_filter:
       sort_by: critic_rating.desc
-      all: 
+      all:
         network: <<value>>
 dynamic_collections:
   Networks:         # mapping name does not matter just needs to be unique
@@ -1563,7 +1563,7 @@ dynamic_collections:
 
 Defines how template variables can be defined by key.
 
-For example, when using `type: tmdb_collections` and you want to define a poster url for some collections
+For example, when using `type: tmdb_collection` and you want to define a poster url for some collections
 
 ```yaml
 templates:
@@ -1574,7 +1574,7 @@ templates:
   url_poster: <<my_collection_poster>>
 dynamic_collections:
   TMDb Collections:          # This name is the mapping name
-    type: tmdb_collections
+    type: tmdb_collection
     remove_suffix: "Collection"
     template_variables:
       my_collection_poster:
@@ -1586,12 +1586,12 @@ dynamic_collections:
 
 Removes the defined prefixes/suffixes from the key before it’s used in the collection title.
 
-For example, when using `type: tmdb_collections` you may not want every collection title to end with `Collection`
+For example, when using `type: tmdb_collection` you may not want every collection title to end with `Collection`
 
 ```yaml
 dynamic_collections:
   TMDb Collections:          # This name is the mapping name
-    type: tmdb_collections
+    type: tmdb_collection
     remove_suffix: "Collection"
 ```
 
@@ -1599,7 +1599,7 @@ dynamic_collections:
 
 This is the format for the collection titles.
 
-there are two special tags you can include in the `title_format` 
+there are two special tags you can include in the `title_format`
 * `<<key_name>>` is required and is what will be replaced by the dynamic key name.
 * `<<library_type>>` will be replaced with either Movie, Show, or Artist depending on your library type.
 
@@ -1637,7 +1637,7 @@ Here's an example using `title_override` that will override the TMDb Star Wars c
 ```yaml
 dynamic_collections:
   TMDb Collections:          # mapping name does not matter, just needs to be unique
-    type: tmdb_collections
+    type: tmdb_collection
     remove_suffix: "Collection"
     title_override:
       10: Star Wars Universe
@@ -1683,7 +1683,7 @@ Here's an example using `include`.
 dynamic_collections:
   Genres:         # mapping name does not matter just needs to be unique
     type: genre
-    include: 
+    include:
       - Action
       - Adventure
       - Animation


### PR DESCRIPTION
## Description

Made some notes about assumed Docker knowledge, fix an option name typo in Dynamic Collections

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
