### PR TITLE
fix inverted delete collections library operations

### DIFF
--- a/modules/operations.py
+++ b/modules/operations.py
@@ -726,11 +726,11 @@ class Operations:
             if (less is not None or managed is not None or configured is not None) \
                     and (less is None or col.childCount < less) \
                     and (managed is None
-                         or (managed is True and "PMM" in labels)
-                         or (managed is False and "PMM" not in labels)) \
+                         or (managed is False and "PMM" in labels)
+                         or (managed is True and "PMM" not in labels)) \
                     and (configured is None
-                         or (configured is True and col.title in self.library.collections)
-                         or (configured is False and col.title not in self.library.collections)):
+                         or (configured is False and col.title in self.library.collections)
+                         or (configured is True and col.title not in self.library.collections)):
                 self.library.query(col.delete)
                 logger.info(f"{col.title} Deleted")
             else:


### PR DESCRIPTION
## Description

Logic is flipped.
Regression due to https://github.com/meisnate12/Plex-Meta-Manager/commit/e7f7cfcff4016203c4fbf857b7e753882049725f

Current Behavior:
- if managed is true and if the collection has PMM then delete
- If managed is false and if the collection does not have PMM then delete.
- if configured is True and if the collection is in configured run then delete.
- if configured is False and if  collection is not in the configured run then delete

Documented Behavior:
- managed
    Collection must be a Managed (the collection has the PMM label) or Unmanaged (the collection does not have the PMM label) Collection.
    Values: true (Managed) or false (Unmanged)

- configured
    Collection must be a Configured (collection is in the specific PMM run) or Unconfigured (collection is not in the specific PMM run) Collection.
    Values: true (Configured) or false (Unconfigured)

### Issues Fixed or Closed

- Untracked

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
