### PR TITLE
Show a specific log message for timeout

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -443,6 +443,8 @@ class Plex(Library):
             os.environ["PLEXAPI_PLEXAPI_TIMEOUT"] = str(self.timeout)
         except Unauthorized:
             raise Failed("Plex Error: Plex token is invalid")
+        except requests.exceptions.ConnectTimeout:
+            raise Failed(f"Plex Error: Plex did not respond within the {self.timeout}-second timeout.")
         except ValueError as e:
             raise Failed(f"Plex Error: {e}")
         except (requests.exceptions.ConnectionError, ParseError):


### PR DESCRIPTION
## Description

Timeout errors are not uncommon, and identifying them as "Plex URL Invalid" in the log is often not helpful as it points people toward the URL when it's probably fine in many timeout cases.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
