### PR TITLE
add a bit about a Python 3.12 issue

### DIFF
--- a/docs/home/guides/local.md
+++ b/docs/home/guides/local.md
@@ -333,6 +333,16 @@ source pmm-venv/bin/activate
 ```
 ````
 
+### If you are running Python 3.12
+
+with the virtual environment activated, type this into your terminal:
+
+```
+pip install setuptools
+```
+
+This will update a piece of the Python infrastructure and prevent an error later.
+
 ### Installing requirements
 
 Plex-Meta-Manager, like every other Python script, depends on support libraries that manage things like connections to Plex, or getting things from the internet, or writing files and so on.

--- a/docs/home/guides/wt/wt-03-lib-err-and-fix.md
+++ b/docs/home/guides/wt/wt-03-lib-err-and-fix.md
@@ -24,6 +24,22 @@ I’ve removed some of the lines for space, but have left the important bits:
 
 You can see there that PMM found its config file, was able to connect to TMDb, was able to connect to Plex, and then failed trying to read the “Movies-NOSUCHLIBRARY" library, which of course doesn’t exist.
 
+<details>
+  <summary>I got a ModuleError instead</summary>
+
+  If you see this error instead:
+  ```
+  ModuleNotFoundError: No module named 'pkg_resources'
+  ```
+  Chances are you're using Python 3.12 and skipped the bit above about Python 3.12.
+
+  Type this into your term minal
+  ```
+  pip install setuptools
+  ```
+  Then try the run command from above again.
+</details>
+
 Open the config file again and change "Movies-NOSUCHLIBRARY" to reflect *your own* Movie library in Plex.
 
 Say my Movies library is called “All The Movies", so mine looks like this:


### PR DESCRIPTION
## Description

Python 3.12 now fails with an error when you run the first time with a config file.  This is due to a broken setuptools install, apparently.

## Type of Change

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
