### PR TITLE
add Discovery UK, Nat Geo Wild, and YouTube Premium to their respective networks

### DIFF
--- a/defaults/overlays/network.yml
+++ b/defaults/overlays/network.yml
@@ -343,7 +343,7 @@ overlays:
 
   Discovery:
     variables: { weight: 10}
-    template: [name: standard, {name: networks, search: [Discovery, Discovery Health Channel, Discovery Channel, Discovery Home & Health Brasil, Discovery Family, Discovery Real Time, Discovery Asia, Discovery Home & Health, Discovery Life, Discovery World, Discovery Science]}]
+    template: [name: standard, {name: networks, search: [Discovery, Discovery Health Channel, Discovery Channel, Discovery Home & Health Brasil, Discovery Family, Discovery Real Time, Discovery Asia, Discovery Home & Health, Discovery Life, Discovery World, Discovery Science, Discovery Channel (UK)]}]
 
   Discovery Kids:
     variables: { weight: 10}
@@ -659,7 +659,7 @@ overlays:
 
   National Geographic:
     variables: { weight: 10}
-    template: [name: standard, {name: networks, search: [National Geographic, National Geographic Channel, National Geographic Brasil, National Geographic Latinoamerica, National Geographic India]}]
+    template: [name: standard, {name: networks, search: [National Geographic, National Geographic Channel, National Geographic Brasil, National Geographic Latinoamerica, National Geographic India, Nat Geo Wild]}]
 
   NBC:
     variables: { weight: 10}
@@ -1111,7 +1111,7 @@ overlays:
 
   YouTube:
     variables: { weight: 10}
-    template: [name: standard, name: networks]
+    template: [name: standard, {name: networks, search: [YouTube, YouTube Premium]}]
 
   ZDF:
     variables: { weight: 10}

--- a/defaults/show/network.yml
+++ b/defaults/show/network.yml
@@ -357,6 +357,7 @@ dynamic_collections:
         - Discovery Life
         - Discovery World
         - Discovery Science
+        - Discovery Channel (UK)
       Disney Channel:
         - Toon Disney
         - Playhouse Disney
@@ -434,6 +435,7 @@ dynamic_collections:
         - National Geographic Brasil
         - National Geographic Latinoamerica
         - National Geographic India
+        - Nat Geo Wild
       NBC:
         - CNBC
         - MSNBC
@@ -506,3 +508,5 @@ dynamic_collections:
         - Viceland
         - Vice TV
         - Vice.com
+      YouTube:
+        - YouTube Premium


### PR DESCRIPTION
## Description

Adding in Discovery Channel (UK), Nat Geo Wild, and YouTube Premium to their respective parent networks.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
