### PR TITLE
Extract file name; re.match only checks the start

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from modules import builder, util
 from modules.library import Library
 from modules.util import Failed, ImageData
+from pathlib import Path
 from PIL import Image
 from plexapi import utils
 from plexapi.audio import Artist, Track, Album
@@ -1384,7 +1385,8 @@ class Plex(Library):
 
         if is_top_level and self.asset_folders and self.dimensional_asset_rename and (not poster or not background):
             for file in util.glob_filter(os.path.join(item_asset_directory, "*.*")):
-                if file.lower().endswith((".png", ".jpg", ".jpeg", "webp")) and not re.match(r"s\d+e\d+|season\d+", file.lower()):
+                p_file = Path(file).name
+                if p_file.lower().endswith((".png", ".jpg", ".jpeg", "webp")) and not re.match(r"s\d+e\d+|season\d+", p_file.lower()):
                     try:
                         with Image.open(file) as image:
                             _w, _h = image.size


### PR DESCRIPTION
## Description

re.match() only checks the beginning of the string, so something like:
```
'config/assets/3 1 2 Hours (2021) {imdb-tt13475394} {tmdb-847208}/Season01_background.jpg'
```
Wouldn't get stopped by the dimensional-asset-rename gate and would get renamed.

Now we grab just the filename [`Season01_background.jpg`] and do the re.match() on it.

I did this rather than use re.search() to guard against something like:
```
config/assets/That Movie About S01E04 of Friends (2021)/this-should-get-renamed.jpg
```

### Issues Fixed or Closed

- Fixes #1457

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
