### PR TITLE
Don't tack empty args onto the query

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -570,7 +570,11 @@ class Plex(Library):
 
     @retry(stop_max_attempt_number=6, wait_fixed=10000, retry_on_exception=util.retry_if_not_plex)
     def fetchItems(self, uri_args):
-        return self.Plex.fetchItems(f"/library/sections/{self.Plex.key}/all{uri_args}")
+        query_path = f"/library/sections/{self.Plex.key}/all{uri_args}"
+        if uri_args is None:
+            query_path = f"/library/sections/{self.Plex.key}/all"
+            
+        return self.Plex.fetchItems(query_path)
 
     def get_all(self, builder_level=None, load=False):
         if load and builder_level in [None, "show", "artist", "movie"]:


### PR DESCRIPTION
## Description

This prevents this error:
```
Unknown Error: (404) not_found; (redacted)/library/sections/2/allNone <html><head><title>Not Found</title></head><body><h1>404 Not Found</h1></body></html
```
Which is caused by blindly appending some arguments onto the end of the URL.  If the arguments are an empty object, you get: `sections/2/allNone` which is clearly incorrect.

It's not the solution to whatever's sending the empty object, but it prevents hitting a tree if it happens.

EDIT: the empty object is coming from `builder.py:1122`:
```
                check_url = self.smart_url if self.smart_url else self.smart_label_url
```
both `self.smart_url` and `self.smart_label_url` are None, so the var ends up as `None`

and a couple lines later:
```
               self.beginning_count = len(self.library.fetchItems(check_url))
 ```
Which fails with the error, but only on 1.32.7.

The same code, running against `1.32.6.7557` and making the same request to `/library/sections/2/allNone` does not fail with a 404, so apparently 1.32.7 is less forgiving.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
