### PR TITLE
Fix episodes typo in example yaml

### DIFF
--- a/docs/metadata/builders/plex.md
+++ b/docs/metadata/builders/plex.md
@@ -428,7 +428,7 @@ Here's an example of an episode collection using `plex_search`.
      collection_order: custom
      builder_level: episode
      plex_search:
-       type: episodes
+       type: episode
        sort_by: audience_rating.desc
        limit: 100
        all:


### PR DESCRIPTION
## Description

I was trying to use this example and getting errors, before I noticed elsewhere in the docs it gives type as episode, not episodes

### Issues Fixed or Closed

## Type of Change

Please delete options that are not relevant.

- [x ] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [x ] My code was submitted to the nightly branch of the repository.
