### PR TITLE
feat: allow env variable substitution

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -952,15 +952,14 @@ class YAML:
         self.yaml.indent(mapping=2, sequence=2)
         try:
             if input_data:
-                self.data = self.yaml.load(input_data)
+                self.data = parse_config(data=input_data)
             else:
                 if start_empty or (create and not os.path.exists(self.path)):
                     with open(self.path, 'w'):
                         pass
                     self.data = {}
                 else:
-                    with open(self.path, encoding="utf-8") as fp:
-                        self.data = self.yaml.load(fp)
+                    self.data = parse_config(path=self.path)
         except ruamel.yaml.error.YAMLError as e:
             e = str(e).replace("\n", "\n      ")
             raise Failed(f"YAML Error: {e}")
@@ -977,3 +976,55 @@ class YAML:
                 self.yaml.dump(self.data, fp)
 
 
+def parse_config(path=None, data=None, tag="!env_var"):
+    """
+    Load a yaml configuration file and resolve any environment variables
+    The environment variables must have !ENV before them and be in this format
+    to be parsed: ${VAR_NAME}.
+    E.g.:
+    database:
+        host: !env_var ${HOST}
+        port: !env_var ${PORT}
+    app:
+        log_path: !ENV '/var/${LOG_PATH}'
+        something_else: !ENV '${AWESOME_ENV_VAR}/var/${A_SECOND_AWESOME_VAR}'
+    :param str path: the path to the yaml file
+    :param str data: the yaml data itself as a stream
+    :param str tag: the tag to look for
+    :return: the dict configuration
+    :rtype: dict[str, T]
+    """
+    # pattern for global vars: look for ${word}
+    pattern = re.compile(".*?\${(\w+)}.*?")
+    loader = ruamel.yaml.SafeLoader
+
+    # the tag will be used to mark where to start searching for the pattern
+    # e.g. somekey: !ENV somestring${MYENVVAR}blah blah blah
+    loader.add_implicit_resolver(tag, pattern, None)
+
+    def constructor_env_variables(loader, node):
+        """
+        Extracts the environment variable from the node's value
+        :param yaml.Loader loader: the yaml loader
+        :param node: the current node in the yaml
+        :return: the parsed string that contains the value of the environment
+        variable
+        """
+        value = loader.construct_scalar(node)
+        match = pattern.findall(value)  # to find all env variables in line
+        if match:
+            full_value = value
+            for g in match:
+                full_value = full_value.replace(f"${{{g}}}", os.environ.get(g, g))
+            return full_value
+        return value
+
+    loader.add_constructor(tag, constructor_env_variables)
+
+    if path:
+        with open(path) as conf_data:
+            return ruamel.yaml.load(conf_data, Loader=loader)
+    elif data:
+        return ruamel.yaml.load(data, Loader=loader)
+    else:
+        raise ValueError("Either a path or data should be defined as input")


### PR DESCRIPTION
## Description

Allows parsing of the configuration file which can include environmental variable substitutions like so:

```
...
tmdb:
  apitoken: !env_var ${TMDB_API_TOKEN}
...
```

As long as the `TMDB_API_TOKEN` env variable is set, this will set `apitoken` to the appropriate value.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
