### PR TITLE
fix "mapping_sort"

### DIFF
--- a/modules/meta.py
+++ b/modules/meta.py
@@ -455,7 +455,8 @@ class DataFile:
                                     sort_name = f"{variables[name_var][len(op):].strip()}, {op}"
                                 if not sort_mapping and variables["mapping_name"].startswith(f"{op} "):
                                     sort_mapping = f"{variables['mapping_name'][len(op):].strip()}, {op}"
-                                break if sort_name and sort_mapping
+                                if sort_name and sort_mapping:
+                                  break
                         else:
                             raise Failed(f"{self.data_type} Error: template sub-attribute move_prefix is blank")
                     variables[f"{self.data_type.lower()}_sort"] = sort_name if sort_name else variables[name_var]


### PR DESCRIPTION
## Description

Looks like I messed up a Python syntax thing.

Follow-up to https://github.com/meisnate12/Plex-Meta-Manager/pull/1930

### Issues Fixed or Closed

- Fixes #(issue)

I got this after I pulled nightly:

```
Traceback (most recent call last):
  File "//plex_meta_manager.py", line 172, in <module>
    from modules.builder import CollectionBuilder
  File "/modules/builder.py", line 5, in <module>
    from modules import anidb, anilist, icheckmovies, imdb, letterboxd, mal, mojo, plex, radarr, reciperr, sonarr, tautulli, tmdb, trakt, tvdb, mdblist, util
  File "/modules/plex.py", line 4, in <module>
    from modules.library import Library
  File "/modules/library.py", line 4, in <module>
    from modules.meta import MetadataFile, OverlayFile
  File "/modules/meta.py", line 458
    break if sort_name and sort_mapping
          ^^
SyntaxError: invalid syntax
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
