### PR TITLE
Change error text

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -978,7 +978,7 @@ class ConfigFile:
             if len(self.libraries) > 0:
                 logger.info(f"{len(self.libraries)} Plex Library Connection{'s' if len(self.libraries) > 1 else ''} Successful")
             else:
-                raise Failed("Plex Error: No Plex libraries were connected to")
+                raise Failed("Config Error: No libraries were found in config")
 
             logger.separator()
 


### PR DESCRIPTION
## Description

This error is related to reading libraries from the config file; the existing error text implies that Plex is implicated in some way when PMM has not yet tried to connect to Plex.  This leads troubleshooters down a blind alley.

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
