### PR TITLE
Installing jpeg-dev and zlib-dev prior to installing requirements ins…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN echo "**** install system packages ****" \
  && apt-get install -y gcc g++ libxml2-dev libxslt-dev libz-dev wget \
  && wget -O /tini https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-"$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && chmod +x /tini \
+ && RUN apk add jpeg-dev zlib-dev
  && pip3 install --no-cache-dir --upgrade --requirement /requirements.txt \
  && apt-get --purge autoremove wget gcc g++ libxml2-dev libxslt-dev libz-dev -y \
  && apt-get clean \


### PR DESCRIPTION
…

## Description

Installing jpeg-dev and zlib-dev prior to installing requirements ins tall pillow. Should allow a docker container to be built for ARM7.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
