### PR TITLE
Nightly

### DIFF
--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -588,3 +588,7 @@ overlays:
   mossi:
     variables: {key: mos, text: MOS, weight: 1, country: bf, width: 230}
     template: [name: flags, name: standard]
+
+  lingala:
+    variables: {key: ln, text: LN, weight: 11, country: cd}
+    template: [name: flags, name: standard]

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -75,6 +75,7 @@ Supported library types: Movie & Show
 | Tamil                    | `ta`  | `30`   | `in`         |  &#10060;   |
 | Urdu                     | `ur`  | `20`   | `pk`         |  &#10060;   |
 | Vietnamese               | `vi`  | `15`   | `vn`         |  &#10060;   |
+| Lingala                  | `ln`  | `11`   | `cd`         |  &#10060;   |
 | Wolof                    | `wo`  | `10`   | `sn`         |  &#10060;   |
 | Mayan                    | `myn` | `8`    | `mx`         |  &#10060;   |
 | Inuktitut                | `iu`  | `7`    | `ca`         |  &#10060;   |


### PR DESCRIPTION
## Description

Lingala (ln) mapped to Democratic Republic of the Congo (cd) in the Overlays/Media/Audio Subtitle Language Flags yml and wiki page

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
