### PR TITLE
Multiple GitHub Action updates

### DIFF
--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -175,3 +175,16 @@ jobs:
           avatar_url: ${{ vars.BOT_IMAGE }}
           author: ${{ vars.REPO_NAME }} Nightly Release
           author_icon_url: ${{ vars.RELEASE_IMAGE }}
+
+  cleanup-tags:
+    runs-on: ubuntu-latest
+    needs: [ increment-build, verify-changes, docker-build-nightly, commit-notification ]
+    if: ${{ success() }}
+    steps:
+      - name: remove tag
+        run: |
+            HUB_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d "{\"username\": \"${{ secrets.DOCKER_HUB_USERNAME }}\", \"password\": \"${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}\"}" https://hub.docker.com/v2/users/login/ | jq -r .token)
+            curl -i -X DELETE \
+            -H "Accept: application/json" \
+            -H "Authorization: JWT $HUB_TOKEN" \
+            https://hub.docker.com/v2/repositories/kometateam/kometa/tags/${{ github.head_ref }}/

--- a/.github/workflows/increment-build.yml
+++ b/.github/workflows/increment-build.yml
@@ -1,7 +1,7 @@
 name: Increment Build
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [nightly]
     types: [closed]
 
@@ -39,7 +39,12 @@ jobs:
             version="${value%-build*}"
           
             if [[ "$value" == *"-"* ]]; then
-                build_value="$((${value#*-build} + 1))"
+                value2="${value#*-build}"
+                if [[ "$value2" == *"."* ]]; then
+                    build_value="$((${value2%.*} + 1))"
+                else
+                    build_value="$((${value2} + 1))"
+                fi
             else
                 build_value="1"
             fi

--- a/.github/workflows/release-develop.yml
+++ b/.github/workflows/release-develop.yml
@@ -2,6 +2,10 @@ name: Develop Release
 
 on:
   workflow_dispatch:
+    inputs:
+      build_number:
+        description: Choose the build number to push develop to.
+        default: 0
 
 jobs:
   release-develop:
@@ -23,10 +27,10 @@ jobs:
           fetch-depth: 0
 
       - name: Fast Forward Develop
+        id: forward
         run: |
             value=$(cat VERSION)
             develop_hash=$(git rev-parse HEAD)
-            next_build="${{ vars.DEVELOP_BUILD }}"
           
             if [[ "$value" == *"-"* ]]; then
                 develop_build="$((${value#*-build}))"
@@ -35,7 +39,6 @@ jobs:
             fi
           
             git checkout origin/nightly
-            
             value=$(cat VERSION)
           
             if [[ "$value" == *"-"* ]]; then
@@ -46,16 +49,25 @@ jobs:
           
             echo "DEVELOP_BUILD: '${develop_build}'"
             echo "NIGHTLY_BUILD: '${nightly_build}'"
-            echo "NEXT_BUILD: '${next_build}'"
-            
-            if (( next_build <= develop_build )); then
-                echo "::error::NEXT_BUILD variable (${next_build}) must be greater than DEVELOP_BUILD (${develop_build})"
+          
+            if ! [[ ${{ github.event.inputs.build_number }} =~ ^[0-9]+$ ]]; then
+                echo "::error::BUILD_NUMBER (${{ github.event.inputs.build_number }}) must be a number"
                 exit 1
-            elif (( next_build > nightly_build )); then
-                echo "::error::NEXT_BUILD variable (${next_build}) must be less than or equal to NIGHTLY_BUILD (${nightly_build})"
+            elif [[ "${{ github.event.inputs.build_number }}" == "0" ]]; then
+                next_build="${nightly_build}"
+            elif (( ${{ github.event.inputs.build_number }} <= develop_build )); then
+                echo "::error::BUILD_NUMBER (${{ github.event.inputs.build_number }}) must be greater than DEVELOP_BUILD (${develop_build})"
                 exit 1
+            elif (( ${{ github.event.inputs.build_number }} > nightly_build )); then
+                echo "::error::BUILD_NUMBER (${{ github.event.inputs.build_number }}) must be less than or equal to NIGHTLY_BUILD (${nightly_build})"
+                exit 1
+            else
+                next_build="${{ github.event.inputs.build_number }}"
             fi
-            
+          
+            echo "NEXT_BUILD: '${next_build}'"
+            echo "build=next_build" >> $GITHUB_OUTPUT
+          
             while : ; do
                 value=$(cat VERSION)
           
@@ -86,7 +98,7 @@ jobs:
         if: success()
         with:
           webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
