### PR TITLE
Commit c8910efc7db0da8d9ab4909614fdcfd9316ab583 regressed EAC3.Atmos Matching

### DIFF
--- a/defaults/overlays/audio_codec.yml
+++ b/defaults/overlays/audio_codec.yml
@@ -66,7 +66,7 @@ templates:
           - key: dtsx
             value: '(?i)\bdts[ ._-]?x\b'
           - key: plus_atmos
-            value: '(?i)^(?=.*\b(dd[p+])|(dolby[ ._-]digital[ ._-]plus)|(e[ ._-]?ac3)\b)(?=.*\batmos(\b|\d))'
+            value: '(?i)^(?=.*\b((dd[p+])|(dolby[ ._-]digital[ ._-]plus)|(e[ ._-]?ac3)\b))(?=.*\batmos(\b|\d))'
           - key: dolby_atmos
             value: '(?i)\batmos(\b|\d)'
           - key: truehd

--- a/defaults/overlays/resolution.yml
+++ b/defaults/overlays/resolution.yml
@@ -208,7 +208,7 @@ templates:
           - alt: plus
             value: '(?i)\bhdr10(\+|p(lus)?\b)'
           - alt: dvhdr
-            value: '(?i)\bdv(.hdr10?\b)'
+            value: '(?i)\bdv((\.hdr10?\b)|(\.hdr10(\+|p(lus)?\b)))'
     optional:
       - all
       - use_<<key>>


### PR DESCRIPTION
1. Commit c8910efc7db0da8d9ab4909614fdcfd9316ab583 regressed EAC3.Atmos Matching
2. Allow DV/HDR10Plus hybrid matching.

## Description

1. Commit c8910efc7db0da8d9ab4909614fdcfd9316ab583 regressed EAC3.Atmos Matching

Example of string that was previously matched:

Movie.2023.2160p.WEB-DL.HEVC.DV.HDR10Plus.EAC3.Atmos.7.1.mkv

2. Allow DV/HDR10Plus hybrid matching.
Example:

Movie.2023.2160p.WEB-DL.HEVC.DV.HDR10Plus.EAC3.Atmos.7.1.mkv matches the HDR10+ Overlay even though Dolby Vision is higher weighed.

### Issues Fixed or Closed

- Fixes c8910efc7db0da8d9ab4909614fdcfd9316ab583

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
