### PR TITLE
Update util.py to minimize word wrap on config.yml rewrite

### DIFF
--- a/modules/util.py
+++ b/modules/util.py
@@ -985,6 +985,7 @@ class YAML:
         self.path = path
         self.input_data = input_data
         self.yaml = ruamel.yaml.YAML()
+        self.yaml.width = 100000
         self.yaml.indent(mapping=2, sequence=2)
         try:
             if input_data:


### PR DESCRIPTION
## Description

Update util.py to minimize word wrap on config.yml rewrite. When tokens/words exceed a certain length, and when PMM rewrites the config.yml file, it pushes some lines to the next line thus exposing tokens and keys both into the meta.log and in the terminal output window

Repro steps:
1 - remove something in the config.yml file that pmm will auto populate (for example the 4 run_order lines)
2 - ensure that you have lines within your MAL section or likely anywhere in the vicinity of being 700+ characters long
3 - run pmm which will re-add the 4 lines and rewrite your config.yml and it will push those long lines down by one
4 - see how those token as and keys which are usually really long in length are pushed to the next line and not redacted in the logs thus exposing those secrets both in the terminal and in the meta.log

### Issues Fixed or Closed

- Fixes https://discord.com/channels/822460010649878528/1179484396613550081

## Type of Change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change (non-code changes affecting only the wiki)
- [ ] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [ x] My code was submitted to the nightly branch of the repository.
