### PR TITLE
Fix for non_item_remove_label to always run when defined

### DIFF
--- a/kometa.py
+++ b/kometa.py
@@ -885,6 +885,9 @@ def run_collection(config, library, metadata, requested_collections):
         except NonExisting as e:
             logger.warning(e)
             library.status[str(mapping_name)]["status"] = "Ignored"
+            if builder.item_details:
+                no_items = True
+                builder.update_item_details(no_items)
         except NotScheduled as e:
             logger.info(e)
             if str(e).endswith("and was deleted"):

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3153,10 +3153,19 @@ class CollectionBuilder:
         if not self.items:
             raise Failed(f"Plex Error: No {self.Type} items found")
 
-    def update_item_details(self):
-        logger.info("")
-        logger.separator(f"Updating Metadata of the Items in {self.name} {self.Type}", space=False, border=False)
-        logger.info("")
+    def update_item_details(self, no_items=False):
+        if (no_items and "non_item_remove_label" in self.item_details) or not no_items:
+            logger.info("")
+            logger.separator(f"Updating Metadata of the Items in {self.name} {self.Type}", space=False, border=False)
+            logger.info("")
+
+        if "non_item_remove_label" in self.item_details:
+            rk_compare = [item.ratingKey for item in self.items]
+            for non_item in self.library.search(label=self.item_details["non_item_remove_label"], libtype=self.builder_level):
+                if non_item.ratingKey not in rk_compare:
+                    self.library.edit_tags("label", non_item, remove_tags=self.item_details["non_item_remove_label"])
+            if no_items:
+                return
 
         add_tags = self.item_details["item_label"] if "item_label" in self.item_details else None
         remove_tags = self.item_details["item_label.remove"] if "item_label.remove" in self.item_details else None
@@ -3165,12 +3174,6 @@ class CollectionBuilder:
         add_genres = self.item_details["item_genre"] if "item_genre" in self.item_details else None
         remove_genres = self.item_details["item_genre.remove"] if "item_genre.remove" in self.item_details else None
         sync_genres = self.item_details["item_genre.sync"] if "item_genre.sync" in self.item_details else None
-
-        if "non_item_remove_label" in self.item_details:
-            rk_compare = [item.ratingKey for item in self.items]
-            for non_item in self.library.search(label=self.item_details["non_item_remove_label"], libtype=self.builder_level):
-                if non_item.ratingKey not in rk_compare:
-                    self.library.edit_tags("label", non_item, remove_tags=self.item_details["non_item_remove_label"])
 
         tmdb_paths = []
         tvdb_paths = []


### PR DESCRIPTION
## Description

It need's to run even when there's no collection items, to remove the labels as defined in the description of the function:

> Matches every movie/show that has the given label and is not in the collection and removes the label

Before it was not removing labels if it was on a collection with 0 matches. It should then still remove the labels defined in non_item_remove_label. 

How to reproduce:
Add a label 'test' to a item.
Then run a collection that has 0 matches, with non_item_remove_label: test
(For example it could happen when TMDB data gets changed and suddenly it doesnt find the correct language for it anymore, it should remove the label even when it has 0 matches for it anymore.)

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
## Checklist

- [x] My code was submitted to the nightly branch of the repository.
