### PR TITLE
Add setting to remove largely useless lists of IDs

### DIFF
--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -68,6 +68,7 @@ settings:
   verify_ssl: true
   custom_repo:
   check_nightly: false
+  max_list_display_size: 
 webhooks:                                       # Can be individually specified per library as well
   error:
   version:

--- a/docs/config/configuration.md
+++ b/docs/config/configuration.md
@@ -98,6 +98,7 @@ settings:
   item_refresh_delay: 0
   playlist_sync_to_users: all
   verify_ssl: true
+  max_list_display_size: 
 webhooks:
   error:
   run_start:

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -56,6 +56,7 @@ The available setting attributes which can be set at each level are outlined bel
 | [`custom_repo`](#custom-repo)                                 |   &#9989;    |   &#10060;    |         &#10060;          |
 | [`verify_ssl`](#verify-ssl)                                   |   &#9989;    |   &#10060;    |         &#10060;          |
 | [`check_nightly`](#check-nightly)                             |   &#9989;    |   &#10060;    |         &#10060;          |
+| [`max_list_display_size`](#max_list_display_size)                             |   &#9989;    |   &#10060;    |         &#10060;          | 
 
 ## Cache
 Cache the Plex GUID and associated IDs for each library item for faster subsequent processing. The cache file is created in the same directory as the configuration file.
@@ -585,5 +586,20 @@ Will check nightly for updates instead of develop.
     <th>Allowed Values</th>
     <td><code>true</code> or <code>false</code>
     </td>
+  </tr>
+</table>
+
+## Check Nightly
+Hide ID and Key lists larger than this value.
+If not set, default value is 99999.
+
+<table class="dualTable colwidths-auto align-default table">
+  <tr>
+    <th>Default Value</th>
+    <td><code>None</code></td>
+  </tr>
+  <tr>
+    <th>Allowed Values</th>
+    <td>any integer</td>
   </tr>
 </table>

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -33,30 +33,30 @@ The available setting attributes which can be set at each level are outlined bel
 | [`show_missing_season_assets`](#show-missing-season-assets)   |   &#9989;    |    &#9989;    |         &#10060;          |
 | [`show_missing_episode_assets`](#show-missing-episode-assets) |   &#9989;    |    &#9989;    |         &#10060;          |
 | [`show_asset_not_needed`](#show-asset-not-needed)             |   &#9989;    |    &#9989;    |         &#10060;          |
-| [`sync_mode`](#sync-mode)                                     |   &#9989;    |    &#9989;    |          &#9989;          |
+| [`sync_mode`](#sync-mode)                                     |   &#9989;    |    &#9989;    |         &#9989;          |
 | [`default_collection_order`](#default-collection-order)       |   &#9989;    |    &#9989;    |         &#10060;          |
-| [`minimum_items`](#minimum-items)                             |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`delete_below_minimum`](#delete-below-minimum)               |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`delete_not_scheduled`](#delete-not-scheduled)               |   &#9989;    |    &#9989;    |          &#9989;          |
+| [`minimum_items`](#minimum-items)                             |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`delete_below_minimum`](#delete-below-minimum)               |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`delete_not_scheduled`](#delete-not-scheduled)               |   &#9989;    |    &#9989;    |         &#9989;          |
 | [`run_again_delay`](#run-again-delay)                         |   &#9989;    |   &#10060;    |         &#10060;          |
-| [`missing_only_released`](#missing-only-released)             |   &#9989;    |    &#9989;    |          &#9989;          |
+| [`missing_only_released`](#missing-only-released)             |   &#9989;    |    &#9989;    |         &#9989;          |
 | [`show_unmanaged`](#show-unmanaged-collections)               |   &#9989;    |    &#9989;    |         &#10060;          |
-| [`show_filtered`](#show-filtered)                             |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`show_options`](#show-options)                               |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`show_missing`](#show-missing)                               |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`only_filter_missing`](#only-filter-missing)                 |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`show_missing_assets`](#show-missing-assets)                 |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`save_report`](#save-report)                                 |   &#9989;    |    &#9989;    |          &#9989;          |
+| [`show_filtered`](#show-filtered)                             |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`show_options`](#show-options)                               |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`show_missing`](#show-missing)                               |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`only_filter_missing`](#only-filter-missing)                 |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`show_missing_assets`](#show-missing-assets)                 |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`save_report`](#save-report)                                 |   &#9989;    |    &#9989;    |         &#9989;          |
 | [`tvdb_language`](#tvdb-language)                             |   &#9989;    |   &#10060;    |         &#10060;          |
-| [`ignore_ids`](#ignore-ids)                                   |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`ignore_imdb_ids`](#ignore-imdb-ids)                         |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`item_refresh_delay`](#item-refresh-delay)                   |   &#9989;    |    &#9989;    |          &#9989;          |
-| [`playlist_sync_to_users`](#playlist-sync-to-users)           |   &#9989;    |   &#10060;    |          &#9989;          |
+| [`ignore_ids`](#ignore-ids)                                   |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`ignore_imdb_ids`](#ignore-imdb-ids)                         |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`item_refresh_delay`](#item-refresh-delay)                   |   &#9989;    |    &#9989;    |         &#9989;          |
+| [`playlist_sync_to_users`](#playlist-sync-to-users)           |   &#9989;    |   &#10060;    |         &#9989;          |
 | [`playlist_report`](#playlist-report)                         |   &#9989;    |   &#10060;    |         &#10060;          |
 | [`custom_repo`](#custom-repo)                                 |   &#9989;    |   &#10060;    |         &#10060;          |
 | [`verify_ssl`](#verify-ssl)                                   |   &#9989;    |   &#10060;    |         &#10060;          |
 | [`check_nightly`](#check-nightly)                             |   &#9989;    |   &#10060;    |         &#10060;          |
-| [`max_list_display_size`](#max_list_display_size)                             |   &#9989;    |   &#10060;    |         &#10060;          | 
+| [`max_list_display_size`](#max_list_display_size)             |   &#9989;    |    &#9989;    |         &#9989;          | 
 
 ## Cache
 Cache the Plex GUID and associated IDs for each library item for faster subsequent processing. The cache file is created in the same directory as the configuration file.

--- a/modules/anidb.py
+++ b/modules/anidb.py
@@ -79,6 +79,11 @@ class AniDB:
         self.username = None
         self.password = None
         self._delay = None
+        try:
+            self.maxitems = config.data['settings']['max_list_display_size']
+        except:
+            self.maxitems = 99999
+
 
     def authorize(self, client, version, expiration):
         self.client = client
@@ -200,5 +205,10 @@ class AniDB:
         else:
             raise Failed(f"AniDB Error: Method {method} not supported")
         logger.debug("")
-        logger.debug(f"{len(anidb_ids)} AniDB IDs Found: {anidb_ids}")
+        id_count = len(anidb_ids)
+        if id_count > 0:
+            if self.maxitems is not None and id_count > self.maxitems:
+                logger.debug(f"{id_count} AniDB IDs Found")
+            else:
+                logger.debug(f"{id_count} AniDB IDs Found: {anidb_ids}")
         return anidb_ids

--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -60,6 +60,11 @@ class AniList:
     def __init__(self, config):
         self.config = config
         self._options = None
+        try:
+            self.maxitems = config.data['settings']['max_list_display_size']
+        except:
+            self.maxitems = 99999
+
 
     @property
     def options(self):
@@ -319,5 +324,10 @@ class AniList:
             logger.info(message)
             anilist_ids = self._search(**data)
         logger.debug("")
-        logger.debug(f"{len(anilist_ids)} AniList IDs Found: {anilist_ids}")
+        id_count = len(anilist_ids)
+        if self.maxitems is not None and id_count > self.maxitems:
+            logger.debug(f"{id_count} AniList IDs Found")
+        else:
+            logger.debug(f"{id_count} AniList IDs Found: {anilist_ids}")
+        
         return anilist_ids

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1,4 +1,5 @@
 import os, re, time
+import json
 from datetime import datetime
 from modules import anidb, anilist, flixpatrol, icheckmovies, imdb, letterboxd, mal, plex, radarr, reciperr, sonarr, tautulli, tmdb, trakt, tvdb, mdblist, util
 from modules.util import Failed, NonExisting, NotScheduled, NotScheduledRange, Deleted
@@ -188,6 +189,10 @@ class CollectionBuilder:
         self.libraries = []
         self.playlist = library is None
         self.overlay = overlay
+        try:
+            self.maxitems = config.data['settings']['max_list_display_size']
+        except:
+            self.maxitems = 99999
         methods = {m.lower(): m for m in self.data}
         if self.playlist:
             self.type = "playlist"
@@ -1585,7 +1590,10 @@ class CollectionBuilder:
         if len(ids) > 0:
             total_ids = len(ids)
             logger.debug("")
-            logger.debug(f"{total_ids} IDs Found: {ids}")
+            if self.maxitems is not None and total_ids > self.maxitems:
+                logger.debug(f"{total_ids} IDs Found")
+            else:
+                logger.debug(f"{total_ids} IDs Found: {ids}")
             logger.debug("")
             for i, input_data in enumerate(ids, 1):
                 input_id, id_type = input_data

--- a/modules/config.py
+++ b/modules/config.py
@@ -331,6 +331,7 @@ class ConfigFile:
             "sync_mode": check_for_attribute(self.data, "sync_mode", parent="settings", default="append", test_list=sync_modes),
             "default_collection_order": check_for_attribute(self.data, "default_collection_order", parent="settings", default_is_none=True),
             "minimum_items": check_for_attribute(self.data, "minimum_items", parent="settings", var_type="int", default=1),
+            "max_list_display_size": check_for_attribute(self.data, "max_list_display_size", parent="settings", var_type="int", default_is_none=True),
             "item_refresh_delay": check_for_attribute(self.data, "item_refresh_delay", parent="settings", var_type="int", default=0),
             "delete_below_minimum": check_for_attribute(self.data, "delete_below_minimum", parent="settings", var_type="bool", default=False),
             "delete_not_scheduled": check_for_attribute(self.data, "delete_not_scheduled", parent="settings", var_type="bool", default=False),
@@ -680,6 +681,7 @@ class ConfigFile:
                 params["show_missing_episode_assets"] = check_for_attribute(lib, "show_missing_episode_assets", parent="settings", var_type="bool", default=self.general["show_missing_episode_assets"], do_print=False, save=False)
                 params["show_asset_not_needed"] = check_for_attribute(lib, "show_asset_not_needed", parent="settings", var_type="bool", default=self.general["show_asset_not_needed"], do_print=False, save=False)
                 params["minimum_items"] = check_for_attribute(lib, "minimum_items", parent="settings", var_type="int", default=self.general["minimum_items"], do_print=False, save=False)
+                params["max_list_display_size"] = check_for_attribute(lib, "max_list_display_size", parent="settings", var_type="int", default=self.general["max_list_display_size"], default_is_none=True, do_print=False, save=False)
                 params["item_refresh_delay"] = check_for_attribute(lib, "item_refresh_delay", parent="settings", var_type="int", default=self.general["item_refresh_delay"], do_print=False, save=False)
                 params["delete_below_minimum"] = check_for_attribute(lib, "delete_below_minimum", parent="settings", var_type="bool", default=self.general["delete_below_minimum"], do_print=False, save=False)
                 params["delete_not_scheduled"] = check_for_attribute(lib, "delete_not_scheduled", parent="settings", var_type="bool", default=self.general["delete_not_scheduled"], do_print=False, save=False)

--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -33,6 +33,10 @@ class IMDb:
         self._ratings = None
         self._genres = None
         self._episode_ratings = None
+        try:
+            self.maxitems = config.data['settings']['max_list_display_size']
+        except:
+            self.maxitems = 99999
 
     def validate_imdb_lists(self, err_type, imdb_lists, language):
         valid_lists = []
@@ -150,8 +154,12 @@ class IMDb:
             imdb_ids.extend(ids_found)
             time.sleep(2)
         logger.exorcise()
-        if len(imdb_ids) > 0:
-            logger.debug(f"{len(imdb_ids)} IMDb IDs Found: {imdb_ids}")
+        id_count = len(imdb_ids)
+        if id_count > 0:
+            if self.maxitems is not None and id_count > self.maxitems:
+                logger.debug(f"{id_count} IMDb IDs Found")
+            else:
+                logger.debug(f"{id_count} IMDb IDs Found: {imdb_ids}")
             return imdb_ids
         raise Failed(f"IMDb Error: No IMDb IDs Found at {imdb_url}")
 

--- a/modules/mal.py
+++ b/modules/mal.py
@@ -86,6 +86,10 @@ class MyAnimeList:
         self.config_path = params["config_path"]
         self.expiration = params["cache_expiration"]
         self.authorization = params["authorization"]
+        try:
+            self.maxitems = config.data['settings']['max_list_display_size']
+        except:
+            self.maxitems = 99999
         logger.secret(self.client_secret)
         if not self._save(self.authorization):
             if not self._refresh():
@@ -313,5 +317,10 @@ class MyAnimeList:
         else:
             raise Failed(f"MyAnimeList Error: Method {method} not supported")
         logger.debug("")
-        logger.debug(f"{len(mal_ids)} MyAnimeList IDs Found: {mal_ids}")
+        id_count = len(mal_ids)
+        if id_count > 0:
+            if self.maxitems is not None and id_count > self.maxitems:
+                logger.debug(f"{id_count} MyAnimeList IDs Found.")
+            else:
+                logger.debug(f"{id_count} MyAnimeList IDs Found: {mal_ids}")
         return mal_ids

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -427,6 +427,11 @@ class Plex(Library):
         self.url = params["plex"]["url"]
         self.token = params["plex"]["token"]
         self.timeout = params["plex"]["timeout"]
+        try:
+            self.maxitems = config.data['settings']['max_list_display_size']
+        except:
+            self.maxitems = 99999
+
         logger.secret(self.url)
         logger.secret(self.token)
         try:
@@ -949,7 +954,10 @@ class Plex(Library):
             raise Failed("Plex Error: No Items found in Plex")
         ids = [(item.ratingKey, "ratingKey") for item in items]
         logger.debug("")
-        logger.debug(f"{len(ids)} Keys Found: {ids}")
+        if self.maxitems is not None and len(ids) > self.maxitems:
+            logger.debug(f"{len(ids)} Keys Found")
+        else:
+            logger.debug(f"{len(ids)} Keys Found: {ids}")
         return ids
 
     def get_collection_items(self, collection, smart_label_collection):

--- a/modules/tautulli.py
+++ b/modules/tautulli.py
@@ -13,6 +13,7 @@ class Tautulli:
         self.library = library
         self.url = params["url"]
         self.apikey = params["apikey"]
+        self.maxitems = 10
         logger.secret(self.url)
         logger.secret(self.apikey)
         try:
@@ -56,7 +57,10 @@ class Tautulli:
                     else:
                         logger.error(f"Plex Error: Item not found {item}")
         logger.debug("")
-        logger.debug(f"{len(rating_keys)} Keys Found: {rating_keys}")
+        if len(rating_keys) > self.maxitems:
+            logger.debug(f"{len(rating_keys)} Keys Found")
+        else:
+            logger.debug(f"{len(rating_keys)} Keys Found: {rating_keys}")
         return rating_keys
 
     def _request(self, url):


### PR DESCRIPTION
## Description

This PR adds a setting:
```
  max_list_display_size: 
```
If a list of Keys or IDs is longer than the value of this setting, it will NOT be displayed.

For example:
```
| Builder: plex_all: movie                                                                           |
|                                                                                                    |
| Processing Plex All Movies                                                                         |
|                                                                                                    |
| 3778 Keys Found                                                                                    |
|                                                                                                    |
| 3778 IDs Found                                                                                     |
|                                                                                                    |
| 3 Titles Found: ['Batman v Superman: Dawn of Justice', 'Gemini', 'El Topo']                        |
| 3 Items found for Remastered-Dovetail Overlay                                                      |
|                                                                                                    |
```

### Issues Fixed or Closed

[feature request](https://features.metamanager.wiki/features/p/toggle-to-hide-lists-of-ids-in-console-output)

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
