### PR TITLE
Update overview.md to refect docker 25.05 changes

### DIFF
--- a/docs/pmm/install/overview.md
+++ b/docs/pmm/install/overview.md
@@ -93,7 +93,6 @@ docker run -it -v "X:\Media\Plex Meta Manager\config:/config:rw" meisnate12/plex
 This is an example docker-compose which will have to be edited to suit your environment before use, but illustrates the minimal contents:
 
 ```yaml
-version: "2.1"
 services:
   plex-meta-manager:
     image: meisnate12/plex-meta-manager
@@ -120,7 +119,6 @@ This example docker-compose would create a container that runs immediately upon 
 As with the one above, this is an example docker-compose which will have to be edited to suit your environment before use.
 
 ```yaml
-version: "2.1"
 services:
   plex-meta-manager:
     image: meisnate12/plex-meta-manager


### PR DESCRIPTION
Starting with latest docker version 25.05 the ``version`` line is now obsolete in docker compose files

## Description

Remove the version line in docker compose

### Issues Fixed or Closed

- Fixes a warning docker will throw about version being depreciated in latest docker version

## Type of Change

- [x ] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [ x] My code was submitted to the nightly branch of the repository.
