### PR TITLE
Fix TVDB Episode Ordering resulting in critical error

### DIFF
--- a/modules/plex.py
+++ b/modules/plex.py
@@ -213,7 +213,7 @@ episode_sorting_options = {"default": -1, "oldest": 0, "newest": 1}
 keep_episodes_options = {"all": 0, "5_latest": 5, "3_latest": 3, "latest": 1, "past_3": -3, "past_7": -7, "past_30": -30}
 delete_episodes_options = {"never": 0, "day": 1, "week": 7, "month": 30, "refresh": 100}
 season_display_options = {"default": -1, "show": 0, "hide": 1}
-episode_ordering_options = {"default": None, "tmdb_aired": "tmdbAiring", "tvdb_aired": "aired", "tvdb_dvd": "dvd", "tvdb_absolute": "absolute"}
+episode_ordering_options = {"default": None, "tmdb_aired": "tmdbAiring", "tvdb_aired": "tvdbAiring", "tvdb_dvd": "tvdbDvd", "tvdb_absolute": "tvdbAbsolute"}
 plex_languages = ["default", "ar-SA", "ca-ES", "cs-CZ", "da-DK", "de-DE", "el-GR", "en-AU", "en-CA", "en-GB", "en-US",
                   "es-ES", "es-MX", "et-EE", "fa-IR", "fi-FI", "fr-CA", "fr-FR", "he-IL", "hi-IN", "hu-HU", "id-ID",
                   "it-IT", "ja-JP", "ko-KR", "lt-LT", "lv-LV", "nb-NO", "nl-NL", "pl-PL", "pt-BR", "pt-PT", "ro-RO",


### PR DESCRIPTION
It appears that the Plex API now prepends the episode ordering with `tvdb`.

This PR addresses the below issue:

![image](https://github.com/user-attachments/assets/d53dcc48-d19e-4c7d-b5cb-975cadbf13c5)

`[kometa.py:747] [CRITICAL] | dvd not found in ['', 'tmdbAiring', 'tvdbAiring', 'tvdbDvd', 'tvdbAbsolute']`

Discussed on Discord here:

https://discord.com/channels/822460010649878528/1273643019790188555
