### PR TITLE
Utilize AniDb Scrapping to DB matching

### DIFF
--- a/modules/builder.py
+++ b/modules/builder.py
@@ -2242,7 +2242,7 @@ class CollectionBuilder:
             logger.trace(f"IDs: {ids}")
             logger.debug("")
             for i, input_data in enumerate(ids, 1):
-                input_id, id_type = input_data
+                input_id, id_type, id_info = input_data
                 logger.ghost(f"Parsing ID {i}/{total_ids}")
                 rating_keys = []
                 if id_type == "ratingKey":
@@ -2306,13 +2306,20 @@ class CollectionBuilder:
                     input_id = int(input_id)
                     if input_id not in self.ignore_ids:
                         found = False
-                        for pl_library in self.libraries:
-                            if input_id in pl_library.movie_map:
-                                found = True
-                                rating_keys = pl_library.movie_map[input_id]
-                                break
-                        if not found and input_id not in self.missing_movies:
-                            self.missing_movies.append(input_id)
+                        if id_info == "show":
+                            for pl_library in self.libraries:
+                                if input_id in pl_library.tmdb_show_map:
+                                    found = True
+                                    rating_keys = pl_library.tmdb_show_map[input_id]
+                                    break
+                        else:
+                            for pl_library in self.libraries:
+                                if input_id in pl_library.movie_map:
+                                    found = True
+                                    rating_keys = pl_library.movie_map[input_id]
+                                    break
+                            if not found and input_id not in self.missing_movies:
+                                self.missing_movies.append(input_id)
                 elif id_type == "tvdb_season" and (self.builder_level == "season" or self.playlist):
                     tvdb_id, season_num = input_id.split("_")
                     tvdb_id = int(tvdb_id)

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -56,74 +56,79 @@ class Convert:
             if "tvdb_id" in ids:
                 tvdb_id = int(ids["tvdb_id"])
                 if tvdb_id not in self._tvdb_to_anidb:
