### PR TITLE
Added Luxembourgish and Mossi as languages; changed MA to MYN

### DIFF
--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -579,6 +579,12 @@ overlays:
 
   zulu:
     variables: {key: zu, text: ZU, weight: 3, country: za}
-    template: [name: flags, name: standard]    
+    template: [name: flags, name: standard]
 
-    
+  luxembourgish:
+    variables: {key: lb, text: LB, weight: 3, country: lu}
+    template: [name: flags, name: standard]  
+
+  mossi:
+    variables: {key: mos, text: MOS, weight: 1, country: bf}
+    template: [name: flags, name: standard]

--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -558,7 +558,7 @@ overlays:
     template: [name: flags, name: standard]
 
   mayan:
-    variables: {key: myn, text: MA, weight: 8, country: mx}
+    variables: {key: myn, text: MYN, weight: 8, country: mx, width: 230}
     template: [name: flags, name: standard]
 
   inuktitut:
@@ -582,9 +582,9 @@ overlays:
     template: [name: flags, name: standard]
 
   luxembourgish:
-    variables: {key: lb, text: LB, weight: 3, country: lu}
+    variables: {key: lb, text: LB, weight: 2, country: lu}
     template: [name: flags, name: standard]  
 
   mossi:
-    variables: {key: mos, text: MOS, weight: 1, country: bf}
+    variables: {key: mos, text: MOS, weight: 1, country: bf, width: 230}
     template: [name: flags, name: standard]

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -82,6 +82,8 @@ Supported library types: Movie & Show
 | Amharic                  | `am`  | `5`    | `et`         |  &#10060;   |
 | Sundanese                | `su`  | `4`    | `id`         |  &#10060;   |
 | Zulu                     | `zu`  | `3`    | `za`         |  &#10060;   |
+| Luxembourgish            | `lb`  | `2`    | `lu`         |  &#10060;   |
+| Mossi                    | `mos` | `1`    | `bf`         |  &#10060;   |
 
 ### Square Style
 


### PR DESCRIPTION
## Description

Added Luxembourgish and Mossi to defaults/overlays/languages yml and md
Changed MY to MYN for Mayan, and added width: 230 


## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.