### PR TITLE
[franchise] remove deleted TMDb Collections from addons

### DIFF
--- a/defaults/movie/franchise.yml
+++ b/defaults/movie/franchise.yml
@@ -74,8 +74,6 @@ dynamic_collections:
         - 557495    # LEGO DC Super Hero Girls
       86066:      # Despicable Me
         - 544669    # Minions
-      9485:       # The Fast and the Furious
-        - 688042    # Hobbs & Shaw
       86115:      # Garfield
         - 373918    # Garfield CGI
       91361:      # Halloween
@@ -88,8 +86,6 @@ dynamic_collections:
         - 401562    # Teenage Mutant Ninja Turtles (Remake)
       111751:     # Texas Chainsaw Massacre
         - 425175    # Texas Chainsaw (Reboot)
-      2467:       # Tomb Raider
-        - 621142    # Tomb Raider (Reboot)
       748:        # X-Men
         - 453993    # The Wolverine
     title_override:

--- a/defaults/movie/franchise.yml
+++ b/defaults/movie/franchise.yml
@@ -98,6 +98,7 @@ dynamic_collections:
         105995: 336560    # Anaconda: Lake Placid vs. Anaconda
         176097: 14177     # Barbershop: Beauty Shop
         448150: 567604    # Deadpool: Once Upon a Deadpool
+        9485: 384018      # Fast & Furious: Hobbs & Shaw
         9735: 6466, 222724  # Friday the 13th: Freddy vs. Jason, Crystal Lake Memories: The Complete History of Friday the 13th
         386382: 326359, 460793  # Frozen: Frozen Fever, Olaf's Frozen Adventure
         2980: 43074 # Ghostbusters: Ghostbusters


### PR DESCRIPTION
Hobbs & Shaw and Tomb Raider (Reboot) collections no longer exist on TMDb, so addons are no longer needed.