### PR TITLE
Updating Award defaults to resolve some minor sorting issues

### DIFF
--- a/defaults/award/cesar.yml
+++ b/defaults/award/cesar.yml
@@ -16,7 +16,7 @@ collections:
       key: best
     template:
       - name: shared
-        sort: Cesar !
+        sort: César !
         allowed_libraries: movie
         image: award/cesar/winner
         translation_key: cesar_best

--- a/defaults/award/golden.yml
+++ b/defaults/award/golden.yml
@@ -16,7 +16,7 @@ collections:
       key: best_picture
     template:
       - name: shared
-        sort: Golden Globes !1
+        sort: Golden Globe !1
         allowed_libraries: movie
         image: award/golden/best_picture_winner
         translation_key: golden_picture

--- a/defaults/award/spirit.yml
+++ b/defaults/award/spirit.yml
@@ -16,7 +16,7 @@ collections:
       key: best
     template:
       - name: shared
-        sort: Spirit !1
+        sort: Independent Spirit Awards !1
         allowed_libraries: movie
         image: award/spirit/winner
         translation_key: spirit_best

--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -606,5 +606,5 @@ overlays:
     template: [name: flags, name: standard]
 
   bambara:
-    variables: {key: bm, text: BM, weight: 12, country: ma}
+    variables: {key: bm, text: BM, weight: 12, country: ml}
     template: [name: flags, name: standard]

--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -604,3 +604,7 @@ overlays:
   lingala:
     variables: {key: ln, text: LN, weight: 11, country: cd}
     template: [name: flags, name: standard]
+
+  bambara:
+    variables: {key: bm, text: BM, weight: 12, country: ma}
+    template: [name: flags, name: standard]

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -77,6 +77,7 @@ Supported library types: Movie & Show
 | Tamil                    | `ta`  | `30`   | `in`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Urdu                     | `ur`  | `20`   | `pk`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Vietnamese               | `vi`  | `15`   | `vn`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Bambara                  | `bm`  | `12`   | `ml`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Lingala                  | `ln`  | `11`   | `cd`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Wolof                    | `wo`  | `10`   | `sn`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Mayan                    | `myn` | `8`    | `mx`         |  :fontawesome-solid-circle-xmark:{ .red }  |


### PR DESCRIPTION
## Description

Minor fixes to the sorting of awards collections

### Issues Fixed or Closed

Sort value of the:

- Independent Spirit Awards collection changed from Spirit to Independent Spirit Awards
- César awards collection changed from Cesar to César
- Golden Globes awards collection changed from Golden Globes to Golden Globe

...to match the sort order of the respective awards' 'Years' collections

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [Yes] My code was submitted to the nightly branch of the repository.
