### PR TITLE
Add last_episode_aired_or_never filter

### DIFF
--- a/docs/metadata/filters.md
+++ b/docs/metadata/filters.md
@@ -125,13 +125,14 @@ Date filters can **NOT** take multiple values.
 
 ### Attribute
 
-| Date Filters                      | Description                                                     |  Movies  |  Shows  | Seasons  | Episodes | Artists  |  Albums  |  Track   |
-|:----------------------------------|:----------------------------------------------------------------|:--------:|:-------:|:--------:|:--------:|:--------:|:--------:|:--------:|
-| `release`                         | Uses the release date attribute (originally available) to match | &#9989;  | &#9989; | &#10060; | &#9989;  | &#10060; | &#9989;  | &#10060; |
-| `added`                           | Uses the date added attribute to match                          | &#9989;  | &#9989; | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
-| `last_played`                     | Uses the date last played attribute to match                    | &#9989;  | &#9989; | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
-| `first_episode_aired`<sup>1</sup> | Uses the first episode aired date to match                      | &#10060; | &#9989; | &#10060; | &#10060; | &#10060; | &#10060; | &#10060; |
-| `last_episode_aired`<sup>1</sup>  | Uses the last episode aired date to match                       | &#10060; | &#9989; | &#10060; | &#10060; | &#10060; | &#10060; | &#10060; |
+| Date Filters                              | Description                                                                    |  Movies  |  Shows  | Seasons  | Episodes | Artists  |  Albums  |  Track   |
+|:------------------------------------------|:-------------------------------------------------------------------------------|:--------:|:-------:|:--------:|:--------:|:--------:|:--------:|:--------:|
+| `release`                                 | Uses the release date attribute (originally available) to match                | &#9989;  | &#9989; | &#10060; | &#9989;  | &#10060; | &#9989;  | &#10060; |
+| `added`                                   | Uses the date added attribute to match                                         | &#9989;  | &#9989; | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
+| `last_played`                             | Uses the date last played attribute to match                                   | &#9989;  | &#9989; | &#9989;  | &#9989;  | &#9989;  | &#9989;  | &#9989;  |
+| `first_episode_aired`<sup>1</sup>         | Uses the first episode aired date to match                                     | &#10060; | &#9989; | &#10060; | &#10060; | &#10060; | &#10060; | &#10060; |
+| `last_episode_aired`<sup>1</sup>          | Uses the last episode aired date to match                                      | &#10060; | &#9989; | &#10060; | &#10060; | &#10060; | &#10060; | &#10060; |
+| `last_episode_aired_or_never`<sup>1</sup> | Similar to `last_episode_aired` but also includes those that haven't aired yet | &#10060; | &#9989; | &#10060; | &#10060; | &#10060; | &#10060; | &#10060; |
 
 <sup>1</sup> Also filters out missing movies/shows from being added to Radarr/Sonarr.
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -90,7 +90,7 @@ filters_by_type = {
     "show_artist": ["folder"],
     "show_season": ["episodes"],
     "artist_album": ["tracks"],
-    "show": ["seasons", "tmdb_status", "tmdb_type", "origin_country", "network", "first_episode_aired", "last_episode_aired"],
+    "show": ["seasons", "tmdb_status", "tmdb_type", "origin_country", "network", "first_episode_aired", "last_episode_aired", "last_episode_aired_or_never"],
     "artist": ["albums"],
     "album": ["record_label"]
 }
@@ -105,7 +105,7 @@ filters = {
 }
 tmdb_filters = [
     "original_language", "origin_country", "tmdb_vote_count", "tmdb_year", "tmdb_keyword", "tmdb_genre",
-    "first_episode_aired", "last_episode_aired", "tmdb_status", "tmdb_type", "tmdb_title"
+    "first_episode_aired", "last_episode_aired", "last_episode_aired_or_never", "tmdb_status", "tmdb_type", "tmdb_title"
 ]
 string_filters = ["title", "summary", "studio", "record_label", "folder", "filepath", "audio_track_title", "tmdb_title"]
 string_modifiers = ["", ".not", ".is", ".isnot", ".begins", ".ends", ".regex"]
@@ -116,7 +116,7 @@ tag_filters = [
 ]
 tag_modifiers = ["", ".not", ".regex", ".count_gt", ".count_gte", ".count_lt", ".count_lte"]
 boolean_filters = ["has_collection", "has_overlay", "has_dolby_vision"]
-date_filters = ["release", "added", "last_played", "first_episode_aired", "last_episode_aired"]
+date_filters = ["release", "added", "last_played", "first_episode_aired", "last_episode_aired", "last_episode_aired_or_never"]
 date_modifiers = ["", ".not", ".before", ".after", ".regex"]
 number_filters = [
     "year", "tmdb_year", "critic_rating", "audience_rating", "user_rating", "tmdb_vote_count", "plays", "duration",
@@ -131,7 +131,7 @@ all_filters = boolean_filters + special_filters + \
               [f"{f}{m}" for f in tag_filters for m in tag_modifiers] + \
               [f"{f}{m}" for f in date_filters for m in date_modifiers] + \
               [f"{f}{m}" for f in number_filters for m in number_modifiers]
-date_attributes = plex.date_attributes + ["first_episode_aired", "last_episode_aired"]
+date_attributes = plex.date_attributes + ["first_episode_aired", "last_episode_aired", "last_episode_aired_or_never"]
 year_attributes = plex.year_attributes + ["tmdb_year"]
 number_attributes = plex.number_attributes + ["channels", "height", "width"]
 tag_attributes = plex.tag_attributes + ["audio_codec", "audio_profile", "video_codec", "video_profile"]
@@ -2155,12 +2155,16 @@ class CollectionBuilder:
                             raise Failed
                         if (modifier == ".not" and check_value in filter_data) or (modifier == "" and check_value not in filter_data):
                             return False
-                    elif filter_attr in ["first_episode_aired", "last_episode_aired"]:
+                    elif filter_attr in ["first_episode_aired", "last_episode_aired", "last_episode_aired_or_never"]:
                         tmdb_date = None
                         if filter_attr == "first_episode_aired":
                             tmdb_date = item.first_air_date
-                        elif filter_attr == "last_episode_aired":
+                        elif filter_attr in ["last_episode_aired", "last_episode_aired_or_never"]:
                             tmdb_date = item.last_air_date
+
+                            # tmdb_date is empty if never aired yet
+                            if tmdb_date is None and filter_attr == "last_episode_aired_or_never":
+                                return True
                         if util.is_date_filter(tmdb_date, modifier, filter_data, filter_final, self.current_time):
                             return False
                     elif modifier in [".gt", ".gte", ".lt", ".lte"]:


### PR DESCRIPTION
## Description

Adds `last_episode_aired_or_never` collection filter, similar to `last_episode_aired` but also won't filter out shows that haven't aired yet (i.e. upcoming shows). Use case is I want to include recently aired shows as well as any upcoming shows (i.e. not yet aired) from Trakt trending

```
'Trending Shows':
    collection_order: custom
    trakt_trending: 125
    sync_mode: sync
    filters:
      last_episode_aired_or_never: 100
```

If I were to run this then it won't include any shows that are having a series premiere in the next 24 hours but haven't aired yet

```
'Trending Shows':
    collection_order: custom
    trakt_trending: 125
    sync_mode: sync
    filters:
      last_episode_aired: 100
```

I'm open to calling this attribute another name.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
