### PR TITLE
Allow any char betwixt dv and hdr10

### DIFF
--- a/defaults/overlays/resolution.yml
+++ b/defaults/overlays/resolution.yml
@@ -208,7 +208,7 @@ templates:
           - alt: plus
             value: '(?i)\bhdr10(\+|p(lus)?\b)'
           - alt: dvhdr
-            value: '(?i)\bdv(\.hdr10?\b)'
+            value: '(?i)\bdv(.hdr10?\b)'
     optional:
       - all
       - use_<<key>>


### PR DESCRIPTION
## Description

Regex was only finding `dv.hdr10`

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
