### PR TITLE
Convert bool to lowercase string for anilist

### DIFF
--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -149,6 +149,8 @@ class AniList:
                         value = f'["{temp}"]'
                 elif attr in ["season", "source", "country"]:
                     value = self.options[attr.replace("_", " ").title()][value]
+                elif attr in ["isAdult", "adult"]:
+                    value = str(value).lower() if type(value) is bool else value
                 if mod == "gte":
                     value -= 1
                 elif mod == "lte":


### PR DESCRIPTION
## Description

Convert the boolean for isAdult to a lowercase string, as that is what the anilist search graphql expects, and fails if you pass it a python boolean (True or False)
### Issues Fixed or Closed

- Fixes #844

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Log of run after change
```
|============================== Running Current Season Test Collection ==============================|
|                                                                                                    |
| Sync Mode: sync                                                                                    |
|                                                                                                    |
| Builder: anilist_search: {'season': 'spring', 'year': 2022, 'adult': False, 'sort_by': 'score', 'limit': 100} |
|                                                                                                    |
| Processing AniList Search:                                                                         |
|       Sort By Average Score                                                                             |
|       Limit to 100 Anime                                                                                |
|       Season is spring                                                                                  |
|       Year is 2022                                                                                      |
|       Adult is False                                                                                    |
| query ($page: Int) {Page(page: $page){pageInfo {hasNextPage}media(sort: SCORE_DESC, type: ANIME, season: SPRING, seasonYear: 2022, isAdult: false){id}}} |
|                                                                                                    |
| 86 AniList IDs Found: [140960, 125367, 142984, 141774, 129201, 140350, 121176, 133891, 116605, 123330, 134732, 124032, 137281, 125124, 132052, 142455, 111321, 132010, 132532, 132171, 127911, 132474, 117197, 125447, 141014, 136080, 129193, 142074, 140457, 138459, 143150, 136226, 133412, 135384, 130586, 141350, 140002, 140830, 142219, 132526, 130319, 109911, 133175, 137633, 143203, 142016, 114108, 133124, 144676, 143455, 132351, 138452, 140085, 143289, 139303, 142842, 139273, 133898, 147728, 113689, 147226, 140842, 145968, 146488, 126783, 108357, 132679, 148295, 117074, 143202, 136303, 139376, 132232, 130705, 145813, 146865, 145848, 138425, 131520, 138700, 142549, 144853, 142806, 143080, 140787, 117756] |

```