### PR TITLE
build requirements + system packages before copying app code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BRANCH_NAME=master
 ENV BRANCH_NAME ${BRANCH_NAME}
 ENV TINI_VERSION v0.19.0
 ENV PMM_DOCKER True
-COPY . /
+COPY requirements.txt requirements.txt
 RUN echo "**** install system packages ****" \
  && apt-get update \
  && apt-get upgrade -y --no-install-recommends \
@@ -19,5 +19,6 @@ RUN echo "**** install system packages ****" \
  && apt-get -f install \
  && apt-get autoclean \
  && rm -rf /requirements.txt /tmp/* /var/tmp/* /var/lib/apt/lists/*
+ COPY . /
 VOLUME /config
 ENTRYPOINT ["/tini", "-s", "python3", "plex_meta_manager.py", "--"]


### PR DESCRIPTION
## Description

While I was working on #1913 I noticed that the Dockerfile busted the cache on every code change because the code is copied, then the requirements are built and the system packages are installed.

A common technique is to copy the requirements files and install system packages (less likely to change) before application code (most likely to change). 

Ideally, the system packages would be installed by themselves first, then the requirements, then copy the app code. Even with this improvement, a change in either python dependencies or system packages would cause *both* dependencies and packages to be re-installed.. but everything seems to be quite tangled and this change here will be far be the greatest decrease in average build time via the structure of the Dockerfile.

TLDR - This decreased my build time from a few minutes per build to a few seconds by taking advantage of Docker Layer Caching

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
