### PR TITLE
use radarr monitor values in config.yml

### DIFF
--- a/docs/config/radarr.md
+++ b/docs/config/radarr.md
@@ -29,7 +29,7 @@ radarr:
   upgrade_existing: false
   monitor_existing: false
   root_folder_path: S:/Movies
-  monitor: false
+  monitor: none
   availability: announced
   quality_profile: HD-1080p
   tag: pmm
@@ -48,7 +48,7 @@ radarr:
 | `monitor_existing` | Ensures all existing movies in collections match your monitor setting.<br>Use the `radarr_monitor_existing` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to match the monitor setting per collection.<br>**boolean:** true or false                        | false       |  :fontawesome-solid-circle-xmark:{ .red }  |
 | `ignore_cache`     | Ignores PMM's cache when adding items to Radarr.<br>Use the `radarr_ignore_cache` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to ignore per collection.<br>**boolean:** true or false                                                                     | false       |  :fontawesome-solid-circle-xmark:{ .red }  |
 | `root_folder_path` | Default Root Folder Path to use when adding new movies.<br>Use the `radarr_folder` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to set the Root Folder per collection.                                                                                     | N/A         | :fontawesome-solid-circle-check:{ .green } |
-| `monitor`          | Monitor the movie when adding new movies.<br>Use the `radarr_monitor` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to set the Monitor value per collection.<br>**Options:** `true`, `false`                                                                | true        |  :fontawesome-solid-circle-xmark:{ .red }  |
+| `monitor`          | Monitor the movie when adding new movies.<br>Use the `radarr_monitor` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to set the Monitor value per collection.<br>**Options:** `movie`, `collection`, or `none`                                               | true        |  :fontawesome-solid-circle-xmark:{ .red }  |
 | `availability`     | Default Minimum Availability to use when adding new movies.<br>Use the `radarr_availability` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to set the Availability per collection.<br>**Options:** `announced`, `cinemas`, `released`, `db`                 | `announced` | :fontawesome-solid-circle-check:{ .green } |
 | `quality_profile`  | Default Quality Profile to use when adding new movies.<br>Use the `radarr_quality` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to set the Quality Profile per collection.                                                                                 | N/A         | :fontawesome-solid-circle-check:{ .green } |
 | `tag`              | Default list or comma-separated string of tags to use when adding new movies.<br>Use the `radarr_tag` [Radarr Setting](../files/arr.md#radarr-definition-settings) in the collection definition to set the Tags per collection.                                                                         | ` `         |  :fontawesome-solid-circle-xmark:{ .red }  |
@@ -80,7 +80,7 @@ radarr:
   upgrade_existing: #
   monitor_existing: #
   root_folder_path: /movies
-  monitor: false
+  monitor: none
   availability: announced
   quality_profile: HD-1080p
   tag: 
@@ -146,7 +146,7 @@ radarr:
   upgrade_existing: false
   monitor_existing: false
   root_folder_path: /movies
-  monitor: false
+  monitor: none
   availability: released
   tag:
   search: false

--- a/modules/config.py
+++ b/modules/config.py
@@ -245,8 +245,6 @@ class ConfigFile:
                     if "save_missing" in self.data["libraries"][library]["settings"]:
                         self.data["libraries"][library]["settings"]["save_report"] = self.data["libraries"][library]["settings"].pop("save_missing")
                 if "radarr" in self.data["libraries"][library] and self.data["libraries"][library]["radarr"]:
-                    if "monitor" in self.data["libraries"][library]["radarr"] and isinstance(self.data["libraries"][library]["radarr"]["monitor"], bool):
-                        self.data["libraries"][library]["radarr"]["monitor"] = True if self.data["libraries"][library]["radarr"]["monitor"] else False
                     if "add" in self.data["libraries"][library]["radarr"]:
                         self.data["libraries"][library]["radarr"]["add_missing"] = self.data["libraries"][library]["radarr"].pop("add")
                 if "sonarr" in self.data["libraries"][library] and self.data["libraries"][library]["sonarr"]:
@@ -308,8 +306,6 @@ class ConfigFile:
         if "gotify" in self.data:                      self.data["gotify"] = self.data.pop("gotify")
         if "anidb" in self.data:                       self.data["anidb"] = self.data.pop("anidb")
         if "radarr" in self.data:
-            if "monitor" in self.data["radarr"] and isinstance(self.data["radarr"]["monitor"], bool):
-                self.data["radarr"]["monitor"] = True if self.data["radarr"]["monitor"] else False
             temp = self.data.pop("radarr")
             if temp and "add" in temp:
                 temp["add_missing"] = temp.pop("add")
@@ -772,7 +768,7 @@ class ConfigFile:
                 "monitor_existing": check_for_attribute(self.data, "monitor_existing", parent="radarr", var_type="bool", default=False),
                 "ignore_cache": check_for_attribute(self.data, "ignore_cache", parent="radarr", var_type="bool", default=False),
                 "root_folder_path": check_for_attribute(self.data, "root_folder_path", parent="radarr", default_is_none=True),
-                "monitor": check_for_attribute(self.data, "monitor", parent="radarr", var_type="bool", default=True),
+                "monitor": check_for_attribute(self.data, "monitor", parent="radarr", test_list=radarr.monitor_descriptions, default="movie"),
                 "availability": check_for_attribute(self.data, "availability", parent="radarr", test_list=radarr.availability_descriptions, default="announced"),
                 "quality_profile": check_for_attribute(self.data, "quality_profile", parent="radarr", default_is_none=True),
                 "tag": check_for_attribute(self.data, "tag", parent="radarr", var_type="lower_list", default_is_none=True),
@@ -1196,7 +1192,7 @@ class ConfigFile:
                             "monitor_existing": check_for_attribute(lib, "monitor_existing", parent="radarr", var_type="bool", default=self.general["radarr"]["monitor_existing"], save=False),
                             "ignore_cache": check_for_attribute(lib, "ignore_cache", parent="radarr", var_type="bool", default=self.general["radarr"]["ignore_cache"], save=False),
                             "root_folder_path": check_for_attribute(lib, "root_folder_path", parent="radarr", default=self.general["radarr"]["root_folder_path"], req_default=True, save=False),
-                            "monitor": check_for_attribute(lib, "monitor", parent="radarr", var_type="bool", default=self.general["radarr"]["monitor"], save=False),
+                            "monitor": check_for_attribute(lib, "monitor", parent="radarr", test_list=radarr.monitor_descriptions, default=self.general["radarr"]["monitor"], save=False),
                             "availability": check_for_attribute(lib, "availability", parent="radarr", test_list=radarr.availability_descriptions, default=self.general["radarr"]["availability"], save=False),
                             "quality_profile": check_for_attribute(lib, "quality_profile", parent="radarr", default=self.general["radarr"]["quality_profile"], req_default=True, save=False),
                             "tag": check_for_attribute(lib, "tag", parent="radarr", var_type="lower_list", default=self.general["radarr"]["tag"], default_is_none=True, save=False),


### PR DESCRIPTION
## Description

In a definition, `radarr_monitor` can be movie/collection/none, but in the config.yml where radarr is defined, monitor has to be a boolean. Sonarr can take the full values in both places.
    
This just copies the Sonarr code over so Radarr uses the defined monitor values instead of insisting on a boolean. However, it will turn configs with `monitor: false` into monitoring movie. Not sure what to do about that.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

Not sure how much this is "bug fix" or "breaking change", honestly.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