-          title: "${{ vars.REPO_NAME }} develop pushed to Build ${{ vars.DEVELOP_BUILD }}: ${{ vars.TEXT_SUCCESS }}"
+          title: "${{ vars.REPO_NAME }} develop pushed to Build ${{ steps.forward.outputs.build }}: ${{ vars.TEXT_SUCCESS }}"
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
           color: ${{ vars.COLOR_SUCCESS }}
           username: ${{ vars.BOT_NAME }}
@@ -100,7 +112,7 @@ jobs:
         with:
           webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
           message: ${{ vars.BUILD_FAILURE_ROLE }}
-          title: "${{ vars.REPO_NAME }} develop pushed to Build ${{ vars.DEVELOP_BUILD }}: ${{ vars.TEXT_FAILURE }}"
+          title: "${{ vars.REPO_NAME }} develop pushed to Build ${{ steps.forward.outputs.build }}: ${{ vars.TEXT_FAILURE }}"
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
           color: ${{ vars.COLOR_FAILURE }}
           username: ${{ vars.BOT_NAME }}

--- a/.github/workflows/release-master.yml
+++ b/.github/workflows/release-master.yml
@@ -2,6 +2,15 @@ name: Master Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_type:
+        type: choice
+        description: Choose which type of release to perform.
+        options:
+          - major
+          - minor
+          - patch
+        default: patch
 
 jobs:
   release-master:
@@ -26,21 +35,25 @@ jobs:
         run: |
             value=$(cat VERSION)
             version="${value%-build*}"
-            next_version="${{ vars.NEXT_VERSION }}"
             echo "CURRENT_VERSION: '${version}'"
-            echo "NEXT_VERSION: '${next_version}'"
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$version"
           
-            if [[ "$version" == "$next_version" ]]; then
-                echo "::error::NEXT_VERSION variable (${next_version}) must be incremented"
-                exit 1
+            if [[ "${{ github.event.inputs.release_type }}" == "major" ]]; then
+                NEW_VERSION="$((MAJOR+1)).0.0"
+            elif [[ "${{ github.event.inputs.release_type }}" == "minor" ]]; then
+                NEW_VERSION="${MAJOR}.$((MINOR+1)).0"
+            else
+                NEW_VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"
             fi
           
-            echo "$next_version" > "VERSION"
+            echo "NEW_VERSION='${NEW_VERSION}'"
+            echo "new_ver=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "$NEW_VERSION" > "VERSION"
           
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
             git add VERSION
-            git commit -m "Kometa Release ${next_version}"
+            git commit -m "Kometa Release ${NEW_VERSION}"
             git push origin nightly
             git push origin refs/heads/nightly:refs/heads/develop
             git push origin refs/heads/nightly:refs/heads/main
@@ -50,7 +63,7 @@ jobs:
         if: success()
         with:
           webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
-          title: "${{ vars.REPO_NAME }} master release ${{ vars.NEXT_VERSION }}: ${{ vars.TEXT_SUCCESS }}"
+          title: "${{ vars.REPO_NAME }} master release ${{ steps.release.outputs.new_ver }}: ${{ vars.TEXT_SUCCESS }}"
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
           color: ${{ vars.COLOR_SUCCESS }}
           username: ${{ vars.BOT_NAME }}
@@ -64,7 +77,7 @@ jobs:
         with:
           webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
           message: ${{ vars.BUILD_FAILURE_ROLE }}
-          title: "${{ vars.REPO_NAME }} master release ${{ vars.NEXT_VERSION }}: ${{ vars.TEXT_FAILURE }}"
+          title: "${{ vars.REPO_NAME }} master release ${{ steps.release.outputs.new_ver }}: ${{ vars.TEXT_FAILURE }}"
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
           color: ${{ vars.COLOR_FAILURE }}
           username: ${{ vars.BOT_NAME }}

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -27,12 +27,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Spellcheck
-        uses: rojopolis/spellcheck-github-actions@0.36.0
+        uses: rojopolis/spellcheck-github-actions@0.37.0
 
   docker-build-pull:
     runs-on: ubuntu-latest
     needs: [ validate-pull ]
-    if: contains(github.event.pull_request.labels.*.name, 'docker')
+    if: contains(github.event.pull_request.labels.*.name, 'docker') || contains(github.event.pull_request.labels.*.name, 'testers')
     steps:
 
       - name: Check Out Repo
@@ -95,3 +95,36 @@ jobs:
           avatar_url: ${{ vars.BOT_IMAGE }}
           author: ${{ vars.DOCKER_NAME }}
           author_icon_url: ${{ vars.DOCKER_IMAGE }}
