### PR TITLE
Bump required Python version to 3.8

### DIFF
--- a/docs/home/guides/local.md
+++ b/docs/home/guides/local.md
@@ -8,7 +8,7 @@ This article will walk you through getting Plex-Meta-Manager [PMM] set up and ru
 4. Setting up a metadata file and creating a couple sample collections.
 
 The specific steps you will be taking:
-1. Verify that Python 3.7 or better is installed and install it if not
+1. Verify that Python 3.8 or better is installed and install it if not
 2. Verify that the Git tools are installed and install them if not
 3. Use `git` to retrieve the code
 4. Install requirements [extra bits of code required for PMM]
@@ -79,7 +79,7 @@ First let's check if it's installed already [type this into your terminal]:
 python3 --version
 ```
 
-If this doesn't return `3.7.0` or higher, you'll need to get Python 3 installed.
+If this doesn't return `3.8.0` or higher, you'll need to get Python 3 installed.
 
 ````{tab} Linux
 Describing a python install for any arbitrary linux is out of scope here, but if you're using Ubuntu, [this](https://techviewleo.com/how-to-install-python-on-ubuntu-linux/) might be useful.

--- a/docs/home/installation.md
+++ b/docs/home/installation.md
@@ -30,7 +30,7 @@ If you are using unRAID, Kubernetes, QNAP, or Synology refer to the following ba
 
 ## Local Install Overview
 
-Plex Meta Manager is compatible with Python 3.7 through 3.11. Later versions may function but are untested.
+Plex Meta Manager is compatible with Python 3.8 through 3.11. Later versions may function but are untested.
 
 These are high-level steps which assume the user has knowledge of python and pip, and the general ability to troubleshoot issues. For a detailed step-by-step walkthrough, refer to the [Local Walkthrough](guides/local) guide.
 

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -4,8 +4,8 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from modules.logs import MyLogger
 
-if sys.version_info[0] != 3 or sys.version_info[1] < 7:
-    print("Version Error: Version: %s.%s.%s incompatible please use Python 3.7+" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+if sys.version_info[0] != 3 or sys.version_info[1] < 8:
+    print("Version Error: Version: %s.%s.%s incompatible please use Python 3.8+" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
     sys.exit(0)
 
 try:


### PR DESCRIPTION
python-dotenv 1.0.0 drops support for 3.7

## Type of Change

Please delete options that are not relevant.

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
