### PR TITLE
-Adding matching pattern for EAC3 to plus_atmos in audio_codec.yml

### DIFF
--- a/defaults/overlays/audio_codec.yml
+++ b/defaults/overlays/audio_codec.yml
@@ -66,7 +66,7 @@ templates:
           - key: dtsx
             value: '(?i)\bdts[ ._-]?x\b'
           - key: plus_atmos
-            value: '(?i)^(?=.*\b(dd[p+])|(dolby digital plus)\b)(?=.*\batmos(\b|\d))'
+            value: '(?i)^(?=.*\b(dd[p+]|dolby[ ._-]digital[ ._-]plus|e[ ._-]?ac3\b))(?=.*\batmos(\b|\d))'
           - key: dolby_atmos
             value: '(?i)\batmos(\b|\d)'
           - key: truehd
@@ -80,7 +80,7 @@ templates:
           - key: hra
             value: '(?i)\bdts[ ._-]?(hd[ ._-])?(hr|hra|hi|ra)(\b|\d)'
           - key: plus
-            value: '(?i)\b(dd[p+])|(dolby digital plus)|(e[ ._-]?ac3)\b'
+            value: '(?i)\b(dd[p+])|(dolby[ ._-]digital[ ._-]plus)|(e[ ._-]?ac3)\b'
           - key: dtses
             value: '(?i)\bdts[ ._-]?es(\b|\d)'
           - key: dts


### PR DESCRIPTION
## Description

-Adding matching pattern for EAC3 to plus_atmos in audio_codec.yml
-"Dolby Digital Plus" was not matching for plus_atmos, so fixing also, as well as permitting ._- characters

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
