### PR TITLE
Update resolution.yml

### DIFF
--- a/defaults/overlays/resolution.yml
+++ b/defaults/overlays/resolution.yml
@@ -74,6 +74,9 @@ external_templates:
         conditions:
           - type: resolution_dovetail
             value: <<horizontal_offset+30>>
+          - type: edition_dovetail
+            horizontal_align: center
+            value: <<horizontal_offset+30>>
       final_vertical_offset:
         default: <<vertical_offset>>
         conditions:


### PR DESCRIPTION
## Description

Fixes an issue where the text on the pngs become offset incorrectly when setting the overlay on the bottom or top center.
Pictures attached of the issue

## Type of Change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ x] My code was submitted to the nightly branch of the repository.


![Plex_25OmHHCyFF](https://github.com/meisnate12/Plex-Meta-Manager/assets/33303104/179d187d-f6a2-4eee-958b-a9584046ff95)
![Plex_7zDPu78QgM](https://github.com/meisnate12/Plex-Meta-Manager/assets/33303104/7447c623-2418-40a4-a9f2-1d35e7f8b474)
