### PR TITLE
Small playlist refactor. Fix for #1877, #1880 and #1882

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1004,6 +1004,21 @@ class Plex(Library):
         except NotFound:
             raise Failed(f"Plex Error: Playlist {title} not found")
 
+    def get_playlist_from_users(self, title):
+        def scan_user(server, title):
+            try:
+                for playlist in server.playlists():
+                    if isinstance(playlist, Playlist):
+                        if playlist.title == title:
+                            return playlist
+            except requests.exceptions.ConnectionError:
+                pass
+        for user in self.users:
+            playlist_obj = scan_user(self.PlexServer.switchUser(user), title)
+            if playlist_obj:
+                return playlist_obj
+        raise Failed(f"Plex Error: Playlist {title} not found")
+
     def get_collection(self, data, force_search=False, debug=True):
         if isinstance(data, Collection):
             return data

--- a/plex_meta_manager.py
+++ b/plex_meta_manager.py
@@ -1046,6 +1046,9 @@ def run_playlists(config):
 
                 builder.send_notifications(playlist=True)
 
+                if valid:
+                    builder.exclude_admin_from_playlist()
+
             except Deleted as e:
                 logger.info(e)
                 status[mapping_name]["status"] = "Deleted"


### PR DESCRIPTION
## Description

While using Plex Meta Manager, I stumbled upon some odd behavior with the playlist functionality. This got me digging into the code to make a few improvements.

The key changes in this pull request are:

1. **Explicit User Specification**: The modifications allow end users to explicitly specify their Plex admin user in the `sync_to_users` and `exclude_users` parameters. This provides more control and flexibility to the users.

2. **Improved Playlist Fetching**: I reworked the `delete_playlist` section. If the admin doesn't have the playlist, it now fetches it from regular users. This was necessary because my changes allow the end user to create playlists for specific users, excluding the admin. Without this change, the code would just look at the admin and stop if the playlist wasn't found. This required the addition of a new function, `get_playlist_from_users()`, in `plex.py`.

3. **Fixed Unexpected Playlist Deletion**: I fixed an issue where playlists were unexpectedly being deleted from the admin account. The problem was in the `delete` function. It was deleting the object before checking if it was a playlist. I rearranged the code to check for the playlist before. If `self.obj` is not a playlist object, the code now executes the `elif self.obj:` section. I also added more logic under `if self.playlist:` to handle different scenarios for the admin and other users.

These changes are all about making playlist management in Plex Meta Manager smoother and more user-friendly.

For more detailed information, please refer to the linked issues associated with this pull request. I welcome any feedback or suggestions for further improvements.

### Issues Fixed or Closed

- Fixes #1877
- Fixes #1880
- Fixes #1882

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
