### PR TITLE
Adding Afrikaans to Languages overlay

### DIFF
--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -608,3 +608,7 @@ overlays:
   bambara:
     variables: {key: bm, text: BM, weight: 12, country: ml}
     template: [name: flags, name: standard]
+
+  afrikaans:
+    variables: {key: af, text: AF, weight: 13, country: za}
+    template: [name: flags, name: standard]

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -88,6 +88,10 @@ Supported library types: Movie & Show
 | Zulu                     | `zu`  | `3`    | `za`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Luxembourgish            | `lb`  | `2`    | `lu`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Mossi                    | `mos` | `1`    | `bf`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Lingala                  | `ln`  | `11`   | `cd`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Bambara                  | `bm`  | `12`   | `ml`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Afrikaans                | `af`  | `13`   | `af`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+
 
 ??? tip "Square Style (click to expand)"
 


### PR DESCRIPTION
## Description

Added Afrikaans to overlays/languages.yml
Updated docs/overlays/languages.md with Afrikaans; and Lingala and Bambara, which were neglected in the previous update

## Type of Change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
- [] Documentation change (non-code changes affecting only the wiki)

## Checklist

Please delete options that are not relevant.

- [Yes] Updated Documentation to reflect changes
