### PR TITLE
fixed typo in config sample

### DIFF
--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -69,7 +69,7 @@ settings:
   ignore_ids:
   ignore_imdb_ids:
   item_refresh_delay: 0
-  playlist_sync_to_user: all
+  playlist_sync_to_users: all
   playlist_exclude_users:
   playlist_report: false
   verify_ssl: true

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -113,7 +113,7 @@ radarr:                          # Can be individually specified per library as 
   token: ################################
   add_missing: false
   add_existing: false
-  root_folder_path: S:/Movies
+  root_folder_path: "S:/Movies"
   monitor: true
   availability: announced
   quality_profile: HD-1080p


### PR DESCRIPTION
playlist_sync_to_user: all
should be
playlist_sync_to_users: all

Because I got the warning:
`Playlist Warning: sync_to_users attribute not found defaulting to playlist_sync_to_users: all`

## Description

Please include a summary of the changes.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change (non-code changes affecting only the wiki)
- [ ] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
