### PR TITLE
[Feature] Add support for mass updating backgrounds with text

### DIFF
--- a/docs/config/operations.md
+++ b/docs/config/operations.md
@@ -257,12 +257,14 @@ Updates every item's background to the chosen sites background. Will fallback to
 
 **Values:**
 
-| Value    | Description         |
-|:---------|:--------------------|
-| `tmdb`   | Use TMDb Background |
-| `plex`   | Use Plex Background |
-| `lock`   | Lock Background     |
-| `unlock` | Unlock Background   |
+| Value                  | Description                                     |
+|:-----------------------|:------------------------------------------------|
+| `tmdb`                 | Use TMDb Background                             |
+| `tmdb_text`            | Use TMDb Background with text                   |
+| `tmdb_text_no_episode` | Use TMDb Background with text but skip episodes |
+| `plex`                 | Use Plex Background                             |
+| `lock`                 | Lock Background                                 |
+| `unlock`               | Unlock Background                               |
 
 ## Mass IMDb Parental Labels
 

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -628,7 +628,7 @@ class Cache:
                     tmdb_dict["imdb_id"] = row["imdb_id"] if row["imdb_id"] else ""
                     tmdb_dict["poster_url"] = row["poster_url"] if row["poster_url"] else ""
                     tmdb_dict["backdrop_url"] = row["backdrop_url"] if row["backdrop_url"] else ""
-                    tmdb_dict["backdrops"] = row["backdrops"] if row["backdrops"] else ""
+                    tmdb_dict["backdrops"] = json.loads(row["backdrops"]) if row["backdrops"] else ""
                     tmdb_dict["vote_count"] = row["vote_count"] if row["vote_count"] else 0
                     tmdb_dict["vote_average"] = row["vote_average"] if row["vote_average"] else 0
                     tmdb_dict["language_iso"] = row["language_iso"] if row["language_iso"] else None
@@ -677,7 +677,7 @@ class Cache:
                     tmdb_dict["imdb_id"] = row["imdb_id"] if row["imdb_id"] else ""
                     tmdb_dict["poster_url"] = row["poster_url"] if row["poster_url"] else ""
                     tmdb_dict["backdrop_url"] = row["backdrop_url"] if row["backdrop_url"] else ""
-                    tmdb_dict["backdrops"] = row["backdrops"] if row["backdrops"] else ""
+                    tmdb_dict["backdrops"] = json.loads(row["backdrops"]) if row["backdrops"] else ""
                     tmdb_dict["vote_count"] = row["vote_count"] if row["vote_count"] else 0
                     tmdb_dict["vote_average"] = row["vote_average"] if row["vote_average"] else 0
                     tmdb_dict["language_iso"] = row["language_iso"] if row["language_iso"] else None

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -172,6 +172,7 @@ class Cache:
                     imdb_id TEXT,
                     poster_url TEXT,
                     backdrop_url TEXT,
+                    backdrops TEXT,
                     vote_count INTEGER,
                     vote_average REAL,
                     language_iso TEXT,
@@ -195,6 +196,7 @@ class Cache:
                     imdb_id TEXT,
                     poster_url TEXT,
                     backdrop_url TEXT,
+                    backdrops TEXT,
                     vote_count INTEGER,
                     vote_average REAL,
                     language_iso TEXT,
@@ -626,6 +628,7 @@ class Cache:
                     tmdb_dict["imdb_id"] = row["imdb_id"] if row["imdb_id"] else ""
                     tmdb_dict["poster_url"] = row["poster_url"] if row["poster_url"] else ""
                     tmdb_dict["backdrop_url"] = row["backdrop_url"] if row["backdrop_url"] else ""
+                    tmdb_dict["backdrops"] = row["backdrops"] if row["backdrops"] else ""
                     tmdb_dict["vote_count"] = row["vote_count"] if row["vote_count"] else 0
                     tmdb_dict["vote_average"] = row["vote_average"] if row["vote_average"] else 0
                     tmdb_dict["language_iso"] = row["language_iso"] if row["language_iso"] else None
