### PR TITLE
batchMultiEdits for Library Operations

### DIFF
--- a/modules/operations.py
+++ b/modules/operations.py
@@ -384,6 +384,8 @@ class Operations:
                                 new_genres = mal_item.genres
                             else:
                                 raise Failed
+                            if new_genres == ["\\N"]:
+                                new_genres = []
                             if not new_genres:
                                 logger.info(f"No Genres Found")
                         if self.library.genre_mapper or self.library.mass_genre_update in ["lock", "unlock"]:


### PR DESCRIPTION
## Description

Added batchMultiEdits to the below Library Operations:
- mass_audience_rating_update
- mass_critic_rating_update
- mass_user_rating_update
- mass_episode_audience_rating_update
- mass_episode_critic_rating_update
- mass_episode_user_rating_update
- mass_content_rating_update
- content_rating_mapper
- mass_genre_update
- genre_mapper
- mass_studio_update
- mass_imdb_parental_labels

Also fixed an issue where IMDb genres were being returned "\\N" and that was being applied to library items.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
