### PR TITLE
improve seasonal anime filter with MAL

### DIFF
--- a/modules/mal.py
+++ b/modules/mal.py
@@ -220,8 +220,15 @@ class MyAnimeList:
         return self._parse_request(url)
 
     def _season(self, season, year, sort_by, limit):
-        url = f"{urls['season']}/{year}/{season}?sort={sort_by}&limit={limit}"
-        return self._parse_request(url)
+        url = f"{urls['season']}/{year}/{season}?sort={sort_by}&limit={limit*2}&fields=start_season"
+        results_all = self._request(url)['data']
+        results = []
+        for anime_data in results_all:
+            if anime_data['node']['start_season']['year'] == year and anime_data['node']['start_season']['season'] == season:
+                results.append(anime_data['node']['id'])
+                if len(results) == limit:
+                    break
+        return results
 
     def _suggestions(self, limit):
         url = f"{urls['suggestions']}?limit={limit}"


### PR DESCRIPTION
## Description

Investigating improvements to seasonal anime filter. 

Currently it just pulls airing anime, which includes ongoing anime. 
This does not match the MAL seasonal charts here: https://myanimelist.net/anime/season

This change fixes this and filters to just the anime that is 'new' for the season. 

This is a little scrappy at the moment but wanted to open a discussion on this. 

## related issue
https://github.com/meisnate12/Plex-Meta-Manager/issues/1153


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
