### PR TITLE
fix: issues with input_id being a list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,5 +28,6 @@ Fixes #2028 TMDb IDs were being ignored on the report
 Fixes a bug when parsing a comma-separated string of ints
 Fixes `imdb_chart` only getting 25 results
 Fixes `imdb_list` not returning items
+Fixes #2135 AniDB Builder type conversion error
 
 Various other Minor Fixes

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -2295,16 +2295,29 @@ class CollectionBuilder:
                                 logger.warning(e)
                                 continue
                 elif id_type == "tmdb" and not self.parts_collection:
-                    input_id = int(input_id)
-                    if input_id not in self.ignore_ids:
-                        found = False
-                        for pl_library in self.libraries:
-                            if input_id in pl_library.movie_map:
-                                found = True
-                                rating_keys = pl_library.movie_map[input_id]
-                                break
-                        if not found and input_id not in self.missing_movies:
-                            self.missing_movies.append(input_id)
+                    if isinstance(input_id, list):
+                        for a_id in input_id:
+                            input_id = int(a_id)
+                            if input_id not in self.ignore_ids:
+                                found = False
+                                for pl_library in self.libraries:
+                                    if input_id in pl_library.movie_map:
+                                        found = True
+                                        rating_keys = pl_library.movie_map[input_id]
+                                        break
+                                if not found and input_id not in self.missing_movies:
+                                    self.missing_movies.append(input_id)
+                    else:
+                        input_id = int(input_id)
+                        if input_id not in self.ignore_ids:
+                            found = False
+                            for pl_library in self.libraries:
+                                if input_id in pl_library.movie_map:
+                                    found = True
+                                    rating_keys = pl_library.movie_map[input_id]
+                                    break
+                            if not found and input_id not in self.missing_movies:
+                                self.missing_movies.append(input_id)
                 elif id_type == "tvdb_season" and (self.builder_level == "season" or self.playlist):
                     tvdb_id, season_num = input_id.split("_")
                     tvdb_id = int(tvdb_id)


### PR DESCRIPTION
Fixing an issue when using MAL and/or anilist

## Description

This change is to fix an issue that has been going on for about a month or so which seemed to have been cause to a list of ids being treated as a single id

```
| Traceback (most recent call last):                                                                 |
|   File "//kometa.py", line 812, in run_collection                                                  |
|     builder.filter_and_save_items(builder.gather_ids(method, value))                               |
|   File "/modules/builder.py", line 2298, in filter_and_save_items                                  |
|     input_id = int(input_id)                                                                       |
|                ^^^^^^^^^^^^^                                                                       |
| TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'       |
|                                                                                                    |
| Unknown Error: int() argument must be a string, a bytes-like object or a real number, not 'list'   |
```

https://github.com/Kometa-Team/Kometa/issues/2135

### Issues Fixed or Closed

- Fixes #(2135)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [x] Updated the CHANGELOG with the changes