@@ -647,11 +650,11 @@ class Cache:
             with closing(connection.cursor()) as cursor:
                 cursor.execute("INSERT OR IGNORE INTO tmdb_movie_data(tmdb_id) VALUES(?)", (obj.tmdb_id,))
                 update_sql = "UPDATE tmdb_movie_data SET title = ?, original_title = ?, studio = ?, overview = ?, tagline = ?, imdb_id = ?, " \
-                             "poster_url = ?, backdrop_url = ?, vote_count = ?, vote_average = ?, language_iso = ?, " \
+                             "poster_url = ?, backdrop_url = ?, backdrops = ?, vote_count = ?, vote_average = ?, language_iso = ?, " \
                              "language_name = ?, genres = ?, keywords = ?, release_date = ?, collection_id = ?, " \
                              "collection_name = ?, expiration_date = ? WHERE tmdb_id = ?"
                 cursor.execute(update_sql, (
-                    obj.title, obj.original_title, obj.studio, obj.overview, obj.tagline, obj.imdb_id, obj.poster_url, obj.backdrop_url,
+                    obj.title, obj.original_title, obj.studio, obj.overview, obj.tagline, obj.imdb_id, obj.poster_url, obj.backdrop_url, json.dumps(obj.backdrops),
                     obj.vote_count, obj.vote_average, obj.language_iso, obj.language_name, "|".join(obj.genres), "|".join(obj.keywords),
                     obj.release_date.strftime("%Y-%m-%d") if obj.release_date else None, obj.collection_id, obj.collection_name,
                     expiration_date.strftime("%Y-%m-%d"), obj.tmdb_id
@@ -674,6 +677,7 @@ class Cache:
                     tmdb_dict["imdb_id"] = row["imdb_id"] if row["imdb_id"] else ""
                     tmdb_dict["poster_url"] = row["poster_url"] if row["poster_url"] else ""
                     tmdb_dict["backdrop_url"] = row["backdrop_url"] if row["backdrop_url"] else ""
+                    tmdb_dict["backdrops"] = row["backdrops"] if row["backdrops"] else ""
                     tmdb_dict["vote_count"] = row["vote_count"] if row["vote_count"] else 0
                     tmdb_dict["vote_average"] = row["vote_average"] if row["vote_average"] else 0
                     tmdb_dict["language_iso"] = row["language_iso"] if row["language_iso"] else None
@@ -699,11 +703,11 @@ class Cache:
             with closing(connection.cursor()) as cursor:
                 cursor.execute("INSERT OR IGNORE INTO tmdb_show_data(tmdb_id) VALUES(?)", (obj.tmdb_id,))
                 update_sql = "UPDATE tmdb_show_data SET title = ?, original_title = ?, studio = ?, overview = ?, tagline = ?, imdb_id = ?, " \
-                             "poster_url = ?, backdrop_url = ?, vote_count = ?, vote_average = ?, language_iso = ?, " \
+                             "poster_url = ?, backdrop_url = ?, backdrops = ?, vote_count = ?, vote_average = ?, language_iso = ?, " \
                              "language_name = ?, genres = ?, keywords = ?, first_air_date = ?, last_air_date = ?, status = ?, " \
                              "type = ?, tvdb_id = ?, countries = ?, seasons = ?, expiration_date = ? WHERE tmdb_id = ?"
                 cursor.execute(update_sql, (
-                    obj.title, obj.original_title, obj.studio, obj.overview, obj.tagline, obj.imdb_id, obj.poster_url, obj.backdrop_url,
+                    obj.title, obj.original_title, obj.studio, obj.overview, obj.tagline, obj.imdb_id, obj.poster_url, obj.backdrop_url, json.dumps(obj.backdrops),
                     obj.vote_count, obj.vote_average, obj.language_iso, obj.language_name, "|".join(obj.genres), "|".join(obj.keywords),
                     obj.first_air_date.strftime("%Y-%m-%d") if obj.first_air_date else None,
                     obj.last_air_date.strftime("%Y-%m-%d") if obj.last_air_date else None,

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -136,7 +136,7 @@ class Operations:
                         sonarr_adds.append((tvdb_id, path))
 
                 tmdb_item = None
-                if any([o == "tmdb" for o in self.library.meta_operations]):
+                if any([o.startswith("tmdb") for o in self.library.meta_operations]):
                     tmdb_item = self.config.TMDb.get_item(item, tmdb_id, tvdb_id, imdb_id, is_movie=self.library.is_movie)
 
                 omdb_item = None
@@ -516,7 +516,7 @@ class Operations:
                         tmdb_backdrop_url = tmdb_item.backdrop_url
                         if(len(tmdb_item.backdrops) > 0):
                             tmdb_backdrop_url = tmdb_item.backdrops[0].url
-
+                    print(tmdb_item)
                     if self.library.mass_poster_update:
                         self.library.poster_update(item, new_poster, tmdb=tmdb_backdrop_url if tmdb_item else None)
                     if self.library.mass_background_update:

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -512,7 +512,7 @@ class Operations:
                         new_poster = None
                         new_background = None
                     
-                    if self.library.mass_background_update && self.library.mass_background_update in ["tmdb_text", "tmdb_text_no_episode"] && tmdb_item:
+                    if self.library.mass_background_update and self.library.mass_background_update in ["tmdb_text", "tmdb_text_no_episode"] and tmdb_item:
                         tmdb_backdrop_url = tmdb_item.backdrop_url
                         if(len(tmdb_item.backdrops) > 0):
                             tmdb_backdrop_url = tmdb_item.backdrops[0].url

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -511,10 +511,16 @@ class Operations:
                         name = None
                         new_poster = None
                         new_background = None
+                    
+                    if tmdb_item:
+                        tmdb_backdrop_url = tmdb_item.backdrop_url
+                        if(len(tmdb_item.backdrops) > 0):
+                            tmdb_backdrop_url = tmdb_item.backdrops[0].url
+
                     if self.library.mass_poster_update:
-                        self.library.poster_update(item, new_poster, tmdb=tmdb_item.poster_url if tmdb_item else None)
+                        self.library.poster_update(item, new_poster, tmdb=tmdb_backdrop_url if tmdb_item else None)
                     if self.library.mass_background_update:
-                        self.library.background_update(item, new_background, tmdb=tmdb_item.backdrop_url if tmdb_item else None)
+                        self.library.background_update(item, new_background, tmdb=tmdb_backdrop_url if tmdb_item else None)
 
                     if self.library.is_show:
                         real_show = None
@@ -536,25 +542,26 @@ class Operations:
                                 self.library.background_update(season, season_background, title=season.title if season else None)
 
                             tmdb_episodes = {}
-                            if season.seasonNumber in tmdb_seasons:
-                                for episode in tmdb_seasons[season.seasonNumber].episodes:
-                                    episode._partial = False
-                                    try:
-                                        tmdb_episodes[episode.episode_number] = episode
-                                    except NotFound:
-                                        logger.error(f"TMDb Error: An Episode of Season {season.seasonNumber} was Not Found")
+                            if self.library.mass_background_update != "tmdb_text_no_episode":
+                                if season.seasonNumber in tmdb_seasons:
+                                    for episode in tmdb_seasons[season.seasonNumber].episodes:
+                                        episode._partial = False
+                                        try:
+                                            tmdb_episodes[episode.episode_number] = episode
+                                        except NotFound:
+                                            logger.error(f"TMDb Error: An Episode of Season {season.seasonNumber} was Not Found")
 
-                            for episode in self.library.query(season.episodes):
-                                try:
-                                    episode_poster, episode_background, _, _ = self.library.find_item_assets(episode, item_asset_directory=item_dir, folder_name=name)
-                                except Failed:
-                                    episode_poster = None
-                                    episode_background = None
-                                tmdb_poster = tmdb_episodes[episode.episodeNumber].still_url if episode.episodeNumber in tmdb_episodes else None
-                                if self.library.mass_poster_update:
-                                    self.library.poster_update(episode, episode_poster, tmdb=tmdb_poster, title=episode.title if episode else None)
-                                if self.library.mass_background_update:
-                                    self.library.background_update(episode, episode_background, title=episode.title if episode else None)
+                                for episode in self.library.query(season.episodes):
+                                    try:
+                                        episode_poster, episode_background, _, _ = self.library.find_item_assets(episode, item_asset_directory=item_dir, folder_name=name)
+                                    except Failed:
+                                        episode_poster = None
+                                        episode_background = None
+                                    tmdb_poster = tmdb_episodes[episode.episodeNumber].still_url if episode.episodeNumber in tmdb_episodes else None
+                                    if self.library.mass_poster_update:
+                                        self.library.poster_update(episode, episode_poster, tmdb=tmdb_poster, title=episode.title if episode else None)
+                                    if self.library.mass_background_update:
+                                        self.library.background_update(episode, episode_background, title=episode.title if episode else None)
 
                 episode_ops = [
                     self.library.mass_episode_audience_rating_update, self.library.mass_episode_critic_rating_update,

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -512,7 +512,7 @@ class Operations:
                         new_poster = None
                         new_background = None
                     
-                    if tmdb_item:
+                    if self.library.mass_background_update && self.library.mass_background_update in ["tmdb_text", "tmdb_text_no_episode"] && tmdb_item:
                         tmdb_backdrop_url = tmdb_item.backdrop_url
                         if(len(tmdb_item.backdrops) > 0):
                             tmdb_backdrop_url = tmdb_item.backdrops[0].url

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -516,7 +516,7 @@ class Operations:
                         tmdb_backdrop_url = tmdb_item.backdrop_url
                         if(len(tmdb_item.backdrops) > 0):
                             tmdb_backdrop_url = tmdb_item.backdrops[0].url
-                    print(tmdb_item)
+
                     if self.library.mass_poster_update:
                         self.library.poster_update(item, new_poster, tmdb=tmdb_backdrop_url if tmdb_item else None)
                     if self.library.mass_background_update:

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1169,7 +1169,7 @@ class Plex(Library):
             image_url = False if image else True
             image = image.location if image else None
             if not image:
-                if attr == "tmdb" and tmdb:
+                if attr.startswith("tmdb") and tmdb:
                     image = tmdb
                     location = "TMDb"
                 if not image:

--- a/modules/tmdb.py
+++ b/modules/tmdb.py
@@ -99,6 +99,7 @@ class TMDBObj:
         self.imdb_id = data["imdb_id"] if isinstance(data, dict) else data.imdb_id
         self.poster_url = data["poster_url"] if isinstance(data, dict) else data.poster_url
         self.backdrop_url = data["backdrop_url"] if isinstance(data, dict) else data.backdrop_url
+        self.backdrops = data["backdrops"] if isinstance(data, dict) else data.backdrops
         self.vote_count = data["vote_count"] if isinstance(data, dict) else data.vote_count
         self.vote_average = data["vote_average"] if isinstance(data, dict) else data.vote_average
         self.language_iso = data["language_iso"] if isinstance(data, dict) else data.original_language.iso_639_1 if data.original_language else None
@@ -130,7 +131,7 @@ class TMDbMovie(TMDBObj):
     @retry(stop_max_attempt_number=6, wait_fixed=10000, retry_on_exception=util.retry_if_not_failed)
     def load_movie(self):
         try:
-            return self._tmdb.TMDb.movie(self.tmdb_id, partial="external_ids,keywords")
+            return self._tmdb.TMDb.movie(self.tmdb_id, partial="external_ids,keywords,backdrops") 
         except NotFound:
             raise Failed(f"TMDb Error: No Movie found for TMDb ID {self.tmdb_id}")
 


### PR DESCRIPTION
## Description

I have a case where I want all my backgrounds to have text for the recommended rows (see https://github.com/sarendsen/replex the hero items use backgrounds)

This MR add this functionality and also adds an option to skip show episodes while batch updating. Im not sure about the yaml config though. Id rather have nested option like this

```yaml
mass_update_background:
 type: tmdb
 text: true
 skip_episodes: true
 skip_seasons: true 
```
But I implemented it as flat for now to keep in check with the rest (see operations.md). 
Let me know what ya think

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
