### PR TITLE
only movies and shows have location

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -2853,7 +2853,11 @@ class CollectionBuilder:
             if "item_edition" in self.item_details and item.editionTitle != self.item_details["item_edition"]:
                 self.library.query_data(item.editEditionTitle, self.item_details["item_edition"])
                 logger.info(f"{item.title[:25]:<25} | Edition | {self.item_details['item_edition']}")
-            path = os.path.dirname(str(item.locations[0])) if self.library.is_movie else str(item.locations[0])
+            path = None
+            if self.library.is_movie:
+                path = os.path.dirname(str(item.locations[0]))
+            elif self.library.is_show:
+                str(item.locations[0])
             if self.library.Radarr and item.ratingKey in self.library.movie_rating_key_map:
                 path = path.replace(self.library.Radarr.plex_path, self.library.Radarr.radarr_path)
                 path = path[:-1] if path.endswith(('/', '\\')) else path


### PR DESCRIPTION
## Description

"path" is only used for Radarr and Sonarr, so if this isn't a movie os show library, theres no reason to try to get it.

### Issues Fixed or Closed

- Fixes #1480

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
