### PR TITLE
Fix mal_search for "sfw: false"

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1533,9 +1533,7 @@ class CollectionBuilder:
                     if "min_score" in final_attributes and "max_score"  in final_attributes and final_attributes["max_score"] <= final_attributes["min_score"]:
                         raise Failed(f"{self.Type} Error: mal_search score.lte/score.lt attribute must be greater than score.gte/score.gt")
                     if "sfw" in dict_methods:
-                        sfw = util.parse(self.Type, "sfw", dict_data, datatype="bool", methods=dict_methods, parent=method_name)
-                        if sfw:
-                            final_attributes["sfw"] = 1
+                        final_attributes["sfw"] = util.parse(self.Type, "sfw", dict_data, datatype="bool", methods=dict_methods, parent=method_name)
                         final_text += f"\nSafe for Work: {final_attributes['sfw']}"
                     if not final_attributes:
                         raise Failed(f"{self.Type} Error: no mal_search attributes found")


### PR DESCRIPTION
## Description
No valid logic for handling when "sfw" was set to false.

This minor change fixes the logic to directly parse the true/false state because the else condition was missing.

![image](https://user-images.githubusercontent.com/87995947/232385463-789a7e91-ffcd-48a5-aa81-dc0a1127997c.png)
vs.
![image](https://user-images.githubusercontent.com/87995947/232386027-d5a9a4a3-59fc-4022-a7c3-87d0fad58bb9.png)

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change


- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
