### PR TITLE
Revert ratings YOLO change

### DIFF
--- a/defaults/overlays/ratings.yml
+++ b/defaults/overlays/ratings.yml
@@ -449,7 +449,7 @@ templates:
     run_definition: <<run_this>>
     ignore_blank_results: true
     overlay:
-      name: text(<<<<rating<<rating_num>>>>_rating<<rating<<rating_num>>_style>>>>)
+      name: text(<<rating<<rating_num>>>>_rating<<rating<<rating_num>>_style>>)
       file: <<rating<<rating_num>>_file>>
       url: <<rating<<rating_num>>_url>>
       git: <<rating<<rating_num>>_git>>


### PR DESCRIPTION
## Description

This reverts the YOLO change that was attempted to fix lettererboxd but broke mdblist and metacritic

### Issues Fixed or Closed

- Revert YOLO change that attempted to fix letterboxd

## Type of Change

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x ] My code was submitted to the nightly branch of the repository.
