### PR TITLE
Update settings.md to fix tvdb_language example

### DIFF
--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -756,7 +756,7 @@ The available setting attributes which can be set at each level are outlined bel
         
         ```yaml
         settings:
-          tvdb_language: en
+          tvdb_language: eng
         ```
 
 ??? blank "`ignore_ids` - List of TMDb/TVDb IDs to ignore.<a class="headerlink" href="#ignore-ids" title="Permanent link">¶</a>"


### PR DESCRIPTION
ISO 639-2 codes are 3 digits. example was en and now eng

## Description

ISO 639-2 codes are 3 digits. example was en and now eng

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
- [] Updated the CHANGELOG with the changes
