### PR TITLE
Default Naming fix after rebrand for default overlay

### DIFF
--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -180,9 +180,9 @@ class Overlay:
             return image_path
 
         if not self.name.startswith(("blur", "backdrop")):
-            if ("kometa" in self.data and self.data["kometa"]) or ("pmm" in self.data and self.data["pmm"]) or ("git" in self.data and self.data["git"] and self.data["git"].startswith("PMM/")):
-                if "kometa" in self.data and self.data["kometa"]:
-                    temp_path = self.data["kometa"]
+            if ("default" in self.data and self.data["default"]) or ("pmm" in self.data and self.data["pmm"]) or ("git" in self.data and self.data["git"] and self.data["git"].startswith("PMM/")):
+                if "default" in self.data and self.data["default"]:
+                    temp_path = self.data["default"]
                 elif "pmm" in self.data and self.data["pmm"]:
                     temp_path = self.data["pmm"]
                 else:


### PR DESCRIPTION
## Description

Fix for after rebrand pmm was changed in default, but it was checking for kometa.

### Issues Fixed or Closed

- Fixes #(issue)
`[2024-04-23 11:01:44,251] [overlays.py:593]           [DEBUG]    | Traceback (most recent call last):                                                                 |
                                                                 |   File "D:\services\bin\kometa\modules\overlays.py", line 550, in compile_overlays                 |
                                                                 |     builder = CollectionBuilder(self.config, overlay_file, k, v, library=self.library, overlay=True) |
                                                                 |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ |
                                                                 |   File "D:\services\bin\kometa\modules\builder.py", line 508, in __init__                          |
                                                                 |     self.overlay = Overlay(config, library, metadata, str(self.mapping_name), overlay_data, suppress, self.builder_level) |
                                                                 |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ |
                                                                 |   File "D:\services\bin\kometa\modules\overlay.py", line 309, in __init__                          |
                                                                 |     raise Failed(f"Overlay Error: Overlay Image not found at: {self.path}")                        |
                                                                 | modules.util.Failed: Overlay Error: Overlay Image not found at: D:\services\config\kometa\overlays\Backdrop.png |`
## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
