### PR TITLE
Fix move_prefix replace code

### DIFF
--- a/modules/meta.py
+++ b/modules/meta.py
@@ -194,7 +194,9 @@ class DataFile:
                             prefix = template["move_collection_prefix"]
                         if prefix:
                             for op in util.get_list(prefix):
-                                variables["collection_name"] = variables["collection_name"].replace(f"{str(op).strip()} ", "") + f", {str(op).strip()}"
+                                # Check if the collection_name starts with the op, but only if it's followed by a space character
+                                if variables["collection_name"].startswith(f"{str(op).strip()} "):
+                                    variables["collection_name"] = variables["collection_name"][len(str(op).strip()):].lstrip() + f", {str(op).strip()}"
                         else:
                             raise Failed(f"{self.data_type} Error: template sub-attribute move_prefix is blank")
 


### PR DESCRIPTION
## Description

Check if any move_prefix exists before attempting a beginning only replace, and appending the prefix with a comma to the end for sort strings

### Issues Fixed or Closed

- Fixes #863 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
