### PR TITLE
Fixing regression in DV HDR10 hybrid matching

### DIFF
--- a/defaults/overlays/resolution.yml
+++ b/defaults/overlays/resolution.yml
@@ -208,7 +208,7 @@ templates:
           - alt: plus
             value: '(?i)\bhdr10(\+|p(lus)?\b)'
           - alt: dvhdr
-            value: '(?i)\bdv((\.hdr10?\b)|(\.hdr10(\+|p(lus)?\b)))'
+            value: '(?i)\bdv((.hdr10?\b)|(.hdr10(\+|p(lus)?\b)))'
     optional:
       - all
       - use_<<key>>


### PR DESCRIPTION
## Description

Fixing regression in DV HDR10 hybrid matching in change made for matching HDR10Plus (any character separating DV & HDR10 apart from a . would not match, example below).

### Issues Fixed or Closed

- Fixes #(issue)

Movie.2021.2160p.WEB-DL.h265.DV.HDR10.EAC3.Atmos.5.1.mkv would match 
Movie.2021.2160p.WEB-DL.h265.[DV HDR10].EAC3.Atmos.5.1.mkv would not match

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
