### PR TITLE
letterboxd films have a new url structure

### DIFF
--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -110,7 +110,7 @@ class Letterboxd:
                         tmdb_id, expired = self.config.Cache.query_letterboxd_map(letterboxd_id)
                     if not tmdb_id or expired is not False:
                         try:
-                            tmdb_id = self._tmdb(f"{base_url}{slug}", language)
+                            tmdb_id = self._tmdb(f"{base_url}/film/{slug}", language)
                         except Failed as e:
                             logger.error(e)
                             continue


### PR DESCRIPTION
## Description

Recent changes on the letterboxd site appears to have broken the letterboxd integration.

### Issues Fixed or Closed

Discovered this bug with this config:

```
templates:
  charts:
    url_poster: <<poster>>
    sort_title: ++<<collection_name>>
    collection_order: custom
    delete_not_scheduled: true
    run_again: true
    visible_home: true
    visible_shared: true
    sync_mode: sync
collections:
  Letterboxd Popular This Week:
    template: {name: charts, poster: https://i.imgur.com/6hY2Khd.png}
    letterboxd_list:
      url: https://letterboxd.com/films/popular/this/week/
      limit: 100
    sort_title: '!!!00 Letterboxd Popular This Week'
    radarr_add_missing: true
    radarr_quality: "Best - 4K"
    item_radarr_tag: pmm, letterboxd-popular-week
    summary: 'The most popular films on Letterboxd this week. https://letterboxd.com/films/popular/this/week/'
    visible_home: true
    visible_shared: true
```

```
Critical Error
Unknown Error: HTTPSConnectionPool(host='letterboxd.comoppenheimer-2023', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fdf1ce63750>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```


## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
