### PR TITLE
Add configuration options to skip missing report generation

### DIFF
--- a/defaults/templates.yml
+++ b/defaults/templates.yml
@@ -106,6 +106,8 @@ templates:
       - limit
       - name_mapping
       - delete_collections_named
+      - skip_missing_report
+      - skip_<<key>>_missing_report
     run_definition:
       - <<use_<<key>>>>
       - <<allowed_libraries>>
@@ -132,6 +134,9 @@ templates:
     file_background: <<file_background_<<key>>>>
     minimum_items: <<minimum_items_<<key>>>>
     delete_collections_named: <<delete_collections_named>>
+    skip_missing_report:
+      - <<skip_missing_report>>
+      - <<skip_<<key>>_missing_report>>
 
   trakt:
     optional:


### PR DESCRIPTION
## Description

Showing missing movies and shows from a collection can be useful, but can also take a lot of time when those collections are large (ex: streaming collections contain 100s of movies and shows, but I would assume most people don't want to see every piece of media missing from a streaming platform).

To solve this problem, `skip_missing_report` and `skip_<<key>>_missing_report` template variables have been added to allow users to disable the generation of the missing report for specific collections.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
