### PR TITLE
[Docs] Fix CSS preventing page titles appearing in search results

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,5 @@
 #
 
-<style>
-  .md-typeset h1,
-  .md-content__button {
-    display: none;
-  }
-</style>
-
 <center>
 ![Logo](assets/logo-full.png)
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -25,6 +25,10 @@
     --md-code-hl-comment-color: #8b949e;
 }
 
+.md-content h1, .md-content__button {
+    display: none;
+}
+
 table tr td code {
   white-space: pre;
 }


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/8e56b1cf-267d-45e6-850e-1098df02fe56)


After:

![image](https://github.com/user-attachments/assets/12b01821-5f7b-4eb3-87e5-cf0ac2c6f5f2)
