### PR TITLE
letterboxd allowed_libraries

### DIFF
--- a/defaults/chart/letterboxd.yml
+++ b/defaults/chart/letterboxd.yml
@@ -11,6 +11,7 @@ external_templates:
   template_variables:
     collection_section: "020"
     image: chart/<<mapping_name_encoded>>
+    allowed_libraries: movie
     sort_title: <<sort_prefix>><<collection_section>><<pre>><<order_<<key>>>>LB_<<sort>>
 
 templates:


### PR DESCRIPTION
## Description

Adding `allowed_libraries: movie` for all letterboxd default collections

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete options that are not relevant.

- [x] Updated Documentation to reflect changes
Wiki already notes "Supported Library Types: Movie"
