### PR TITLE
Update example for Template Variables

### DIFF
--- a/docs/config/libraries.md
+++ b/docs/config/libraries.md
@@ -197,7 +197,7 @@ Library template variables to be applied to every Metadata and Overlay file run.
 ```yaml
 libraries:
   Movies:
-    template_variable:
+    template_variables:
       collection_mode: true
 ```
 


### PR DESCRIPTION
## Description

Changed example for Template Variables from `template_variable:` to `template_variables:`
Don't know why the backticks are also shown as changed, did not touch them but looks okay to me.

## Type of Change

Please delete options that are not relevant.

- [x] Wiki Update (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