+
+  notify-testers:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'labeled' && github.event.label.name == 'tester'
+    steps:
+
+      - name: Get Description
+        id: get-description
+        run: |
+          body="${{ github.event.pull_request.body }}"
+          body=$(echo "$body" | sed -n '/## Description/,/## Issues Fixed or Closed/{/## Description/b;/## Issues Fixed or Closed/b;p}')
+          body=$(echo $body|tr -d '\n')
+          echo "description=$body" >> $GITHUB_OUTPUT
+
+      - name: Discord Testers Notification
+        uses: Kometa-Team/discord-notifications@master
+        with:
+          webhook_id_token: ${{ secrets.TESTERS_WEBHOOK }}
+          message: "The Kometa team are requesting <@&917323027438510110> to assist with testing an upcoming feature/bug fix.
+
+                    * For Local Git pull and checkout the `${{ github.head_ref }}` branch 
+
+                    * For Docker use the `kometateam/kometa:${{ github.head_ref }}` image to do your testing
+
+                    Please report back either here or on the original GitHub Pull Request"
+          title: ${{ github.event.pull_request.title }}
+          description: ${{ steps.get-description.outputs.description }}
+          url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/pull/${{ github.event.number }}
+          color: ${{ vars.COLOR_SUCCESS }}
+          username: ${{ vars.BOT_NAME }}
+          avatar_url: ${{ vars.BOT_IMAGE }}
+          author: ${{ vars.GIT_NAME }}
+          author_icon_url: ${{ vars.GIT_IMAGE }}

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -1,7 +1,7 @@
 name: Validate Pull Request
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled]
 
 jobs:
@@ -33,12 +33,55 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ validate-pull ]
     if: contains(github.event.pull_request.labels.*.name, 'docker') || contains(github.event.pull_request.labels.*.name, 'testers')
+    outputs:
+      commit-msg: ${{ steps.update-version.outputs.commit-msg }}
+      version: ${{ steps.update-version.outputs.version }}
     steps:
+
+      - name: Create App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_TOKEN }}
 
       - name: Check Out Repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Update VERSION File
+        id: update-version
+        run: |
+            value=$(cat VERSION)
+            old_msg=$(git log -1 HEAD --pretty=format:%s)
+            echo "commit-msg=${old_msg}" >> $GITHUB_OUTPUT
+            version="${value%-build*}"
+      
+            if [[ "$value" == *"-"* ]]; then
+                value2="${value#*-build}"
+                if [[ "$value2" == *"."* ]]; then
+                    build_value="${value2%.*}"
+                    part_value="$((${value2#*.} + 1))"
+                else
+                    build_value="${value#*-build}"
+                    part_value="1"
+                fi
+            else
+                build_value="0"
+                part_value="1"
+            fi
+      
+            new_value="${version}-build${build_value}.${part_value}"
+            echo "version=${new_value}" >> $GITHUB_OUTPUT
+      
+            echo "$new_value" > "VERSION"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add VERSION
+            git commit -m "Part: ${part_value}"
+            git push
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -122,6 +165,27 @@ jobs:
                     Please report back either here or on the original GitHub Pull Request"
           title: ${{ github.event.pull_request.title }}
           description: ${{ steps.get-description.outputs.description }}
+          url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/pull/${{ github.event.number }}
+          color: ${{ vars.COLOR_SUCCESS }}
+          username: ${{ vars.BOT_NAME }}
+          avatar_url: ${{ vars.BOT_IMAGE }}
+          author: ${{ vars.GIT_NAME }}
+          author_icon_url: ${{ vars.GIT_IMAGE }}
+
+  update-testers:
+    runs-on: ubuntu-latest
+    needs: [ docker-build-pull ]
+    if: github.event.action == 'synchronize' && github.event.label.name == 'tester'
+    steps:
+
+      - name: Discord Testers Notification
+        uses: Kometa-Team/discord-notifications@master
+        with:
+          webhook_id_token: ${{ secrets.TESTERS_WEBHOOK }}
+          message: "New Commit Pushed to `${{ github.head_ref }}`: ${{ needs.docker-build-pull.outputs.version }}
+          
+                    ${{ needs.docker-build-pull.outputs.commit-msg }}"
+          description: ${{ needs.docker-build-pull.outputs.commit-msg }}
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/pull/${{ github.event.number }}
           color: ${{ vars.COLOR_SUCCESS }}
           username: ${{ vars.BOT_NAME }}

--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -15,7 +15,7 @@ jobs:
           echo "Base Repo: ${{ github.event.pull_request.base.repo.full_name }}"
           echo "Base Ref: ${{ github.base_ref }}"
           echo "Head Repo: ${{ github.event.pull_request.head.repo.full_name }}"
