### PR TITLE
Dragonball fix

### DIFF
--- a/defaults/playlist.yml
+++ b/defaults/playlist.yml
@@ -124,6 +124,6 @@ playlists:
       key: dragonball
     template:
       - name: playlist
-        trakt_list: https://trakt.tv/users/qamazi/lists/dragon-ball-binged-out
+        trakt_list: https://trakt.tv/users/jamespgriffith/lists/everything-of-dragon-ball-ever-made-recommended-order
         summary_dragonball: Dragon Ball follows the adventures of an extraordinarily strong young boy named Goku as he searches for the seven dragon balls. These balls, when combined, can grant the owner any one wish he desires. Along the way he makes many new friends, and enemies, and he trains to become the strongest fighter in the world.
       - name: arr

--- a/defaults/playlist.yml
+++ b/defaults/playlist.yml
@@ -124,6 +124,6 @@ playlists:
       key: dragonball
     template:
       - name: playlist
-        trakt_list: https://trakt.tv/users/jamespgriffith/lists/everything-of-dragon-ball-ever-made-recommended-order
+        trakt_list: https://trakt.tv/users/grawler/lists/dragon-ball-in-order
         summary_dragonball: Dragon Ball follows the adventures of an extraordinarily strong young boy named Goku as he searches for the seven dragon balls. These balls, when combined, can grant the owner any one wish he desires. Along the way he makes many new friends, and enemies, and he trains to become the strongest fighter in the world.
       - name: arr

--- a/docs/defaults/playlist.md
+++ b/docs/defaults/playlist.md
@@ -94,7 +94,7 @@ The below Trakt lists are used to populate the playlists associated with the key
 trakt_list:
   arrow: https://trakt.tv/users/donxy/lists/arrowverse
   dcau: https://trakt.tv/users/donxy/lists/dc-animated-series-universe
-  dragonball: https://trakt.tv/users/qamazi/lists/dragon-ball-binged-out
+  dragonball: https://trakt.tv/users/jamespgriffith/lists/everything-of-dragon-ball-ever-made-recommended-order
   mcu: https://trakt.tv/users/donxy/lists/marvel-cinematic-universe
   pokemon: https://trakt.tv/users/munch54/lists/pokemon-watching-order
   startrek: https://trakt.tv/users/goodevilgenius/lists/star-trek-chronology

--- a/docs/defaults/playlist.md
+++ b/docs/defaults/playlist.md
@@ -94,7 +94,7 @@ The below Trakt lists are used to populate the playlists associated with the key
 trakt_list:
   arrow: https://trakt.tv/users/donxy/lists/arrowverse
   dcau: https://trakt.tv/users/donxy/lists/dc-animated-series-universe
-  dragonball: https://trakt.tv/users/jamespgriffith/lists/everything-of-dragon-ball-ever-made-recommended-order
+  dragonball: https://trakt.tv/users/grawler/lists/dragon-ball-in-order
   mcu: https://trakt.tv/users/donxy/lists/marvel-cinematic-universe
   pokemon: https://trakt.tv/users/munch54/lists/pokemon-watching-order
   startrek: https://trakt.tv/users/goodevilgenius/lists/star-trek-chronology


### PR DESCRIPTION
## Description
qamazi/lists/dragon-ball-binged-out is no longer available on trakt. I found this similar list which serves the same purpose.

```
1 | Trakt Error: List https://trakt.tv/users/qamazi/lists/dragon-ball-binged-out not found 
1 | Trakt Error: No valid Trakt Lists in ['https://trakt.tv/users/qamazi/lists/dragon-ball-binged-out']
```

### Issues Fixed or Closed

I did not file an issue for this fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
