### PR TITLE
Fixes #1939 - Show metadata backup fails due to shows not having `item.editionTitle`

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1526,12 +1526,15 @@ class Plex(Library):
             if year_titles.count(f"{item.title} ({item.year})") > 1:
                 match_dict["title"] = item.title
                 match_dict["year"] = item.year
-                if item.editionTitle:
-                    map_key = f"{item.title} ({item.year}) [{item.editionTitle}]"
-                    match_dict["edition"] = item.editionTitle
-                else:
-                    map_key = f"{item.title} ({item.year})"
-                    match_dict["blank_edition"] = True
+                map_key = f"{item.title} ({item.year})"
+                match_dict["blank_edition"] = True
+                try:
+                    if item.editionTitle:
+                        map_key = f"{item.title} ({item.year}) [{item.editionTitle}]"
+                        match_dict["edition"] = item.editionTitle
+                        match_dict["blank_edition"] = False
+                except:
+                    dont_care = True
             else:
                 map_key = f"{item.title} ({item.year})"
                 match_dict["title"] = item.title


### PR DESCRIPTION
Fixes #1939