### PR TITLE
[Draft] Add Optional Score Filtering to AniList UserList Builder

### DIFF
--- a/modules/anilist.py
+++ b/modules/anilist.py
@@ -36,7 +36,7 @@ media_source = {
     "original": "ORIGINAL", "manga": "MANGA", "light_novel": "LIGHT_NOVEL", "visual_novel": "VISUAL_NOVEL",
     "video_game": "VIDEO_GAME", "other": "OTHER", "novel": "NOVEL", "doujinshi": "DOUJINSHI", "anime": "ANIME"
 }
-score_format = {"point_100": "POINT_100", "point_10": "POINT_10", "point_10_decimal": "POINT_10_decimal", "point_5": "POINT_5", "point_3": "POINT_3"}
+score_format = {"point_100": "POINT_100", "point_10_decimal": "POINT_10_DECIMAL", "point_10": "POINT_10", "point_5": "POINT_5", "point_3": "POINT_3"}
 base_url = "https://graphql.anilist.co"
 tag_query = "query{MediaTagCollection {name, category}}"
 genre_query = "query{GenreCollection}"


### PR DESCRIPTION
## Description

Add Score Filtering functionality to the AniList Builder for UserList Queries, which allows setting a specific `score_format` for the query to return, a `score` value used for comparison, and a `modifier` field. AniList allows different score formats to be used on a per account basis, so this will allow the query to transform the score based on the user's choice.

Since the GraphQL query does not support score filtering by default, I appended the functionality within the `_userlist` function within `anilist.py`. Because I have done `None` checks for specific arguments, this should be a non-breaking change and will not affect current configurations.

Main reason for adding this feature is so I can auto filter based on my own Completed List and only put shows that have been rated higher than a certain score within the Collection. Because this was a quick code change done late at night, I haven't tested it and have marked the PR as a Draft. I will continue to work on this to fully test the functionality and document the changes. I did also want to get feedback on whether this feature would be in the scope of the project.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
- [ ] I have tested the code to ensure functionality with no regression.
- [ ] I have documented the functionality on the corresponding/relevant files.
