### PR TITLE
add `mapping_sort`

### DIFF
--- a/docs/files/templates.md
+++ b/docs/files/templates.md
@@ -210,7 +210,7 @@ In addition, templates also have a few special attributes that they can use:
 
     <div id="move-prefix" />The `move_prefix` attribute can be used to specify a list or comma-separated string of 
     prefixes to move to the end of the collection/playlist name for sorting. This changes the template variables
-    `collection_sort` and `playlist_sort`.
+    `collection_sort`, `playlist_sort`, and `mapping_sort`.
 
     ???+ example "Example"
 
@@ -241,6 +241,7 @@ Every template also has access to these template variables:
 * Either `<<collection_name>>`, `<<playlist_name>>`, or `<<overlay_name>>` which is the name of the definition.
 * `<<mapping_name>>` is the original mapping name for the definition in the YAML file.
 * Either `<<collection_sort>>` or `<<playlist_sort>>` which is the name of the definition after `move_prefix` is applied.
+* `<<mapping_sort>>` which is the original mapping name for the definition after `move_prefix` is applied.
 * `<<library_type>>` which is the library type (`movie`, `show`, `artist`, `video`).
 * `<<library_name>>` which is the name of the library.
 * All template variables can append `_encoded` to the variable name to use a URL encode version of the variable. ex. 

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -447,9 +447,9 @@ class DataFile:
                             prefix = template["move_collection_prefix"]
                         if prefix:
                             for op in util.get_list(prefix):
-                                if variables[name_var].startswith(f"{op} "):
+                                if not sort_name and variables[name_var].startswith(f"{op} "):
                                     sort_name = f"{variables[name_var][len(op):].strip()}, {op}"
-                                if variables["mapping_name"].startswith(f"{op} "):
+                                if not sort_mapping and variables["mapping_name"].startswith(f"{op} "):
                                     sort_mapping = f"{variables['mapping_name'][len(op):].strip()}, {op}"
                                 break if sort_name and sort_mapping
                         else:

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -436,6 +436,7 @@ class DataFile:
                                 optional.append(f"{final_key}_encoded")
 
                     sort_name = None
+                    sort_mapping = None
                     if "move_prefix" in template or "move_collection_prefix" in template:
                         prefix = None
                         if "move_prefix" in template:
@@ -448,10 +449,13 @@ class DataFile:
                             for op in util.get_list(prefix):
                                 if variables[name_var].startswith(f"{op} "):
                                     sort_name = f"{variables[name_var][len(op):].strip()}, {op}"
-                                    break
+                                if variables["mapping_name"].startswith(f"{op} "):
+                                    sort_mapping = f"{variables['mapping_name'][len(op):].strip()}, {op}"
+                                break if sort_name and sort_mapping
                         else:
                             raise Failed(f"{self.data_type} Error: template sub-attribute move_prefix is blank")
                     variables[f"{self.data_type.lower()}_sort"] = sort_name if sort_name else variables[name_var]
+                    variables["mapping_sort"] = sort_mapping if sort_mapping else variables["mapping_name"]
 
                     for key, value in variables.copy().items():
                         if "<<" in key and ">>" in key:


### PR DESCRIPTION
## Description

This simply adds a `mapping_sort`, like `collection_sort`.

I want the different variable because of the way my config is using the mapping name as the sort of "canonical" collection name, and the collection name itself gets a prefix as a sort of "display name".

See https://github.com/ymendel/PMM-config/blob/92a057219365bc12f5f33b2bda165928398b3ad6/templates/collections.yml#L22

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
