### PR TITLE
Added support for new F1 Sprint weekend format

### DIFF
--- a/docs/home/guides/formula.md
+++ b/docs/home/guides/formula.md
@@ -42,6 +42,28 @@ Formula                                   -> Library Folder
 │       ├── 02x10 - Bahrein GP - Highlights.mkv
 ```
 
+For weekends with a Sprint race (this example also includes Ted's Notebook segments), the format looks like this:
+```
+Formula                                   -> Library Folder
+├── Season 2023                           -> Folder for each F1 Season
+│   ├── 04 - Azerbaijan GP                -> Folder for each Race in a season
+│       ├── 04x01 - Azerbaijan GP - Pre-Qualifying Buildup.mkv
+│       ├── 04x02 - Azerbaijan GP - Qualifying Session.mkv
+│       ├── 04x03 - Azerbaijan GP - Post-Qualifying Analysis.mkv
+│       ├── 04x04 - Azerbaijan GP - Ted's Qualifying Notebook.mkv
+│       ├── 04x05 - Azerbaijan GP - Pre-Sprint Shootout Buildup.mkv
+│       ├── 04x06 - Azerbaijan GP - Sprint Shootout Session.mkv
+│       ├── 04x07 - Azerbaijan GP - Post-Sprint Shootout Analysis.mkv
+│       ├── 04x08 - Azerbaijan GP - Pre-Sprint Race Buildup.mkv
+│       ├── 04x09 - Azerbaijan GP - Sprint Race Session.mkv
+│       ├── 04x10 - Azerbaijan GP - Post-Sprint Race Analysis.mkv
+│       ├── 04x11 - Azerbaijan GP - Ted's Sprint Notebook.mkv
+│       ├── 04x12 - Azerbaijan GP - Pre-Race Buildup.mkv
+│       ├── 04x13 - Azerbaijan GP - Race Session.mkv
+│       ├── 04x14 - Azerbaijan GP - Post-Race Analysis.mkv
+│       ├── 04x15 - Azerbaijan GP - Ted's Race Notebook.mkv
+```
+
 What matters for plex and for pmm.
 * The show name can be whatever you want it to be but the pre created metadata file will only work if you use just the year numbers.
 * The season folder can be called whatever you want as long as plex scans it in with the Season Number matching the race number.

--- a/modules/ergast.py
+++ b/modules/ergast.py
@@ -29,6 +29,7 @@ terms = {
     "pre": ["pre", "voorbeschouwing"],
     "post": ["post", "nabeschouwing"],
     "quali": ["quali", "kwalificatie"],
+    "shootout": ["shootout"],
     "notebook": ["notebook", "notitieboekje"],
     "preview": ["preview", "seizoensvoorbeschouwing"],
     "summary": ["summary", "samenvatting"],
@@ -41,9 +42,9 @@ names = {
         "Free Practice 1": "Vrije Training 1",
         "Free Practice 2": "Vrije Training 2",
         "Free Practice 3": "Vrije Training 3",
-        "Pre-Sprint Build-up": "Sprint Voorbeschouwing",
-        "Post-Sprint Analysis": "Sprint Nabeschouwing",
-        "Sprint Qualifying": "Sprint Kwalificatie",
+        "Pre-Sprint Race Build-up": "Sprint Race Voorbeschouwing",
+        "Post-Sprint Race Analysis": "Sprint Race Nabeschouwing",
+        "Sprint Race Session": "Sprint Race",
         "Ted's Sprint Notebook": "Ted's Sprint Notitieboekje",
         "Pre-Qualifying Build-up": "Kwalificatie Voorbeschouwing",
         "Post-Qualifying Analysis": "Kwalificatie Nabeschouwing",
@@ -55,6 +56,10 @@ names = {
         "Highlights": "Samenvatting",
         "Race Session": "Race",
         "Ted's Race Notebook": "Ted's Race Notitieboekje",
+        "Ted's Qualifying Notebook": "Ted's Kwalificatie Notitieboekje",
+        "Pre-Sprint Shootout Build-up": "Sprint Shootout Voorbeschouwing",
+        "Post-Sprint Shootout Analysis": "Sprint Shootout Nabeschouwing",
+        "Sprint Shootout Session": "Sprint Shootout",
     }
 }
 
@@ -91,20 +96,29 @@ class Race:
             output = "Free Practice 2"
         elif any([x in title for x in terms["free practice 3"]]):
             output = "Free Practice 3"
+        elif "shootout" in title:
+            if any([x in title for x in terms["pre"]]):
+                output = "Pre-Sprint Shootout Build-up"
+            elif any([x in title for x in terms["post"]]):
+                output = "Post-Sprint Shootout Analysis"
+            else:
+                output = "Sprint Shootout Session"
         elif "sprint" in title:
             if any([x in title for x in terms["pre"]]):
-                output = "Pre-Sprint Build-up"
+                output = "Pre-Sprint Race Build-up"
             elif any([x in title for x in terms["post"]]):
-                output = "Post-Sprint Analysis"
+                output = "Post-Sprint Race Analysis"
             elif any([x in title for x in terms["notebook"]]):
                 output = "Ted's Sprint Notebook"
             else:
-                output = "Sprint Qualifying"
+                output = "Sprint Race Session"
         elif any([x in title for x in terms["quali"]]):
             if any([x in title for x in terms["pre"]]):
                 output = "Pre-Qualifying Build-up"
-            elif any([x in title for x in terms["post"] + terms["notebook"]]):
+            elif any([x in title for x in terms["post"]]):
                 output = "Post-Qualifying Analysis"
+            elif any ([x in title for x in terms["notebook"]]):
+                output = "Ted's Qualifying Notebook"
             else:
                 output = "Qualifying Session"
         elif any([x in title for x in terms["preview"]]):


### PR DESCRIPTION
## Description

Added support for new F1 Sprint weekend format:
- Added support for Sprint Shootout
- Adjusted Sprint Qualifying to Sprint Race
- Adjusted translations accordingly Small adjustment:
- Separated Post-Qualifying Analysis and Ted's Qualifying Notebook

As F1 changed the Sprint weekend format since last weekend, the Shootout sessions weren't being picked up properly by PMM.
This fixes that. It remains compatible with "old sprint format" weekends for 2022, but the sessions will be named Sprint Race instead of Sprint Qualifying.


### Issues Fixed or Closed



## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

(little bit of both?)



## Checklist

- [x ] My code was submitted to the nightly branch of the repository.
