### PR TITLE
Languages added to overlays

### DIFF
--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -35,13 +35,9 @@ external_templates:
       pmm_<<key>>:
         conditions:
           - file.exists: false
-            file_<<key>>.exists: false
             url.exists: false
-            url_<<key>>.exists: false
             git.exists: false
-            git_<<key>>.exists: false
             repo.exists: false
-            repo_<<key>>.exists: false
             value: flag/<<final_style>>/<<country_<<key>>>>
     default:
       style: round
@@ -440,9 +436,13 @@ overlays:
     variables: {key: fi, text: FI, weight: 280}
     template: [name: flags, name: standard]
 
-  filipino:
+  tagalog:
     variables: {key: tl, text: FL, weight: 270, country: ph}
     template: [name: flags, name: standard]
+    
+  filipino:
+    variables: {key: fil, text: FIL, weight: 265, country: ph}
+    template: [name: flags, name: standard]  
 
   galician:
     variables: {key: gl, text: GL, weight: 260, country: es}
@@ -561,5 +561,23 @@ overlays:
     template: [name: flags, name: standard]
 
   inuktitut:
-    variables: {key: iu, text: IK, weight: 5, country: ca}
+    variables: {key: iu, text: IK, weight: 7, country: ca}
     template: [name: flags, name: standard]
+    
+  romany:
+    variables: {key: rom, text: ROM, weight: 6, country: ro}
+    template: [name: flags, name: standard]    
+    
+  amharic:
+    variables: {key: am, text: AM, weight: 5, country: et}
+    template: [name: flags, name: standard]    
+  
+  sundanese:
+    variables: {key: su, text: SU, weight: 4, country: id}
+    template: [name: flags, name: standard]    
+
+  zulu:
+    variables: {key: zu, text: ZU, weight: 3, country: za}
+    template: [name: flags, name: standard]    
+
+    

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -46,7 +46,8 @@ Supported library types: Movie & Show
 | Estonian                 | `et` | `300`  | `ee`         |  &#10060;   |
 | Basque                   | `eu` | `290`  | `es`         |  &#10060;   |
 | Finnish                  | `fi` | `280`  | `fi`         |  &#10060;   |
-| Filipino                 | `tl` | `270`  | `ph`         |  &#10060;   |
+| Tagalog                  | `tl` | `270`  | `ph`         |  &#10060;   |
+| Filipino                 | `fil`| `265`  | `ph`         |  &#10060;   |
 | Galician                 | `gl` | `260`  | `es`         |  &#10060;   |
 | Hebrew                   | `he` | `250`  | `il`         |  &#10060;   |
 | Croatian                 | `hr` | `240`  | `hr`         |  &#10060;   |
@@ -77,6 +78,10 @@ Supported library types: Movie & Show
 | Wolof                    | `wo` | `10`   | `sn`         |  &#10060;   |
 | Mayan                    | `myn`| `8`    | `mx`         |  &#10060;   |
 | Inuktitut                | `iu` | `5`    | `ca`         |  &#10060;   |
+| Romany                   | `rom`| `6`    | `ro`         |  &#10060;   |
+| Sundanese                | `su` | `4`    | `id`         |  &#10060;   |
+| Amharic                  | `am` | `5`    | `et`         |  &#10060;   |
+| Zulu                     | `zu` | `3`    | `za`         |  &#10060;   |
 
 ### Square Style
 

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -77,10 +77,10 @@ Supported library types: Movie & Show
 | Vietnamese               | `vi` | `15`   | `vn`         |  &#10060;   |
 | Wolof                    | `wo` | `10`   | `sn`         |  &#10060;   |
 | Mayan                    | `myn`| `8`    | `mx`         |  &#10060;   |
-| Inuktitut                | `iu` | `5`    | `ca`         |  &#10060;   |
+| Inuktitut                | `iu` | `7`    | `ca`         |  &#10060;   |
 | Romany                   | `rom`| `6`    | `ro`         |  &#10060;   |
-| Sundanese                | `su` | `4`    | `id`         |  &#10060;   |
 | Amharic                  | `am` | `5`    | `et`         |  &#10060;   |
+| Sundanese                | `su` | `4`    | `id`         |  &#10060;   |
 | Zulu                     | `zu` | `3`    | `za`         |  &#10060;   |
 
 ### Square Style


### PR DESCRIPTION
## Description

Added filipino, amharic, sundanese, zulu, and romany to defaults/overlays/languages.yml
Renamedthe existing 'filipino' 'tagalog'
Updated docs/overlays/languages.md to reflect the changes.

### Issues Fixed or Closed

- Fixes #(issue)

Request raised here:
https://discord.com/channels/822460010649878528/1140059838555095182

## Type of Change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