-                    self._tvdb_to_anidb[tvdb_id] = [(anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"]))]
+                    self._tvdb_to_anidb[tvdb_id] = [[anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"])]]
                 else:
-                    self._tvdb_to_anidb[tvdb_id].append((anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"])))
+                    self._tvdb_to_anidb[tvdb_id].append([anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"])])
                 if anidb_id not in self._anidb_to_tvdb:
                     self._anidb_to_tvdb[anidb_id] = [tvdb_id]
                 else:
                     self._anidb_to_tvdb[anidb_id].append(tvdb_id)
-        for anidb_id, ids in self._anidb_ids_automated["anime"].items():
-            anidb_id = int(anidb_id)
-            if "MAL" in ids["resources"]:
-                for mal_id in util.get_list(ids["resources"]["MAL"], int_list=True):
-                    if mal_id not in self._mal_to_anidb:
-                        self._mal_to_anidb[mal_id] = [anidb_id]
-                    else:
-                        self._mal_to_anidb[mal_id].append(anidb_id)
-                    if anidb_id not in self._anidb_to_mal:
-                        self._anidb_to_mal[anidb_id] = [mal_id]
-                    else:
-                        self._anidb_to_mal[anidb_id].append(mal_id)
-            if "IMDB" in ids["resources"]:
-                for imdb_id in util.get_list(ids["resources"]["IMDB"]):
-                    if str(imdb_id).startswith("tt"):
-                        if imdb_id not in self._imdb_to_anidb:
-                            self._imdb_to_anidb[imdb_id] = [anidb_id]
-                        else:
-                            self._imdb_to_anidb[imdb_id].append(anidb_id)
-                        if anidb_id not in self._anidb_to_imdb:
-                            self._anidb_to_imdb[anidb_id] = [imdb_id]
-                        else:
-                            self._anidb_to_imdb[anidb_id].append(imdb_id)
-            if "TMDB" in ids["resources"]:
-                for tmdb_id in util.get_list(ids["resources"]["TMDB"]):
-                    if tmdb_id not in self._anidb_to_tmdb:
-                        self._anidb_to_tmdb[tmdb_id] = [anidb_id]
-                    else:
-                        self._anidb_to_tmdb[tmdb_id].append(anidb_id)
-                    if str(tmdb_id).startswith("movie/"):
-                        tmdb_id = int(tmdb_id[6:])
-                        if anidb_id not in self._anidb_to_tmdb:
-                            self._anidb_to_tmdb[anidb_id] = [(tmdb_id, "movie")]
-                        else:
-                            self._anidb_to_tmdb[anidb_id].append((tmdb_id, "movie"))
-                    elif str(tmdb_id).startswith("tv/"):
-                        tmdb_id = int(tmdb_id[3:])
-                        if anidb_id not in self._anidb_to_tmdb:
-                            self._anidb_to_tmdb[anidb_id] = [(tmdb_id, "show")]
-                        else:
-                            self._anidb_to_tmdb[anidb_id].append((tmdb_id, "show"))
+        if "animes" in self._anidb_ids_automated:
+            for anidb_id, ids in self._anidb_ids_automated["animes"].items():
+                if "resources" in ids:
+                    anidb_id = int(anidb_id)
+                    if "MAL" in ids["resources"]:
+                        for mal_id in util.get_list(ids["resources"]["MAL"], int_list=True):
+                            if mal_id not in self._mal_to_anidb:
+                                self._mal_to_anidb[mal_id] = [anidb_id]
+                            else:
+                                self._mal_to_anidb[mal_id].append(anidb_id)
+                            if anidb_id not in self._anidb_to_mal:
+                                self._anidb_to_mal[anidb_id] = [mal_id]
+                            else:
+                                self._anidb_to_mal[anidb_id].append(mal_id)
+                    if "IMDB" in ids["resources"]:
+                        for imdb_id in util.get_list(ids["resources"]["IMDB"]):
+                            if str(imdb_id).startswith("tt"):
+                                if imdb_id not in self._imdb_to_anidb:
+                                    self._imdb_to_anidb[imdb_id] = [anidb_id]
+                                else:
+                                    self._imdb_to_anidb[imdb_id].append(anidb_id)
+                                if anidb_id not in self._anidb_to_imdb:
+                                    self._anidb_to_imdb[anidb_id] = [imdb_id]
+                                else:
+                                    self._anidb_to_imdb[anidb_id].append(imdb_id)
+                    if "TMDB" in ids["resources"]:
+                        for tmdb_id in util.get_list(ids["resources"]["TMDB"]):
+                            if tmdb_id not in self._tmdb_to_anidb:
+                                self._tmdb_to_anidb[tmdb_id] = [anidb_id]
+                            else:
+                                self._tmdb_to_anidb[tmdb_id].append(anidb_id)
+                            if str(tmdb_id).startswith("movie/"):
+                                tmdb_id = int(tmdb_id[6:])
+                                if anidb_id not in self._anidb_to_tmdb:
+                                    self._anidb_to_tmdb[anidb_id] = [[tmdb_id, "movie"]]
+                                else:
+                                    self._anidb_to_tmdb[anidb_id].append([tmdb_id, "movie"])
+                            elif str(tmdb_id).startswith("tv/"):
+                                tmdb_id = int(tmdb_id[3:])
+                                if anidb_id not in self._anidb_to_tmdb:
+                                    self._anidb_to_tmdb[anidb_id] = [[tmdb_id, "show"]]
+                                else:
+                                    self._anidb_to_tmdb[anidb_id].append([tmdb_id, "show"])
 
     def anidb_to_imdb(self, anidb_id, fail=False):
+        anidb_id = int(anidb_id)
         if anidb_id in self._anidb_to_imdb:
-            return self._anidb_to_imdb[int(anidb_id)]
+            return self._anidb_to_imdb[anidb_id]
         elif fail:
             raise Failed(f"IMDb ID not found for AniDB ID: {anidb_id}")
         else:
             return []
 
     def anidb_to_mal(self, anidb_id, fail=False):
+        anidb_id = int(anidb_id)
         if anidb_id in self._anidb_to_mal:
-            return self._anidb_to_mal[int(anidb_id)]
+            return self._anidb_to_mal[anidb_id]
         elif fail:
             raise Failed(f"MAL ID not found for AniDB ID: {anidb_id}")
         else:
             return []
 
     def anidb_to_tvdb(self, anidb_id, fail=False):
+        anidb_id = int(anidb_id)
         if anidb_id in self._anidb_to_tvdb:
-            return self._anidb_to_tvdb[int(anidb_id)]
+            return self._anidb_to_tvdb[anidb_id]
         elif fail:
             raise Failed(f"TVDb ID not found for AniDB ID: {anidb_id}")
         else:
@@ -131,16 +136,19 @@ class Convert:
 
     def anidb_to_tmdb(self, anidb_id, library_type=["movie","show"], fail=False):
         ids = []
+        anidb_id = int(anidb_id)
         library_type = library_type if isinstance(library_type, list) else [tmdb_type]
-        for anidb_id, tmdb_type in self._anidb_to_tmdb:
-            if (tmdb_type in library_type):
-                ids.append((anidb_id, tmdb_type))
+        if anidb_id in self._anidb_to_tmdb:
+            for tmdb_id, tmdb_type in self._anidb_to_tmdb[anidb_id]:
+                if (tmdb_type in library_type):
+                    ids.append([tmdb_id, tmdb_type])
         if fail and not ids:
             raise Failed(f"TMDb ID not found for AniDB ID: {anidb_id}")
         return ids
 
     def anilist_to_anidb(self, anilist_id, fail=False):
-        if imdb_id in self._anilist_to_anidb:
+        anilist_id = int(anilist_id)
+        if anilist_id in self._anilist_to_anidb:
             return self._anilist_to_anidb[anilist_id]
         elif fail:
             raise Failed(f"AniDB ID not found for AniList ID: {anilist_id}")
@@ -156,8 +164,9 @@ class Convert:
             return []
 
     def mal_to_anidb(self, mal_id, fail=False):
-        if int(mal_id) in self._mal_to_anidb:
-            return self._mal_to_anidb[int(mal_id)]
+        mal_id = int(mal_id)
+        if mal_id in self._mal_to_anidb:
+            return self._mal_to_anidb[mal_id]
         elif fail:
             raise Failed(f"AniDB ID not found for MAL ID: {mal_id}")
         else:
@@ -165,11 +174,13 @@ class Convert:
 
     def tvdb_to_anidb(self, tvdb_id, season=[1,-1], epoffset=[0], fail=False):
         ids = []
+        tvdb_id = int(tvdb_id)
         season = season if isinstance(season, list) else [season]
         epoffset = epoffset if isinstance(epoffset, list) else [epoffset]
-        for anidb_id, season_id, epoffset_id in self._tvdb_to_anidb:
-            if (season_id in season and epoffset_id in epoffset):
-                ids.append((anidb_id, season_id, epoffset_id))
+        if tvdb_id in self._tvdb_to_anidb:
+            for anidb_id, season_id, epoffset_id in self._tvdb_to_anidb[tvdb_id]:
+                if (season_id in season and epoffset_id in epoffset):
+                    ids.append([anidb_id, season_id, epoffset_id])
         if fail and not ids:
             raise Failed(f"AniDB ID not found for TVDb ID: {tvdb_id}")
         return ids
@@ -395,16 +406,21 @@ class Convert:
                     for guid_tag in item.guids:
                         try:
                             url_parsed = requests.utils.urlparse(guid_tag.id)
-                            if url_parsed.scheme == "tvdb":                 tvdb_id.append(int(url_parsed.netloc))
-                            elif url_parsed.scheme == "imdb":               imdb_id.append(url_parsed.netloc)
-                            elif url_parsed.scheme == "tmdb":               tmdb_movie_id.append(int(url_parsed.netloc))
+                            if url_parsed.scheme == "tvdb":
+                                tvdb_id.append(int(url_parsed.netloc))
+                            elif url_parsed.scheme == "imdb":
+                                imdb_id.append(url_parsed.netloc)
+                            elif url_parsed.scheme == "tmdb" and check_id == "movie":
+                                tmdb_movie_id.append(int(url_parsed.netloc))
+                            elif url_parsed.scheme == "tmdb" and check_id == "show":
+                                tmdb_show_id.append(int(url_parsed.netloc))
                         except ValueError:
                             pass
                 except requests.exceptions.ConnectionError:
                     library.query(item.refresh)
                     logger.stacktrace()
                     raise Failed("No External GUIDs found")
-                if not tvdb_id and not imdb_id and not tmdb_movie_id:
+                if not tvdb_id and not imdb_id and not tmdb_movie_id and not tmdb_show_id:
                     library.query(item.refresh)
                     raise Failed("Refresh Metadata")
             elif item_type == "imdb":                       imdb_id.append(check_id)

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -5,79 +5,223 @@ from plexapi.exceptions import BadRequest
 
 logger = util.logger
 
-anime_lists_url = "https://raw.githubusercontent.com/Kometa-Team/Anime-IDs/master/anime_ids.json"
+anime_manual_lists_url = "https://raw.githubusercontent.com/Kometa-Team/Anime-IDs/master/anime_ids.json"
+anime_automated_lists_url = "https://raw.githubusercontent.com/notseteve/AnimeAggregations/main/aggregate/AnimeToExternal.json"
 
 class Convert:
     def __init__(self, config):
         self.config = config
-        self._anidb_ids = {}
+        self._anidb_ids_manual = {}
+        self._anidb_ids_automated = {}
         self._mal_to_anidb = {}
         self._anidb_to_mal = {}
         self._anilist_to_anidb = {}
         self._anidb_to_imdb = {}
         self._anidb_to_tvdb = {}
+        self._anidb_to_tmdb = {}
         self._imdb_to_anidb = {}
         self._tvdb_to_anidb = {}
-        self._anidb_ids = self.config.get_json(anime_lists_url)
-        for anidb_id, ids in self._anidb_ids.items():
+        self._tmdb_to_anidb = {}
+        self._anidb_ids_manual = self.config.get_json(anime_manual_lists_url)
+        self._anidb_ids_automated = self.config.get_json(anime_automated_lists_url)
+        for anidb_id, ids in self._anidb_ids_manual.items():
             anidb_id = int(anidb_id)
             if "mal_id" in ids:
                 for mal_id in util.get_list(ids["mal_id"], int_list=True):
-                    self._mal_to_anidb[mal_id] = anidb_id
+                    if mal_id not in self._mal_to_anidb:
+                        self._mal_to_anidb[mal_id] = [anidb_id]
+                    else
+                        self._mal_to_anidb[mal_id].append(anidb_id)
                     if anidb_id not in self._anidb_to_mal:
-                        self._anidb_to_mal[anidb_id] = mal_id
+                        self._anidb_to_mal[anidb_id] = [mal_id]
+                    else
+                        self._anidb_to_mal[anidb_id].append(mal_id)
             if "anilist_id" in ids:
                 for anilist_id in util.get_list(ids["anilist_id"], int_list=True):
-                    self._anilist_to_anidb[anilist_id] = anidb_id
-            if "imdb_id" in ids and str(ids["imdb_id"]).startswith("tt"):
-                self._anidb_to_imdb[anidb_id] = util.get_list(ids["imdb_id"])
-                for im_id in util.get_list(ids["imdb_id"]):
-                    self._imdb_to_anidb[im_id] = anidb_id
+                    if anilist_id not in self._anilist_to_anidb:
+                        self._anilist_to_anidb[anilist_id] = [anidb_id]
+                    else
+                        self._anilist_to_anidb[anilist_id].append(anidb_id)
+            if "imdb_id" in ids:
+                for imdb_id in util.get_list(ids["imdb_id"]):
+                    if str(imdb_id).startswith("tt"):
+                        if imdb_id not in self._imdb_to_anidb:
+                            self._imdb_to_anidb[imdb_id] = [anidb_id]
+                        else
+                            self._imdb_to_anidb[imdb_id].append(anidb_id)
+                        if anidb_id not in self._anidb_to_imdb:
+                            self._anidb_to_imdb[anidb_id] = [imdb_id]
+                        else
+                            self._anidb_to_imdb[anidb_id].append(imdb_id)
             if "tvdb_id" in ids:
-                self._anidb_to_tvdb[anidb_id] = int(ids["tvdb_id"])
-                if "tvdb_season" in ids and ids["tvdb_season"] in [1, -1] and ids["tvdb_epoffset"] == 0:
-                    self._tvdb_to_anidb[int(ids["tvdb_id"])] = anidb_id
+                tvdb_id = int(ids["tvdb_id"])
+                if tvdb_id not in self._tvdb_to_anidb:
+                    self._tvdb_to_anidb[tvdb_id] = [(anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"]))]
+                else
+                    self._tvdb_to_anidb[tvdb_id].append((anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"]))]
+                if anidb_id not in self._anidb_to_tvdb:
+                    self._anidb_to_tvdb[anidb_id] = [tvdb_id]
+                else
+                    self._anidb_to_tvdb[anidb_id].append(tvdb_id)
+        for anidb_id, ids in self._anidb_ids_automated["anime"].items():
+            anidb_id = int(anidb_id)
+            if "MAL" in ids["resources"]:
+                for mal_id in util.get_list(ids["resources"]["MAL"], int_list=True):
+                    if mal_id not in self._mal_to_anidb:
+                        self._mal_to_anidb[mal_id] = [anidb_id]
+                    else
+                        self._mal_to_anidb[mal_id].append(anidb_id)
+                    if anidb_id not in self._anidb_to_mal:
+                        self._anidb_to_mal[anidb_id] = [mal_id]
+                    else
+                        self._anidb_to_mal[anidb_id].append(mal_id)
+            if "IMDB" in ids["resources"]:
+                for imdb_id in util.get_list(ids["resources"]["IMDB"]):
+                    if str(imdb_id).startswith("tt"):
+                        if imdb_id not in self._imdb_to_anidb:
+                            self._imdb_to_anidb[imdb_id] = [anidb_id]
+                        else
+                            self._imdb_to_anidb[imdb_id].append(anidb_id)
+                        if anidb_id not in self._anidb_to_imdb:
+                            self._anidb_to_imdb[anidb_id] = [imdb_id]
+                        else
+                            self._anidb_to_imdb[anidb_id].append(imdb_id)
+            if "TMDB" in ids["resources"]:
+                for tmdb_id in util.get_list(ids["resources"]["TMDB"]):
+                    if tmdb_id not in self._anidb_to_tmdb:
+                        self._anidb_to_tmdb[tmdb_id] = [anidb_id]
+                    else
+                        self._anidb_to_tmdb[tmdb_id].append(anidb_id)
+                    if str(tmdb_id).startswith("movie/"):
+                        tmdb_id = int(tmdb_id[6:])
+                        if anidb_id not in self._anidb_to_tmdb:
+                            self._anidb_to_tmdb[anidb_id] = [(tmdb_id, "movie")]
+                        else
+                            self._anidb_to_tmdb[anidb_id].append((tmdb_id, "movie"))
+                    elif str(tmdb_id).startswith("tv/"):
+                        tmdb_id = int(tmdb_id[3:])
+                        if anidb_id not in self._anidb_to_tmdb:
+                            self._anidb_to_tmdb[anidb_id] = [(tmdb_id, "show")]
+                        else
+                            self._anidb_to_tmdb[anidb_id].append((tmdb_id, "show"))
 
-    def imdb_to_anidb(self, imdb_id):
+    def anidb_to_imdb(self, anidb_id, fail=False):
+        if anidb_id in self._anidb_to_imdb:
+            return self._anidb_to_imdb[int(anidb_id)]
+        elif fail:
+            raise Failed(f"IMDb ID not found for AniDB ID: {anidb_id}")
+        else:
+            return []
+
+    def anidb_to_mal(self, anidb_id, fail=False):
+        if anidb_id in self._anidb_to_mal:
+            return self._anidb_to_mal[int(anidb_id)]
+        elif fail:
+            raise Failed(f"MAL ID not found for AniDB ID: {anidb_id}")
+        else:
+            return []
+
+    def anidb_to_tvdb(self, anidb_id, fail=False):
+        if anidb_id in self._anidb_to_tvdb:
+            return self._anidb_to_tvdb[int(anidb_id)]
+        elif fail:
+            raise Failed(f"TVDb ID not found for AniDB ID: {anidb_id}")
+        else:
+            return []
+
+    def anidb_to_tmdb(self, anidb_id, library_type=["movie","show"], fail=False):
+        ids = []
+        library_type = library_type if isinstance(library_type, list) else [tmdb_type]
+        for anidb_id, tmdb_type in self._anidb_to_tmdb:
+            if (tmdb_type in library_type):
+                ids.append((anidb_id, tmdb_type))
+        if fail and not ids:
+            raise Failed(f"TMDb ID not found for AniDB ID: {anidb_id}")
+        return ids
+
+    def anilist_to_anidb(self, anilist_id, fail=False):
+        if imdb_id in self._anilist_to_anidb:
+            return self._anilist_to_anidb[anilist_id]
+        elif fail:
+            raise Failed(f"AniDB ID not found for AniList ID: {anilist_id}")
+        else:
+            return []
+
+    def imdb_to_anidb(self, imdb_id, fail=False):
         if imdb_id in self._imdb_to_anidb:
             return self._imdb_to_anidb[imdb_id]
-        else:
+        elif fail:
             raise Failed(f"AniDB ID not found for IMDb ID: {imdb_id}")
-
-    def tvdb_to_anidb(self, tvdb_id):
-        if int(tvdb_id) in self._tvdb_to_anidb:
-            return self._tvdb_to_anidb[int(tvdb_id)]
         else:
+            return []
+
+    def mal_to_anidb(self, mal_id, fail=False):
+        if int(mal_id) in self._mal_to_anidb:
+            return self._mal_to_anidb[int(mal_id)]
+        elif fail:
+            raise Failed(f"AniDB ID not found for MAL ID: {mal_id}")
+        else:
+            return []
+
+    def tvdb_to_anidb(self, tvdb_id, season=[1,-1], epoffset=[0], fail=False):
+        ids = []
+        season = season if isinstance(season, list) else [season]
+        epoffset = epoffset if isinstance(epoffset, list) else [epoffset]
+        for anidb_id, season_id, epoffset_id in self._tvdb_to_anidb:
+            if (season_id in season and epoffset_id in epoffset):
+                ids.append((anidb_id, season_id, epoffset_id))
+        if fail and not ids:
             raise Failed(f"AniDB ID not found for TVDb ID: {tvdb_id}")
+        return ids
+
+    def tmdb_to_anidb(self, tmdb_id, is_movie=True, fail=False):
+        if is_movie:
+            if f"movie/{tmdb_id}" in self._tmdb_to_anidb:
+                return self._tmdb_to_anidb[f"movie/{tmdb_id}"]
+            elif fail:
+                raise Failed(f"AniDB ID not found for TMDb ID: movie/{tmdb_id}")
+            else:
+                return []
+        else:
+            if f"tv/{tmdb_id}" in self._tmdb_to_anidb:
+                return self._tmdb_to_anidb[f"tv/{tmdb_id}"]
+            elif fail:
+                raise Failed(f"AniDB ID not found for TMDb ID: tv/{tmdb_id}")
+            else:
+                return []
 
     def anidb_to_ids(self, anidb_ids, library):
         ids = []
         anidb_list = anidb_ids if isinstance(anidb_ids, list) else [anidb_ids]
         for anidb_id in anidb_list:
+            added = False
             if anidb_id in library.anidb_map:
+                added = True
                 ids.append((library.anidb_map[anidb_id], "ratingKey"))
-            elif anidb_id in self._anidb_to_imdb:
-                added = False
-                for imdb in self._anidb_to_imdb[anidb_id]:
-                    tmdb, tmdb_type = self.imdb_to_tmdb(imdb)
-                    if tmdb and tmdb_type == "movie":
-                        ids.append((tmdb, "tmdb"))
-                        added = True
-                if added is False and anidb_id in self._anidb_to_tvdb:
-                    ids.append((self._anidb_to_tvdb[anidb_id], "tvdb"))
-            elif anidb_id in self._anidb_to_tvdb:
-                ids.append((self._anidb_to_tvdb[anidb_id], "tvdb"))
-            elif str(anidb_id) in self._anidb_ids:
-                logger.warning(f"Convert Warning: No TVDb ID or IMDb ID found for AniDB ID: {anidb_id}")
-            else:
+            for tmdb, tmdb_type in anidb_to_tmdb(anidb_id):
+                added = True
+                ids.append((int(tmdb), "tmdb", tmdb_type))
+            for tvdb in anidb_to_tvdb(anidb_id):
+                added = True
+                ids.append((int(tvdb), "tvdb"))
+            for imdb in anidb_to_imdb(anidb_id):
+                ids.append((imdb, "imdb"))
+                tmdb, tmdb_type = self.imdb_to_tmdb(imdb)
+                if tmdb and tmdb_type:
+                    added = True
+                    ids.append((tmdb, "tmdb", tmdb_type))
+            if not added and (str(anidb_id) in self._anidb_ids_manual or str(anidb_id) in self._anidb_ids_automated):
+                logger.warning(f"Convert Warning: No TVDb ID, IMDb ID, nor TMDb ID found for AniDB ID: {anidb_id}")
+            elif not added:
                 logger.error(f"AniDB Error: No Anime found for AniDB ID: {anidb_id}")
         return ids
 
     def anilist_to_ids(self, anilist_ids, library):
         anidb_ids = []
         for anilist_id in anilist_ids:
-            if anilist_id in self._anilist_to_anidb:
-                anidb_ids.append(self._anilist_to_anidb[anilist_id])
+            anidb_id = self.anilist_to_anidb(anilist_id)
+            if anidb_id:
+                anidb_ids.append(anidb_id[0])
             else:
                 logger.warning(f"Convert Warning: No AniDB ID Found for AniList ID: {anilist_id}")
         return self.anidb_to_ids(anidb_ids, library)
@@ -87,10 +231,12 @@ class Convert:
         for mal_id in mal_ids:
             if int(mal_id) in library.mal_map:
                 ids.append((library.mal_map[int(mal_id)], "ratingKey"))
-            elif int(mal_id) in self._mal_to_anidb:
-                ids.extend(self.anidb_to_ids(self._mal_to_anidb[int(mal_id)], library))
             else:
-                logger.warning(f"Convert Warning: No AniDB ID Found for MyAnimeList ID: {mal_id}")
+                anidb_id = self.mal_to_anidb(anilist_id)
+                if anidb_id:
+                    ids.extend(self.anidb_to_ids(anidb_id[0], library))
+                else:
+                    logger.warning(f"Convert Warning: No AniDB ID Found for MyAnimeList ID: {mal_id}")
         return ids
 
     def tmdb_to_imdb(self, tmdb_id, is_movie=True, fail=False):
@@ -213,18 +359,20 @@ class Convert:
     def ids_from_cache(self, ratingKey, guid, item_type, check_id, library):
         media_id_type = None
         cache_id = None
+        library_id = None
         imdb_check = None
         expired = None
         if self.config.Cache:
             cache_id, imdb_check, media_type, expired = self.config.Cache.query_guid_map(guid)
             if (cache_id or imdb_check) and not expired:
                 media_id_type = "movie" if "movie" in media_type else "show"
+                library_id = "TVDb" if "show" == media_type else "TMDb"
                 if item_type == "hama" and check_id.startswith("anidb"):
                     anidb_id = int(re.search("-(.*)", check_id).group(1))
                     library.anidb_map[anidb_id] = ratingKey
                 elif item_type == "myanimelist":
                     library.mal_map[int(check_id)] = ratingKey
-        return media_id_type, cache_id, imdb_check, expired
+        return media_id_type, cache_id, library_id, imdb_check, expired
 
     def scan_guid(self, guid_str):
         guid = requests.utils.urlparse(guid_str)
@@ -232,14 +380,15 @@ class Convert:
 
     def get_id(self, item, library):
         expired = None
-        tmdb_id = []
+        tmdb_movie_id = []
+        tmdb_show_id = []
         tvdb_id = []
         imdb_id = []
-        anidb_id = None
+        anidb_id = []
         item_type, check_id = self.scan_guid(item.guid)
-        media_id_type, cache_id, imdb_check, expired = self.ids_from_cache(item.ratingKey, item.guid, item_type, check_id, library)
+        media_id_type, cache_id, library_id, imdb_check, expired = self.ids_from_cache(item.ratingKey, item.guid, item_type, check_id, library)
         if (cache_id or imdb_check) and expired is False:
-            return media_id_type, cache_id, imdb_check
+            return media_id_type, cache_id, library_id, imdb_check
         try:
             if item_type == "plex":
                 try:
@@ -248,25 +397,25 @@ class Convert:
                             url_parsed = requests.utils.urlparse(guid_tag.id)
                             if url_parsed.scheme == "tvdb":                 tvdb_id.append(int(url_parsed.netloc))
                             elif url_parsed.scheme == "imdb":               imdb_id.append(url_parsed.netloc)
-                            elif url_parsed.scheme == "tmdb":               tmdb_id.append(int(url_parsed.netloc))
+                            elif url_parsed.scheme == "tmdb":               tmdb_movie_id.append(int(url_parsed.netloc))
                         except ValueError:
                             pass
                 except requests.exceptions.ConnectionError:
                     library.query(item.refresh)
                     logger.stacktrace()
                     raise Failed("No External GUIDs found")
-                if not tvdb_id and not imdb_id and not tmdb_id:
+                if not tvdb_id and not imdb_id and not tmdb_movie_id:
                     library.query(item.refresh)
                     raise Failed("Refresh Metadata")
             elif item_type == "imdb":                       imdb_id.append(check_id)
             elif item_type == "thetvdb":                    tvdb_id.append(int(check_id))
-            elif item_type == "themoviedb":                 tmdb_id.append(int(check_id))
+            elif item_type == "themoviedb":                 tmdb_movie_id.append(int(check_id))
             elif item_type in ["xbmcnfo", "xbmcnfotv"]:
                 if len(check_id) > 10:
                     raise Failed(f"XMBC NFO Local ID: {check_id}")
                 try:
                     if item_type == "xbmcnfo":
-                        tmdb_id.append(int(check_id))
+                        tmdb_movie_id.append(int(check_id))
                     else:
                         tvdb_id.append(int(check_id))
                 except ValueError:
@@ -276,54 +425,61 @@ class Convert:
                     tvdb_id.append(int(re.search("-(.*)", check_id).group(1)))
                 elif check_id.startswith("anidb"):
                     anidb_str = str(re.search("-(.*)", check_id).group(1))
-                    anidb_id = int(anidb_str[1:] if anidb_str[0] == "a" else anidb_str)
-                    library.anidb_map[anidb_id] = item.ratingKey
+                    anidb_id = [int(anidb_str[1:] if anidb_str[0] == "a" else anidb_str)]
+                    library.anidb_map[anidb_id[0]] = item.ratingKey
                 else:
                     raise Failed(f"Hama Agent ID: {check_id} not supported")
             elif item_type == "myanimelist":
                 library.mal_map[int(check_id)] = item.ratingKey
-                if int(check_id) in self._mal_to_anidb:
-                    anidb_id = self._mal_to_anidb[int(check_id)]
-                else:
+                anidb_id = self.mal_to_anidb(check_id)
+                if not anidb_id:
                     raise Failed(f"AniDB ID not found for MyAnimeList ID: {check_id}")
             elif item_type == "local":                      raise NonExisting("No match in Plex")
             else:                                           raise NonExisting(f"Agent {item_type} not supported")
 
             if anidb_id:
-                if anidb_id in self._anidb_to_imdb:
-                    added = False
-                    for imdb in self._anidb_to_imdb[anidb_id]:
+                added = False
+                for anidb in anidb_id:
+                    for tmdb, tmdb_type in self.anidb_to_tmdb(anidb):
+                        added = True
+                        if tmdb_type == "movie":
+                            tmdb_movie_id.append(tmdb)
+                        if tmdb_type == "show":
+                            tmdb_show_id.append(tmdb)
+                    for imdb in self.anidb_to_imdb(anidb):
+                        imdb_id.append(imdb)
                         tmdb, tmdb_type = self.imdb_to_tmdb(imdb)
-                        if tmdb and tmdb_type == "movie":
-                            imdb_id.append(imdb)
-                            tmdb_id.append(int(tmdb))
+                        if tmdb:
                             added = True
-                    if added is False and anidb_id in self._anidb_to_tvdb:
-                        tvdb_id.append(int(self._anidb_to_tvdb[anidb_id]))
-                elif anidb_id in self._anidb_to_tvdb:
-                    tvdb_id.append(int(self._anidb_to_tvdb[anidb_id]))
-                else:
+                            if tmdb_type == "movie":
+                                tmdb_movie_id.append(tmdb)
+                            if tmdb_type == "show":
+                                tmdb_show_id.append(tmdb)
+                    for tvdb in self.anidb_to_tvdb(anidb):
+                        added = True
+                        tvdb_id.append(tvdb)
+                if not added:
                     raise Failed(f"AniDB: {anidb_id} not found")
             else:
-                if not tmdb_id and imdb_id:
+                if not tmdb_movie_id and imdb_id:
                     for imdb in imdb_id:
                         tmdb, tmdb_type = self.imdb_to_tmdb(imdb)
-                        if tmdb and ((tmdb_type == "movie" and library.is_movie) or (tmdb_type == "show" and library.is_show)):
-                            tmdb_id.append(int(tmdb))
+                        if tmdb_type == "movie":
+                            tmdb_movie_id.append(tmdb)
+                        if tmdb_type == "show":
+                            tmdb_show_id.append(tmdb)
 
-                if not imdb_id and tmdb_id and library.is_movie:
-                    for tmdb in tmdb_id:
+                if not imdb_id and tmdb_movie_id and library.is_movie:
+                    for tmdb in tmdb_movie_id:
                         imdb = self.tmdb_to_imdb(tmdb)
                         if imdb:
                             imdb_id.append(imdb)
 
-                if not tvdb_id and tmdb_id and library.is_show:
-                    for tmdb in tmdb_id:
+                if not tvdb_id and tmdb_show_id and library.is_show:
+                    for tmdb in tmdb_show_id:
                         tvdb = self.tmdb_to_tvdb(tmdb)
                         if tvdb:
                             tvdb_id.append(int(tvdb))
-                    if not tvdb_id:
-                        raise Failed(f"Unable to convert TMDb ID: {', '.join([str(t) for t in tmdb_id])} to TVDb ID")
 
             if not imdb_id and tvdb_id:
                 for tvdb in tvdb_id:
@@ -339,17 +495,20 @@ class Convert:
                     logger.info(f" Cache  |  {'^' if expired else '+'}  | {ids} | {item.title}")
                     self.config.Cache.update_guid_map(item.guid, cache_ids, imdb_in, expired, guid_type)
 
-            if (tmdb_id or imdb_id) and library.is_movie:
-                update_cache(tmdb_id, "TMDb", imdb_id, "movie")
-                return "movie", tmdb_id, imdb_id
+            if (tmdb_movie_id or imdb_id) and library.is_movie:
+                update_cache(tmdb_movie_id, "TMDb", imdb_id, "movie")
+                return "movie", tmdb_movie_id, "TMDb", imdb_id
             elif (tvdb_id or imdb_id) and library.is_show:
                 update_cache(tvdb_id, "TVDb", imdb_id, "show")
-                return "show", tvdb_id, imdb_id
-            elif anidb_id and (tmdb_id or imdb_id) and library.is_show:
-                update_cache(tmdb_id, "TMDb", imdb_id, "show_movie")
-                return "movie", tmdb_id, imdb_id
+                return "show", tvdb_id, "TVDb", imdb_id
+            elif anidb_id and tmdb_movie_id and library.is_show:
+                update_cache(tmdb_movie_id, "TMDb", imdb_id, "show_movie")
+                return "movie", tmdb_movie_id, "TMDb", imdb_id
+            elif tmdb_show_id and library.is_show:
+                update_cache(tmdb_show_id, "TMDb", imdb_id, "show_tmdb")
+                return "show", tmdb_show_id, "TMDb", imdb_id
             else:
-                logger.debug(f"TMDb: {tmdb_id}, IMDb: {imdb_id}, TVDb: {tvdb_id}")
+                logger.debug(f"TMDb: {tmdb_movie_id}, TMDb-Show: {tmdb_show_id}, IMDb: {imdb_id}, TVDb: {tvdb_id}")
                 raise Failed(f"No ID to convert")
         except Failed as e:
             logger.info(f'Mapping Error | {item.guid:<46} | {e} for "{item.title}"')
@@ -359,4 +518,4 @@ class Convert:
         except BadRequest:
             logger.stacktrace()
             logger.info(f'Mapping Error | {item.guid:<46} | Bad Request for "{item.title}"')
-        return None, None, None
+        return None, None, None, None

--- a/modules/convert.py
+++ b/modules/convert.py
@@ -30,38 +30,38 @@ class Convert:
                 for mal_id in util.get_list(ids["mal_id"], int_list=True):
                     if mal_id not in self._mal_to_anidb:
                         self._mal_to_anidb[mal_id] = [anidb_id]
-                    else
+                    else:
                         self._mal_to_anidb[mal_id].append(anidb_id)
                     if anidb_id not in self._anidb_to_mal:
                         self._anidb_to_mal[anidb_id] = [mal_id]
-                    else
+                    else:
                         self._anidb_to_mal[anidb_id].append(mal_id)
             if "anilist_id" in ids:
                 for anilist_id in util.get_list(ids["anilist_id"], int_list=True):
                     if anilist_id not in self._anilist_to_anidb:
                         self._anilist_to_anidb[anilist_id] = [anidb_id]
-                    else
+                    else:
                         self._anilist_to_anidb[anilist_id].append(anidb_id)
             if "imdb_id" in ids:
                 for imdb_id in util.get_list(ids["imdb_id"]):
                     if str(imdb_id).startswith("tt"):
                         if imdb_id not in self._imdb_to_anidb:
                             self._imdb_to_anidb[imdb_id] = [anidb_id]
-                        else
+                        else:
                             self._imdb_to_anidb[imdb_id].append(anidb_id)
                         if anidb_id not in self._anidb_to_imdb:
                             self._anidb_to_imdb[anidb_id] = [imdb_id]
-                        else
+                        else:
                             self._anidb_to_imdb[anidb_id].append(imdb_id)
             if "tvdb_id" in ids:
                 tvdb_id = int(ids["tvdb_id"])
                 if tvdb_id not in self._tvdb_to_anidb:
                     self._tvdb_to_anidb[tvdb_id] = [(anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"]))]
-                else
-                    self._tvdb_to_anidb[tvdb_id].append((anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"]))]
+                else:
+                    self._tvdb_to_anidb[tvdb_id].append((anidb_id, int(ids["tvdb_season"]), int(ids["tvdb_epoffset"])))
                 if anidb_id not in self._anidb_to_tvdb:
                     self._anidb_to_tvdb[anidb_id] = [tvdb_id]
-                else
+                else:
                     self._anidb_to_tvdb[anidb_id].append(tvdb_id)
         for anidb_id, ids in self._anidb_ids_automated["anime"].items():
             anidb_id = int(anidb_id)
@@ -69,40 +69,40 @@ class Convert:
                 for mal_id in util.get_list(ids["resources"]["MAL"], int_list=True):
                     if mal_id not in self._mal_to_anidb:
                         self._mal_to_anidb[mal_id] = [anidb_id]
-                    else
+                    else:
                         self._mal_to_anidb[mal_id].append(anidb_id)
                     if anidb_id not in self._anidb_to_mal:
                         self._anidb_to_mal[anidb_id] = [mal_id]
-                    else
+                    else:
                         self._anidb_to_mal[anidb_id].append(mal_id)
             if "IMDB" in ids["resources"]:
                 for imdb_id in util.get_list(ids["resources"]["IMDB"]):
                     if str(imdb_id).startswith("tt"):
                         if imdb_id not in self._imdb_to_anidb:
                             self._imdb_to_anidb[imdb_id] = [anidb_id]
-                        else
+                        else:
                             self._imdb_to_anidb[imdb_id].append(anidb_id)
                         if anidb_id not in self._anidb_to_imdb:
                             self._anidb_to_imdb[anidb_id] = [imdb_id]
-                        else
+                        else:
                             self._anidb_to_imdb[anidb_id].append(imdb_id)
             if "TMDB" in ids["resources"]:
                 for tmdb_id in util.get_list(ids["resources"]["TMDB"]):
                     if tmdb_id not in self._anidb_to_tmdb:
                         self._anidb_to_tmdb[tmdb_id] = [anidb_id]
-                    else
+                    else:
                         self._anidb_to_tmdb[tmdb_id].append(anidb_id)
                     if str(tmdb_id).startswith("movie/"):
                         tmdb_id = int(tmdb_id[6:])
                         if anidb_id not in self._anidb_to_tmdb:
                             self._anidb_to_tmdb[anidb_id] = [(tmdb_id, "movie")]
-                        else
+                        else:
                             self._anidb_to_tmdb[anidb_id].append((tmdb_id, "movie"))
                     elif str(tmdb_id).startswith("tv/"):
                         tmdb_id = int(tmdb_id[3:])
                         if anidb_id not in self._anidb_to_tmdb:
                             self._anidb_to_tmdb[anidb_id] = [(tmdb_id, "show")]
-                        else
+                        else:
                             self._anidb_to_tmdb[anidb_id].append((tmdb_id, "show"))
 
     def anidb_to_imdb(self, anidb_id, fail=False):

--- a/modules/library.py
+++ b/modules/library.py
@@ -28,6 +28,7 @@ class Library(ABC):
         self.overlay_files = []
         self.images_files = []
         self.movie_map = {}
+        self.tmdb_show_map = {}
         self.show_map = {}
         self.imdb_map = {}
         self.anidb_map = {}
@@ -372,14 +373,18 @@ class Library(ABC):
             if key not in self.movie_rating_key_map and key not in self.show_rating_key_map:
                 if isinstance(item, tuple):
                     item_type, check_id = self.config.Convert.scan_guid(guid)
-                    id_type, main_id, imdb_id, _ = self.config.Convert.ids_from_cache(key, guid, item_type, check_id, self)
+                    id_type, main_id, library_id, imdb_id, _ = self.config.Convert.ids_from_cache(key, guid, item_type, check_id, self)
                 else:
-                    id_type, main_id, imdb_id = self.config.Convert.get_id(item, self)
+                    id_type, main_id, library_id, imdb_id = self.config.Convert.get_id(item, self)
                 if main_id:
-                    if id_type == "movie":
-                        self.movie_rating_key_map[key] = main_id[0]
-                        util.add_dict_list(main_id, key, self.movie_map)
-                    elif id_type == "show":
+                    if library_id == "TMDb":
+                        if id_type == "movie":
+                            self.movie_rating_key_map[key] = main_id[0]
+                            util.add_dict_list(main_id, key, self.movie_map)
+                        elif id_type == "show":
+                            self.movie_rating_key_map[key] = main_id[0]
+                            util.add_dict_list(main_id, key, self.tmdb_show_map)
+                    if library_id == "TVDb" and id_type == "show":
                         self.show_rating_key_map[key] = main_id[0]
                         util.add_dict_list(main_id, key, self.show_map)
                 if imdb_id:

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -1598,6 +1598,8 @@ class MetadataFile(DataFile):
                         item.extend([self.library.fetch_item(i) for i in self.library.show_map[mapping_id]])
                     elif mapping_id in self.library.imdb_map:
                         item.extend([self.library.fetch_item(i) for i in self.library.imdb_map[mapping_id]])
+                    elif self.library.is_show and mapping_id in self.library.tmdb_show_map:
+                        item.extend([self.library.fetch_item(i) for i in self.library.tmdb_show_map[mapping_id]])
                     else:
                         logger.error(f"{self.type_str} Error: {id_type} ID not mapped")
                         continue

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -270,12 +270,16 @@ class Operations:
                 def get_anidb_id():
                     if item.ratingKey in reverse_anidb:
                         return reverse_anidb[item.ratingKey]
-                    elif tvdb_id in self.config.Convert._tvdb_to_anidb:
-                        return self.config.Convert._tvdb_to_anidb[tvdb_id]
-                    elif imdb_id in self.config.Convert._imdb_to_anidb:
-                        return self.config.Convert._imdb_to_anidb[imdb_id]
-                    else:
-                        return False
+                    else
+                        if tmdb_id:
+                            anidb_ids = (self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie) or [None])[0]
+                        if tvdb_id and not anidb_id:
+                            anidb_ids = (self.config.Convert.tvdb_to_anidb(tvdb_id) or [[None]])[0][0]
+                        if imdb_id and not anidb_id:
+                            anidb_ids = (self.config.Convert.imdb_to_anidb(imdb_id) or [None])[0]
+                        if not anidb_ids:
+                            return False
+                        return anidb_ids
 
                 _anidb_obj = None
                 def anidb_obj():
@@ -307,10 +311,10 @@ class Operations:
                             mal_id = reverse_mal[item.ratingKey]
                         elif not anidb_id:
                             logger.warning(f"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid: {item.guid}")
-                        elif anidb_id not in self.config.Convert._anidb_to_mal:
-                            logger.warning(f"Convert Warning: No MyAnimeList Found for AniDB ID: {anidb_id} of Guid: {item.guid}")
-                        else:
-                            mal_id = self.config.Convert._anidb_to_mal[anidb_id]
+                        else
+                            mal_id = (self.config.Convert.anidb_to_mal(anidb_id) or [None])[0]
+                            if not mal_id:
+                                logger.warning(f"Convert Warning: No MyAnimeList Found for AniDB ID: {anidb_id} of Guid: {item.guid}")
                         if mal_id:
                             try:
                                 _mal_obj = self.config.MyAnimeList.get_anime(mal_id)

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -272,9 +272,9 @@ class Operations:
                         return reverse_anidb[item.ratingKey]
                     else:
                         if tmdb_id:
-                            anidb_ids = self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie)
+                            anidb_ids = self.config.Convert.tmdb_to_anidb(tmdb_id, "movie" if self.library.is_movie else "show")
                             if anidb_ids:
-                                return anidb_ids[0]
+                                return anidb_ids[0][0]
                             else:
                                 logger.warning(f"No AniDB ID for TMDb ID: {tmdb_id}")
                         if tvdb_id:

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -270,7 +270,7 @@ class Operations:
                 def get_anidb_id():
                     if item.ratingKey in reverse_anidb:
                         return reverse_anidb[item.ratingKey]
-                    else
+                    else:
                         if tmdb_id:
                             anidb_ids = (self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie) or [None])[0]
                         if tvdb_id and not anidb_id:
@@ -311,7 +311,7 @@ class Operations:
                             mal_id = reverse_mal[item.ratingKey]
                         elif not anidb_id:
                             logger.warning(f"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid: {item.guid}")
-                        else
+                        else:
                             mal_id = (self.config.Convert.anidb_to_mal(anidb_id) or [None])[0]
                             if not mal_id:
                                 logger.warning(f"Convert Warning: No MyAnimeList Found for AniDB ID: {anidb_id} of Guid: {item.guid}")

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -272,14 +272,24 @@ class Operations:
                         return reverse_anidb[item.ratingKey]
                     else:
                         if tmdb_id:
-                            anidb_ids = (self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie) or [None])[0]
-                        if tvdb_id and not anidb_id:
-                            anidb_ids = (self.config.Convert.tvdb_to_anidb(tvdb_id) or [[None]])[0][0]
-                        if imdb_id and not anidb_id:
-                            anidb_ids = (self.config.Convert.imdb_to_anidb(imdb_id) or [None])[0]
-                        if not anidb_ids:
-                            return False
-                        return anidb_ids
+                            anidb_ids = self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie)
+                            if anidb_ids:
+                                return anidb_ids[0]
+                            else:
+                                logger.warning(f"No AniDB ID for TMDb ID: {tmdb_id}")
+                        if tvdb_id:
+                            anidb_ids = self.config.Convert.tvdb_to_anidb(tvdb_id)
+                            if anidb_ids:
+                                return anidb_ids[0][0]
+                            else:
+                                logger.warning(f"No AniDB ID for TVDb ID: {tvdb_id}")
+                        if imdb_id:
+                            anidb_ids = self.config.Convert.imdb_to_anidb(imdb_id)
+                            if anidb_ids:
+                                return anidb_ids[0]
+                            else:
+                                logger.warning(f"No AniDB ID for IMDb ID: {imdb_id}")
+                        return False
 
                 _anidb_obj = None
                 def anidb_obj():

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -360,12 +360,14 @@ class Overlays:
                                                 elif str(format_var).startswith(("anidb", "mal")):
                                                     anidb_id = None
                                                     if item.ratingKey in reverse_anidb:
-                                                        anidb_id = reverse_anidb[item.ratingKey]
-                                                    elif tvdb_id in self.config.Convert._tvdb_to_anidb:
-                                                        anidb_id = self.config.Convert._tvdb_to_anidb[tvdb_id]
-                                                    elif imdb_id in self.config.Convert._imdb_to_anidb:
-                                                        anidb_id = self.config.Convert._imdb_to_anidb[imdb_id]
-
+                                                        + = reverse_anidb[item.ratingKey]
+                                                    else:
+                                                        if tmdb_id:
+                                                            anidb_id = (self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie) or [None])[0]
+                                                        if tvdb_id and not anidb_id:
+                                                            anidb_id = (self.config.Convert.tvdb_to_anidb(tvdb_id) or [[None]])[0][0]
+                                                        if imdb_id and not anidb_id:
+                                                            anidb_id = (self.config.Convert.imdb_to_anidb(imdb_id) or [None])[0]
                                                     if str(format_var).startswith("anidb"):
                                                         if anidb_id:
                                                             anidb_obj = self.config.AniDB.get_anime(anidb_id)
@@ -382,10 +384,12 @@ class Overlays:
                                                             mal_id = reverse_mal[item.ratingKey]
                                                         elif not anidb_id:
                                                             raise Failed(f"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid: {item.guid}")
-                                                        elif anidb_id not in self.config.Convert._anidb_to_mal:
-                                                            raise Failed(f"Convert Warning: No MyAnimeList Found for AniDB ID: {anidb_id} of Guid: {item.guid}")
-                                                        else:
-                                                            mal_id = self.config.Convert._anidb_to_mal[anidb_id]
+                                                        else
+                                                            mal_id = self.config.Convert.anidb_to_mal(anidb_id)
+                                                            if mal_id:
+                                                                mal_id = mal_id[0]
+                                                            else:
+                                                                raise Failed(f"Convert Warning: No MyAnimeList Found for AniDB ID: {anidb_id} of Guid: {item.guid}")
                                                         if mal_id:
                                                             found_rating = self.config.MyAnimeList.get_anime(mal_id).score
                                             except Failed as err:

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -363,7 +363,7 @@ class Overlays:
                                                         anidb_id = reverse_anidb[item.ratingKey]
                                                     else:
                                                         if tmdb_id:
-                                                            anidb_id = (self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie) or [None])[0]
+                                                            anidb_id = (self.config.Convert.tmdb_to_anidb(tmdb_id, "movie" if self.library.is_movie else "show") or [[None]])[0][0]
                                                         if tvdb_id and not anidb_id:
                                                             anidb_id = (self.config.Convert.tvdb_to_anidb(tvdb_id) or [[None]])[0][0]
                                                         if imdb_id and not anidb_id:

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -360,7 +360,7 @@ class Overlays:
                                                 elif str(format_var).startswith(("anidb", "mal")):
                                                     anidb_id = None
                                                     if item.ratingKey in reverse_anidb:
-                                                        + = reverse_anidb[item.ratingKey]
+                                                        anidb_id = reverse_anidb[item.ratingKey]
                                                     else:
                                                         if tmdb_id:
                                                             anidb_id = (self.config.Convert.tmdb_to_anidb(tmdb_id, self.library.is_movie) or [None])[0]
@@ -384,7 +384,7 @@ class Overlays:
                                                             mal_id = reverse_mal[item.ratingKey]
                                                         elif not anidb_id:
                                                             raise Failed(f"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid: {item.guid}")
-                                                        else
+                                                        else:
                                                             mal_id = self.config.Convert.anidb_to_mal(anidb_id)
                                                             if mal_id:
                                                                 mal_id = mal_id[0]

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1084,7 +1084,7 @@ class Plex(Library):
             imdb_id = []
             if self.config.Cache:
                 cache_id, _, media_type, _ = self.config.Cache.query_guid_map(item.guid)
-                if cache_id:
+                if cache_id and media_type != "show_tmdb":
                     ids.extend([(t_id, "tmdb" if "movie" in media_type else "tvdb") for t_id in cache_id])
                     continue
             try:
@@ -1516,7 +1516,7 @@ class Plex(Library):
         imdb_id = None
         if self.config.Cache:
             t_id, i_id, guid_media_type, _ = self.config.Cache.query_guid_map(item.guid)
-            if t_id:
+            if t_id and guid_media_type != "show_tmdb":
                 if "movie" in guid_media_type:
                     tmdb_id = t_id[0]
                 else:


### PR DESCRIPTION
## Description

### Summary
Utilize an AniDB Scrapper library to automatically pull AniDB matching, rather than have to enter everything manually.

### Details
- Added some support for TMDb/tv
- Stopped using "private" methods outside of convert.py
- Switched `X_to_anidb` and `anidb_to_X` to consistently be 1 to Many.

### Related Changes

- https://github.com/Kometa-Team/Anime-IDs/pull/1
- https://github.com/Kometa-Team/Kometa/pull/2037

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code was submitted to the nightly branch of the repository.
