### PR TITLE
alter_collection & sync_collection batch edits

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -2515,8 +2515,6 @@ class CollectionBuilder:
                 amount_unchanged += 1
             else:
                 items_added.append(item)
-                if not self.playlist:
-                    self.library.alter_collection(item, name, smart_label_collection=self.smart_label_collection)
                 amount_added += 1
                 if self.details["changes_webhooks"]:
                     self.notification_additions.append(util.item_set(item, self.library.get_id_from_maps(item.ratingKey)))
@@ -2526,6 +2524,8 @@ class CollectionBuilder:
             logger.info(f"Playlist: {self.name} created")
         elif self.playlist and items_added:
             self.obj.addItems(items_added)
+        elif items_added:
+        	self.library.alter_collection(items_added, name, smart_label_collection=self.smart_label_collection)
         if self.do_report and items_added:
             self.library.add_additions(self.name, [(i.title, self.library.get_id_from_maps(i.ratingKey)) for i in items_added], self.library.is_movie)
         logger.exorcise()
@@ -2548,14 +2548,14 @@ class CollectionBuilder:
                 number_text = f"{i}/{total}"
                 logger.info(f"{number_text:>{spacing}} | {self.name} {self.Type} | - | {util.item_title(item)}")
                 items_removed.append(item)
-                if not self.playlist:
-                    self.library.alter_collection(item, self.name, smart_label_collection=self.smart_label_collection, add=False)
                 amount_removed += 1
                 if self.details["changes_webhooks"]:
                     self.notification_removals.append(util.item_set(item, self.library.get_id_from_maps(item.ratingKey)))
             if self.playlist and items_removed:
                 self.library._reload(self.obj)
                 self.obj.removeItems(items_removed)
+            elif items_removed:
+            	self.library.alter_collection(items_removed, self.name, smart_label_collection=self.smart_label_collection, add=False)
             if self.do_report and items_removed:
                 self.library.add_removed(self.name, [(i.title, self.library.get_id_from_maps(i.ratingKey)) for i in items_removed], self.library.is_movie)
             logger.info("")

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -880,24 +880,19 @@ class Plex(Library):
                  r._data.attrib.get('promotedToOwnHome'), r._data.attrib.get('promotedToSharedHome'))
                 for r in self.Plex.fetchItems(f"/hubs/sections/{self.Plex.key}/manage")]
 
-    def alter_collection(self, item, collection, smart_label_collection=False, add=True):
+    def alter_collection(self, items, collection, smart_label_collection=False, add=True):
+        self.Plex.batchMultiEdits(items)
         if smart_label_collection:
-            self.query_data(item.addLabel if add else item.removeLabel, collection)
+            if add: 
+            	self.Plex.addLabel(collection) 
+            else: 
+            	self.Plex.removeLabel(collection)
         else:
-            locked = True
-            item = self.reload(item)
-            if self.agent in ["tv.plex.agents.movie", "tv.plex.agents.series"]:
-                field = next((f for f in item.fields if f.name == "collection"), None)
-                locked = field is not None
-            try:
-                self.query_collection(item, collection, locked=locked, add=add)
-            except TypeError:
-                logger.info(item.collections)
-                for col in item.collections:
-                    logger.info(col.id)
-                    logger.info(col.key)
-                    logger.info(col.tag)
-                raise
+            if add:
+                self.Plex.addCollection(collection)
+            else:
+            	self.Plex.removeCollection(collection)
+        self.Plex.saveMultiEdits()
 
     def move_item(self, collection, item, after=None):
         key = f"{collection.key}/items/{item}/move"


### PR DESCRIPTION
## Description

Changed `add_to_collection` and `sync_collection` methods in `builder.py` to pass the parameters required for batchEdits to `alter_collection` in `plex.py`. `plex.py` has also been updated to implement the [batchEdit](https://github.com/pkkid/python-plexapi/pull/1184) functionality from PythonPlexAPI.

With the above changes I noticed dramatic improvements in the time taken to add 45 items to a movie collection which also had a custom sort. `19.1nightly27` took 4:07 seconds, versus 31 seconds using the code from this PR.

Note: PythonPlexAPI is currently broken for adding collections, and [this PR](https://github.com/pkkid/python-plexapi/pull/1287) will need to be released in order for my implementation to succeed.

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