-          echo "Head Ref: ${{ github.head_ref }}"
+          echo "Head Ref: ${{ github.event.pull_request.head.ref }}"
 
       - name: Check Base Branch
         if: github.base_ref == 'master' || github.base_ref == 'develop'
@@ -105,10 +105,10 @@ jobs:
           context: ./
           file: ./Dockerfile
           build-args: |
-            "BRANCH_NAME=${{ github.head_ref }}"
+            "BRANCH_NAME=${{ github.event.pull_request.head.ref }}"
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: kometateam/kometa:${{ github.head_ref }}
+          tags: kometateam/kometa:${{ github.event.pull_request.head.ref }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -117,7 +117,7 @@ jobs:
         if: success()
         with:
           webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
-          title: "${{ vars.REPO_NAME }} ${{ github.head_ref }}: ${{ vars.TEXT_SUCCESS }}"
+          title: "${{ vars.REPO_NAME }} ${{ github.event.pull_request.head.ref }}: ${{ vars.TEXT_SUCCESS }}"
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
           color: ${{ vars.COLOR_SUCCESS }}
           username: ${{ vars.BOT_NAME }}
@@ -131,7 +131,7 @@ jobs:
         with:
           webhook_id_token: ${{ secrets.BUILD_WEBHOOK }}
           message: ${{ vars.BUILD_FAILURE_ROLE }}
-          title: "${{ vars.REPO_NAME }} ${{ github.head_ref }}: ${{ vars.TEXT_FAILURE }}"
+          title: "${{ vars.REPO_NAME }} ${{ github.event.pull_request.head.ref }}: ${{ vars.TEXT_FAILURE }}"
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/actions/runs/${{ github.run_id }}
           color: ${{ vars.COLOR_FAILURE }}
           username: ${{ vars.BOT_NAME }}
@@ -158,9 +158,9 @@ jobs:
           webhook_id_token: ${{ secrets.TESTERS_WEBHOOK }}
           message: "The Kometa team are requesting <@&917323027438510110> to assist with testing an upcoming feature/bug fix.
 
-                    * For Local Git pull and checkout the `${{ github.head_ref }}` branch 
+                    * For Local Git pull and checkout the `${{ github.event.pull_request.head.ref }}` branch 
 
-                    * For Docker use the `kometateam/kometa:${{ github.head_ref }}` image to do your testing
+                    * For Docker use the `kometateam/kometa:${{ github.event.pull_request.head.ref }}` image to do your testing
 
                     Please report back either here or on the original GitHub Pull Request"
           title: ${{ github.event.pull_request.title }}
@@ -182,9 +182,7 @@ jobs:
         uses: Kometa-Team/discord-notifications@master
         with:
           webhook_id_token: ${{ secrets.TESTERS_WEBHOOK }}
-          message: "New Commit Pushed to `${{ github.head_ref }}`: ${{ needs.docker-build-pull.outputs.version }}
-          
-                    ${{ needs.docker-build-pull.outputs.commit-msg }}"
+          message: "New Commit Pushed to `${{ github.event.pull_request.head.ref }}`: ${{ needs.docker-build-pull.outputs.version }}"
           description: ${{ needs.docker-build-pull.outputs.commit-msg }}
           url: https://github.com/Kometa-Team/${{ vars.REPO_NAME }}/pull/${{ github.event.number }}
           color: ${{ vars.COLOR_SUCCESS }}

--- a/modules/request.py
+++ b/modules/request.py
@@ -44,7 +44,13 @@ class Version:
         self.full = version_string.replace("develop", "build")
         version_parts = self.full.split("-build")
         self.main = version_parts[0]
-        self.build = int(version_parts[1]) if len(version_parts) > 1 else 0
+        self.build = 0
+        self.part = 0
+        if len(version_parts) > 1:
+            sub_parts = str(version_parts[1]).split(".")
+            self.build = int(sub_parts[0])
+            if len(sub_parts) > 1:
+                self.parts = int(sub_parts[1])
 
     def __bool__(self):
         return self.full != "Unknown"


### PR DESCRIPTION
## Description

Now Removes PR Docker Tags when the PR is Merged
Changes `release-develop` and `release-master` to using workflow inputs
Adds Version Parts to docker PRs so you can tell which commit the log is from
Adds Tester Notification Option 
Allow Forked PRs to run PR actions

## Type of Change

Please delete options that are not relevant.

- [x] Infrastructure change (changes related to the github repo, build process, or the like)
