### PR TITLE
Only split move_prefix if there is a space after

### DIFF
--- a/modules/meta.py
+++ b/modules/meta.py
@@ -184,8 +184,8 @@ class DataFile:
                             prefix = template["move_collection_prefix"]
                         if prefix:
                             for op in util.get_list(prefix):
-                                if variables[name_var].startswith(op):
-                                    sort_name = f"{variables[name_var][len(op):]}, {op}"
+                                if variables[name_var].startswith(f"{op} "):
+                                    sort_name = f"{variables[name_var][len(op):].lstrip()}, {op}"
                                     break
                         else:
                             raise Failed(f"{self.data_type} Error: template sub-attribute move_prefix is blank")


### PR DESCRIPTION
Fixes issues where a move_prefix of "A" turns
"Avengers" into "vengers, A" by checking if the string starts with the prefix, followed by a space

Also fixes issue where the sort_title includes a preceding space
"The Fast and the Furious"->" Fast and the Furious, The"

## Description

Please include a summary of the changes.

### Issues Fixed or Closed
N/A
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code was submitted to the nightly branch of the repository.
