### PR TITLE
remove references to meisnate12 metadata files

### DIFF
--- a/docs/config/libraries.md
+++ b/docs/config/libraries.md
@@ -23,18 +23,18 @@ libraries:
   Movies:
     metadata_path:
       - file: config/Movies.yml
-      - git: meisnate12/MovieCharts
-      - git: meisnate12/Studios
-      - git: meisnate12/IMDBGenres
-      - git: meisnate12/People
+      - git: PMM/chart/imdb
+      - git: PMM/studio
+      - git: PMM/genre
+      - git: PMM/actor
     operations:
       mass_critic_rating_update: tmdb
       split_duplicates: true
   TV Shows:
     metadata_path:
       - file: config/TV Shows.yml
-      - git: meisnate12/ShowCharts
-      - git: meisnate12/Networks
+      - git: PMM/chart/tmdb
+      - git: PMM/show/network
     overlay_path:
       - remove_overlays: false
       - file: config/Overlays.yml
@@ -45,12 +45,12 @@ libraries:
       token: ####################
     metadata_path:
       - file: config/TV Shows.yml
-      - git: meisnate12/ShowCharts
-      - git: meisnate12/Networks
+      - git: PMM/chart/tmdb
+      - git: PMM/show/network
   Anime:
     metadata_path:
       - file: config/Anime.yml
-      - git: meisnate12/AnimeCharts
+      - git: PMM/chart/myanimelist
     radarr:
       url: http://192.168.1.45:7878
       token: ################################
@@ -121,15 +121,15 @@ plex:
 
 ### Metadata Path
 
-The `metadata_path` attribute is used to define [Metadata Files](../metadata/metadata) by specifying the path type and path of the files that will be executed against the parent library. See [Path Types](paths) for how to define them. 
+The `metadata_path` attribute is used to define [Metadata Files](../metadata/metadata) by specifying the path type and path of the files that will be executed against the parent library. See [Path Types](paths) for how to define them.
 
 ```yaml
 libraries:
   TV Shows:
     metadata_path:
       - file: config/TV Shows.yml
-      - git: meisnate12/ShowCharts
-      - git: meisnate12/Networks
+      - git: PMM/chart/tmdb
+      - git: PMM/show/network
 ```
 
 By default, when `metadata_path` is missing the script will look within the root PMM directory for a metadata file called `<MAPPING_NAME>.yml`. In this example, Plex Meta Manager will look for a file named `TV Shows.yml`.
@@ -141,7 +141,7 @@ libraries:
 
 ### Overlay Path
 
-The `overlay_path` attribute is used to define [Overlay Files](../metadata/metadata) by specifying the path type and path of the files that will be executed against the parent library. See [Path Types](paths) for how to define them. 
+The `overlay_path` attribute is used to define [Overlay Files](../metadata/metadata) by specifying the path type and path of the files that will be executed against the parent library. See [Path Types](paths) for how to define them.
 
 ```yaml
 libraries:
@@ -166,7 +166,7 @@ libraries:
       - file: config/Overlays.yml
 ```
 
-#### Reapply Overlays 
+#### Reapply Overlays
 
 You can reapply overlays from a library by adding `reapply_overlays: true` to `overlay_path`. This will reapply overlays to every item in your library.
 
@@ -180,7 +180,7 @@ libraries:
       - file: config/Overlays.yml
 ```
 
-#### Reset Overlays 
+#### Reset Overlays
 
 You can reset overlays from a library by adding `reset_overlays` to `overlay_path` and setting it to either `tmdb` or `plex` depending on where you want to source the images from. This will use the reset image when overlaying items in your library.
 
@@ -235,6 +235,6 @@ You can define Playlist Files by using `playlist_files` mapper by specifying the
 
 ```yaml
 playlist_files:
-  - file: config/playlists.yml       
-  - git: meisnate12/Playlists
+  - file: config/playlists.yml
+  - git: PMM/playlist
 ```

--- a/docs/config/operations.md
+++ b/docs/config/operations.md
@@ -8,7 +8,7 @@ Within each library, operations can be defined by using the `operations` attribu
 libraries:
   Movies:
     metadata_path:
-      - git: meisnate12/MovieCharts
+      - git: PMM/chart/imdb
     operations:
       mass_critic_rating_update: tmdb
       split_duplicates: true

--- a/docs/config/paths.md
+++ b/docs/config/paths.md
@@ -103,7 +103,7 @@ libraries:
     metadata_path:
       - file: config/TVShows.yml
       - folder: config/TV Shows/
-      - git: meisnate12/ShowCharts
+      - git: PMM/chart/tmdb
       - repo: charts
       - url: https://somewhere.com/PopularTV.yml
 ```
@@ -112,7 +112,7 @@ Within the above example, PMM will:
 
 * First, look within the root of the PMM directory (also known as `config/`) for a metadata file named `TVShows.yml`. If this file does not exist, PMM will skip the entry and move to the next one in the list.
 * Then, look within the root of the PMM directory (also known as `config/`) for a directory called `TV Shows`, and then load any metadata files within that directory.
-* Then, look at the [meisnate12 folder](https://github.com/meisnate12/Plex-Meta-Manager-Configs/tree/master/meisnate12) within the GitHub Configs Repo for a file called `MovieCharts.yml` which it finds [here](https://github.com/meisnate12/Plex-Meta-Manager-Configs/blob/master/meisnate12/MovieCharts.yml).
+* Then, look at the [meisnate12 folder](https://github.com/meisnate12/Plex-Meta-Manager-Configs/tree/master/meisnate12) within the GitHub Configs Repo for a file called `MovieCharts.yml` which it finds [here](https://github.com/meisnate12/Plex-Meta-Manager-Configs/blob/master/PMM/chart/imdb.yml).
 * Then, look at the within the Custom Defined Repo for a file called `charts.yml`.
 * Finally, load the metadata file located at `https://somewhere.com/PopularTV.yml`
 
@@ -167,7 +167,7 @@ In this example, multiple `playlist_files` attribute path types are defined:
 playlist_files:
   - file: config/playlists.yml
   - folder: config/Playlists/
-  - git: meisnate12/Playlists
+  - git: PMM/playlist
   - repo: playlists
   - url: https://somewhere.com/Playlists.yml
 ```

--- a/docs/metadata/details/schedule.md
+++ b/docs/metadata/details/schedule.md
@@ -9,10 +9,10 @@ libraries:
     schedule: weekly(sunday)
     metadata_path:
       - file: config/Movies.yml
-      - git: meisnate12/MovieCharts
-      - git: meisnate12/Studios
-      - git: meisnate12/IMDBGenres
-      - git: meisnate12/People
+      - git: PMM/chart/imdb
+      - git: PMM/studio
+      - git: PMM/genre
+      - git: PMM/actor
     operations:
       mass_critic_rating_update: tmdb
 ```
@@ -24,13 +24,13 @@ libraries:
     metadata_path:
       - file: config/Movies.yml
         schedule: weekly(monday)
-      - git: meisnate12/MovieCharts
+      - git: PMM/chart/imdb
         schedule: weekly(tuesday)
-      - git: meisnate12/Studios
+      - git: PMM/studio
         schedule: weekly(wednesday)
-      - git: meisnate12/IMDBGenres
+      - git: PMM/genre
         schedule: weekly(thursday)
-      - git: meisnate12/People
+      - git: PMM/actor
         schedule: weekly(friday)
     overlay_path:
       - git: PMM/overlays/imdb


### PR DESCRIPTION
## Description

Removes references to the meisnate12/BLAH metadata files throughout; replaces them with references to PMM/BLAH

## Type of Change

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
