### PR TITLE
Allow lists of ratings updates, either pmm or default

### DIFF
--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -938,6 +938,31 @@
             ],
             "title": "trakt"
         },
+        "pmm-lib-collection-path": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "pmm": {
+                    "type": "string",
+                    "enum": ["actor", "anilist","aspect","audio_language","bafta","based","basic","berlinale","cannes","cesar","choice","collectionless","content_rating_au","content_rating_cs","content_rating_de","content_rating_nz","content_rating_mal","content_rating_uk","content_rating_us","continent","country","decade","director","emmy","flixpatrol","franchise","genre","golden","imdb","myanimelist","network","nfr","oscars","other_chart","pca","producer","razzie","region","resolution","sag","seasonal","separator_award","separator_chart","spirit","streaming","studio","subtitle_language","sundance","tautulli","tiff","tmdb","trakt","universe","venice","writer","year"]
+                },
+                "schedule": {
+                    "type": "string"
+                },
+                "asset_directory": {
+                    "oneOf": [
+                        { "type": "string"},
+                        { "type": "array", "uniqueItems": true, "items": {"type": "string" }}
+                    ]
+                },
+                "template_variables": {
+                    "$ref": "#/definitions/template-variables-collections"
+                }
+            },
+            "required": [
+                "pmm"
+            ]
+        },
         "lib-collection-path": {
             "type": "object",
             "additionalProperties": false,
@@ -1243,6 +1268,9 @@
             "items": {
                 "anyOf": [
                     {
+                        "$ref": "#/definitions/pmm-lib-collection-path",
+                        "deprecated": true
+                    }, {
                         "$ref": "#/definitions/lib-collection-path"
                     }, {
                         "$ref": "#/definitions/file-path"
@@ -1287,6 +1315,8 @@
             "items": {
                 "anyOf": [
                     {
+                        "$ref": "#/definitions/pmm-lib-collection-path"
+                    }, {
                         "$ref": "#/definitions/lib-collection-path"
                     }, {
                         "$ref": "#/definitions/file-path"
@@ -1390,28 +1420,136 @@
                     "enum": ["tmdb","tvdb","omdb","mdb","anidb","mal","lock","unlock","remove","reset"]
                 },
                 "mass_audience_rating_update": {
-                    "type": "string",
-                    "enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]
+                    "anyOf": [
+                        { 
+                            "type": "number"
+                        },
+                        { 
+                            "type": "string",
+                            "enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]
+                        },
+                        { 
+                            "type": "array", 
+                            "uniqueItems": true, 
+                            "items": 
+                            {
+                                "anyOf": [
+                                    {"enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]},
+                                    {"type": "number"}
+                                ]
+                            }
+                        }
+                    ]
                 },
                 "mass_critic_rating_update": {
-                    "type": "string",
-                    "enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]
+                    "anyOf": [
+                        { 
+                            "type": "number"
+                        },
+                        { 
+                            "type": "string",
+                            "enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]
+                        },
+                        { 
+                            "type": "array", 
+                            "uniqueItems": true, 
+                            "items": 
+                            {
+                                "anyOf": [
+                                    {"enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]},
+                                    {"type": "number"}
+                                ]
+                            }
+                        }
+                    ]
                 },
                 "mass_user_rating_update": {
-                    "type": "string",
-                    "enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]
+                    "anyOf": [
+                        { 
+                            "type": "number"
+                        },
+                        { 
+                            "type": "string",
+                            "enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]
+                        },
+                        { 
+                            "type": "array", 
+                            "uniqueItems": true, 
+                            "items": 
+                            {
+                                "anyOf": [
+                                    {"enum": ["tmdb","imdb","trakt_user","omdb","mdb","mdb_average","mdb_imdb","mdb_metacritic","mdb_metacriticuser","mdb_trakt","mdb_tomatoes","mdb_tomatoesaudience","mdb_tmdb","mdb_letterboxd","mdb_myanimelist","anidb_rating","anidb_average","anidb_score","mal","lock","unlock","remove","reset"]},
+                                    {"type": "number"}
+                                ]
+                            }
+                        }
+                    ]
                 },
                 "mass_episode_audience_rating_update": {
-                    "type": "string",
-                    "enum": ["tmdb","imdb","lock","remove","reset","unlock"]
+                    "anyOf": [
+                        { 
+                            "type": "number"
+                        },
+                        { 
+                            "type": "string",
+                            "enum": ["tmdb","imdb","lock","remove","reset","unlock"]
+                        },
+                        { 
+                            "type": "array", 
+                            "uniqueItems": true, 
+                            "items": 
+                            {
+                                "anyOf": [
+                                    {"enum": ["tmdb","imdb","lock","remove","reset","unlock"]},
+                                    {"type": "number"}
+                                ]
+                            }
+                        }
+                    ]
                 },
                 "mass_episode_critic_rating_update": {
-                    "type": "string",
-                    "enum": ["tmdb","imdb","lock","remove","reset","unlock"]
+                    "anyOf": [
+                        { 
+                            "type": "number"
+                        },
+                        { 
+                            "type": "string",
+                            "enum": ["tmdb","imdb","lock","remove","reset","unlock"]
+                        },
+                        { 
+                            "type": "array", 
+                            "uniqueItems": true, 
+                            "items": 
+                            {
+                                "anyOf": [
+                                    {"enum": ["tmdb","imdb","lock","remove","reset","unlock"]},
+                                    {"type": "number"}
+                                ]
+                            }
+                        }
+                    ]
                 },
                 "mass_episode_user_rating_update": {
-                    "type": "string",
-                    "enum": ["tmdb","imdb","lock","remove","reset","unlock"]
+                    "anyOf": [
+                        { 
+                            "type": "number"
+                        },
+                        { 
+                            "type": "string",
+                            "enum": ["tmdb","imdb","lock","remove","reset","unlock"]
+                        },
+                        { 
+                            "type": "array", 
+                            "uniqueItems": true, 
+                            "items": 
+                            {
+                                "anyOf": [
+                                    {"enum": ["tmdb","imdb","lock","remove","reset","unlock"]},
+                                    {"type": "number"}
+                                ]
+                            }
+                        }
+                    ]
                 },
                 "mass_poster_update": {
                     "type": "string",

--- a/json-schema/prototype_config.yml
+++ b/json-schema/prototype_config.yml
@@ -23,7 +23,7 @@ libraries:
     - url: https://foo.bar.com/something.yml
     - git: bing/bang/boing
     - repo: bing
-    - default: cannes
+    - pmm: cannes
     - default: choice
     - default: emmy
     - default: spirit
@@ -118,6 +118,14 @@ libraries:
       asset_directory: config/assets
 
     operations:
+      mass_audience_rating_update: 
+       - mdb_average
+       - imdb
+       - 2.0
+      mass_episode_audience_rating_update: 
+       - tmdb
+       - imdb
+       - 2.0
       split_duplicates: false
       assets_for_all: false
       genre_mapper:

--- a/json-schema/prototype_config.yml
+++ b/json-schema/prototype_config.yml
@@ -119,13 +119,13 @@ libraries:
 
     operations:
       mass_audience_rating_update: 
-       - mdb_average
-       - imdb
-       - 2.0
+      - mdb_average
+      - imdb
+      - 2.0
       mass_episode_audience_rating_update: 
-       - tmdb
-       - imdb
-       - 2.0
+      - tmdb
+      - imdb
+      - 2.0
       split_duplicates: false
       assets_for_all: false
       genre_mapper:


### PR DESCRIPTION
## Description

now accepts
```
      mass_audience_rating_update: 
      - mdb_average
      - imdb
      - 2.0
      mass_episode_audience_rating_update: 
      - tmdb
      - imdb
      - 2.0
```

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] My code was submitted to the nightly branch of the repository.
