### PR TITLE
Make it more explicit that these template variables apply only to the defaults

### DIFF
--- a/docs/defaults/collection_variables.md
+++ b/docs/defaults/collection_variables.md
@@ -1,5 +1,7 @@
 # Shared Collection Template Variables
 
+IMPORTANT: The variables in this table are only valid in the context of the [`PMM default metadata files`](guide).
+
 There are some `template_variables` that all the PMM Defaults except [`franchise`](movie/franchise) and [`collectionless`](both/collectionless) can use to manipulate the file from the default settings which are provided. 
 
 Note that the `template_variables:` section only needs to be used if you do want to actually change how the defaults work. Any value not specified is its default value if it has one if not it's just ignored.

--- a/docs/defaults/overlay_variables.md
+++ b/docs/defaults/overlay_variables.md
@@ -1,5 +1,7 @@
 # Shared Overlay Template Variables
 
+IMPORTANT: The variables in this table are only valid in the context of the [`PMM default metadata files`](guide).
+
 There are some `template_variables` that all the PMM Defaults except `franchise` can use to manipulate the file from the default settings which are provided. 
 
 Note that the `template_variables:` section only needs to be used if you do want to actually change how the defaults work. Any value not specified is its default value if it has one if not it's just ignored.


### PR DESCRIPTION
## Description

A search of the docs may point a reader directly to this list, so they won't have the context of having gotten here from a default page.

## Type of Change

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
