### PR TITLE
JsonUrl builder

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1,7 +1,7 @@
 import os, re, time
 from arrapi import ArrException
 from datetime import datetime
-from modules import anidb, anilist, flixpatrol, icheckmovies, imdb, letterboxd, mal, plex, radarr, reciperr, sonarr, tautulli, tmdb, trakt, tvdb, mdblist, util
+from modules import anidb, anilist, flixpatrol, icheckmovies, imdb, letterboxd, mal, plex, radarr, reciperr, jsonurl, sonarr, tautulli, tmdb, trakt, tvdb, mdblist, util
 from modules.util import Failed, FilterFailed, NonExisting, NotScheduled, NotScheduledRange, Deleted
 from modules.overlay import Overlay
 from modules.poster import PMMImage
@@ -16,7 +16,7 @@ logger = util.logger
 advance_new_agent = ["item_metadata_language", "item_use_original_title"]
 advance_show = ["item_episode_sorting", "item_keep_episodes", "item_delete_episodes", "item_season_display", "item_episode_sorting"]
 all_builders = anidb.builders + anilist.builders + flixpatrol.builders + icheckmovies.builders + imdb.builders + \
-               letterboxd.builders + mal.builders + plex.builders + reciperr.builders + tautulli.builders + \
+               letterboxd.builders + mal.builders + plex.builders + reciperr.builders + jsonurl.builders + tautulli.builders + \
                tmdb.builders + trakt.builders + tvdb.builders + mdblist.builders + radarr.builders + sonarr.builders
 show_only_builders = [
     "tmdb_network", "tmdb_show", "tmdb_show_details", "tvdb_show", "tvdb_show_details", "tmdb_airing_today",
@@ -153,7 +153,7 @@ custom_sort_builders = [
     "tautulli_popular", "tautulli_watched", "mdblist_list", "letterboxd_list", "icheckmovies_list", "flixpatrol_top",
     "anilist_top_rated", "anilist_popular", "anilist_trending", "anilist_search", "anilist_userlist",
     "mal_all", "mal_airing", "mal_upcoming", "mal_tv", "mal_movie", "mal_ova", "mal_special", "mal_search",
-    "mal_popular", "mal_favorite", "mal_suggested", "mal_userlist", "mal_season", "mal_genre", "mal_studio"
+    "mal_popular", "mal_favorite", "mal_suggested", "mal_userlist", "mal_season", "mal_genre", "mal_studio", "json_url"
 ]
 episode_parts_only = ["plex_pilots"]
 overlay_only = ["overlay", "suppress_overlays"]
@@ -1041,6 +1041,8 @@ class CollectionBuilder:
                     self._plex(method_name, method_data)
                 elif method_name in reciperr.builders:
                     self._reciperr(method_name, method_data)
+                elif method_name in jsonurl.builders:
+                    self._jsonurl(method_name, method_data)
                 elif method_name in tautulli.builders:
                     self._tautulli(method_name, method_data)
                 elif method_name in tmdb.builders:
@@ -1841,6 +1843,11 @@ class CollectionBuilder:
         elif method_name == "stevenlu_popular":
             self.builders.append((method_name, util.parse(self.Type, method_name, method_data, "bool")))
 
+    def _jsonurl(self, method_name, method_data):
+        if method_name == "json_url":
+            for json_url in util.get_list(method_data):
+                self.builders.append((method_name, json_url))
+
     def _mdblist(self, method_name, method_data):
         for mdb_dict in self.config.Mdblist.validate_mdblist_lists(self.Type, method_data):
             self.builders.append((method_name, mdb_dict))
@@ -2088,6 +2095,8 @@ class CollectionBuilder:
             ids = self.config.Letterboxd.get_tmdb_ids(method, value, self.language)
         elif "reciperr" in method or "stevenlu" in method:
             ids = self.config.Reciperr.get_imdb_ids(method, value)
+        elif "json_url" in method:
+            ids = self.config.JsonUrl.get_rating_keys(method, value)
         elif "mdblist" in method:
             ids = self.config.Mdblist.get_tmdb_ids(method, value, self.library.is_movie if not self.playlist else None)
         elif "tmdb" in method:

--- a/modules/config.py
+++ b/modules/config.py
@@ -21,6 +21,7 @@ from modules.plex import Plex
 from modules.radarr import Radarr
 from modules.sonarr import Sonarr
 from modules.reciperr import Reciperr
+from modules.jsonurl import JsonUrl
 from modules.mdblist import Mdblist
 from modules.tautulli import Tautulli
 from modules.tmdb import TMDb
@@ -705,6 +706,7 @@ class ConfigFile:
             self.ICheckMovies = ICheckMovies(self)
             self.Letterboxd = Letterboxd(self)
             self.Reciperr = Reciperr(self)
+            self.JsonUrl = JsonUrl(self)
             self.Ergast = Ergast(self)
 
             logger.separator()

--- a/modules/jsonurl.py
+++ b/modules/jsonurl.py
@@ -1,0 +1,58 @@
+from modules import util
+from modules.util import Failed
+from plexapi.exceptions import BadRequest
+from plexapi.video import Movie, Show
+
+logger = util.logger
+
+builders = ["json_url"]
+
+class JsonUrl:
+    def __init__(self, config):
+        self.config = config
+        #self.library = library
+
+    def _request(self, url, name="JsonUrl"):
+        response = self.config.get(url)
+        if response.status_code >= 400:
+            raise Failed(f"{name} Error: JSON not found at {url}")
+        return response.json()
+
+    def validate_list(self, data):
+        valid_lists = []
+        for json_list in util.get_list(data, split=False):
+            if "rating_key" not in self._request(json_list).data[0]:
+                raise Failed(f"JSON URL Error: JSON structure is invalid at {json_list}")
+            valid_lists.append(json_list)
+        return valid_lists
+
+    def get_imdb_ids(self, method, data):
+        name = "StevenLu" if method == "stevenlu_popular" else "Reciperr"
+        logger.info(f"Processing {name} Movies")
+        if method == "reciperr_list":
+            ids = [(i["imdb_id"], "imdb") for i in self._request(data)]
+        elif method == "stevenlu_popular":
+            ids = [(i["imdb_id"], "imdb") for i in self._request(stevenlu_url, name="StevenLu")]
+        else:
+            raise Failed(f"Config Error: Method {method} not supported")
+        if not ids:
+            raise Failed(f"{name} Error: No IDs found.")
+        return ids
+
+    def get_rating_keys(self, method, data):
+        logger.info(f"Processing JsonUrl found at: {data}")
+
+        response = self._request(data)
+
+        items = None
+        for entry in response["data"]:
+            if "rating_key" in entry:
+                items = response["data"]
+                break
+        if items is None:
+            raise Failed("JsonUrl Error: No Items found in the response")
+
+        rating_keys = []
+        for item in items:
+            rating_keys.append((item["rating_key"], "ratingKey"))
+        return rating_keys


### PR DESCRIPTION
## Description

# New builder: JsonUrl
I had a pretty specific use case here. I wanted to be able to use Tautulli's non api endpoint to generate a list of movies from the media_info endpoint. The non api version is a little more powerful and lets you set multiple sort orders. This JsonUrl module will let you process a list of rating keys from a URL.
The module is working but the checking it does isn't as advanced as the checking performed by the Tautulli module. A further enhancement would be to use the same method that Tautulli does to check each rating key.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
