### PR TITLE
Small regex fix for DV HDR (resolution overlay), after DV HDR and DV HDR10+ got split

### DIFF
--- a/defaults/overlays/resolution.yml
+++ b/defaults/overlays/resolution.yml
@@ -217,7 +217,7 @@ templates:
           - alt: plus
             value: '(?i)\bhdr10(\+|p(lus)?\b)'
           - alt: dvhdr
-            value: '(?i)\bdv((.hdr10?\b)'
+            value: '(?i)\bdv(.hdr10?\b)'
           - alt: dvhdrplus
             value: '(?i)\bdv.HDR10(\+|P(lus)?\b)'
     optional:


### PR DESCRIPTION
## Description

Fix for:
Overlay Error: Regular Expression Invalid: (?i)\bdv((.hdr10?\b)

Removed the extra **(** that was left over of the old OR group with DV HDR10+

### Issues Fixed or Closed

- Related to PR #1947

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] My code was submitted to the nightly branch of the repository.
