### PR TITLE
Letterboxd filters additional detail

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 # New Features
 Added the `character` search option to the `imdb_search` builder
 
+# Defaults
+Fixed incorrect content rating mappings in various Default files
+
 # Bug Fixes
 Fixed the `cast` search option for the `imdb_search` builder
 Fixes #2258 `imdb_list` sort was not being parsed correctly
-Fixed incorrect content rating mappings in various Default files
+Fixes `letterboxd_list` rating filter to use a 1-10 rating vs 1-100 to reflect how letterboxd ratings work on their website

--- a/docs/files/builders/letterboxd.md
+++ b/docs/files/builders/letterboxd.md
@@ -48,6 +48,7 @@ You can add different filters directly to this builder.
 | `note`<sup>2</sup>   | **Description:** Search for the specified value in the note. The note is the list owner's note not site wide note.<br>**Values:**  Any String                                                               |
 
 <sup>1</sup> These filters only work if the URL is to the List View of the Letterboxd list (i.e. it should have `/detail/` in the url) or to an account's Reviews (i.e. it should have `/USERNAME/films/reviews/` in the url)
+
 <sup>2</sup> This filters only work if the URL is to the List View of the Letterboxd list. (i.e. it should have `/detail/` in the url)
 
 ```yaml

--- a/docs/files/builders/letterboxd.md
+++ b/docs/files/builders/letterboxd.md
@@ -40,14 +40,15 @@ collections:
 
 You can add different filters directly to this builder.
 
-| Filter Attribute     | Description                                                                                                                                                    |
-|:---------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `limit`              | **Description:** Max number of items per returned.<br>**Values:**  number greater than `1`                                                                     |
-| `rating`<sup>1</sup> | **Description:** Search for the specified rating range. The rating is the list owner's rating not site wide rating.<br>**Values:**  range of int i.e. `80-100` |
-| `year`<sup>1</sup>   | **Description:** Search for the specified year range.<br>**Values:**  range of int i.e. `1990-1999`                                                            |
-| `note`<sup>1</sup>   | **Description:** Search for the specified value in the note. The note is the list owner's note not site wide note.<br>**Values:**  Any String                  |
+| Filter Attribute     | Description                                                                                                                                                                                               |
+|:---------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `limit`              | **Description:** Max number of items per returned.<br>**Values:**  number greater than `1`                                                                                                                |
+| `rating`<sup>1</sup> | **Description:** Search for the specified rating range. The rating is the list owner's rating not site wide rating.<br>**Values:**  range of int i.e. `7-10` (convert Lettboxd stars to a 10 point scale) |
+| `year`<sup>1</sup>   | **Description:** Search for the specified year range.<br>**Values:**  range of int i.e. `1990-1999`                                                                                                       |
+| `note`<sup>2</sup>   | **Description:** Search for the specified value in the note. The note is the list owner's note not site wide note.<br>**Values:**  Any String                                                             |
 
-<sup>1</sup> These filters only work if the URL is to the List View of the Letterboxd list. (i.e. it should have `/detail/` in the url)
+<sup>1</sup> These filters only work if the URL is to the List View of the Letterboxd list (i.e. it should have `/detail/` in the url) or to an account's Reviews (i.e. it should have `/USERNAME/films/reviews/` in the url)
+<sup>2</sup> This filters only work if the URL is to the List View of the Letterboxd list. (i.e. it should have `/detail/` in the url)
 
 ```yaml
 collections:

--- a/docs/files/builders/letterboxd.md
+++ b/docs/files/builders/letterboxd.md
@@ -40,12 +40,12 @@ collections:
 
 You can add different filters directly to this builder.
 
-| Filter Attribute     | Description                                                                                                                                                                                               |
-|:---------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `limit`              | **Description:** Max number of items per returned.<br>**Values:**  number greater than `1`                                                                                                                |
-| `rating`<sup>1</sup> | **Description:** Search for the specified rating range. The rating is the list owner's rating not site wide rating.<br>**Values:**  range of int i.e. `7-10` (convert Lettboxd stars to a 10 point scale) |
-| `year`<sup>1</sup>   | **Description:** Search for the specified year range.<br>**Values:**  range of int i.e. `1990-1999`                                                                                                       |
-| `note`<sup>2</sup>   | **Description:** Search for the specified value in the note. The note is the list owner's note not site wide note.<br>**Values:**  Any String                                                             |
+| Filter Attribute     | Description                                                                                                                                                                                                 |
+|:---------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `limit`              | **Description:** Max number of items per returned.<br>**Values:**  number greater than `1`                                                                                                                  |
+| `rating`<sup>1</sup> | **Description:** Search for the specified rating range. The rating is the list owner's rating not site wide rating.<br>**Values:**  range of int i.e. `8-10` (convert Letterboxd stars to a 10 point scale) |
+| `year`<sup>1</sup>   | **Description:** Search for the specified year range.<br>**Values:**  range of int i.e. `1990-1999`                                                                                                         |
+| `note`<sup>2</sup>   | **Description:** Search for the specified value in the note. The note is the list owner's note not site wide note.<br>**Values:**  Any String                                                               |
 
 <sup>1</sup> These filters only work if the URL is to the List View of the Letterboxd list (i.e. it should have `/detail/` in the url) or to an account's Reviews (i.e. it should have `/USERNAME/films/reviews/` in the url)
 <sup>2</sup> This filters only work if the URL is to the List View of the Letterboxd list. (i.e. it should have `/detail/` in the url)

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -88,7 +88,7 @@ class Letterboxd:
                 "url": util.parse(err_type, "url", letterboxd_dict, methods=dict_methods, parent="letterboxd_list").strip(),
                 "limit": util.parse(err_type, "limit", letterboxd_dict, methods=dict_methods, datatype="int", parent="letterboxd_list", default=0) if "limit" in dict_methods else 0,
                 "note": util.parse(err_type, "note", letterboxd_dict, methods=dict_methods, parent="letterboxd_list") if "note" in dict_methods else None,
-                "rating": util.parse(err_type, "rating", letterboxd_dict, methods=dict_methods, datatype="int", parent="letterboxd_list", maximum=100, range_split="-") if "rating" in dict_methods else None,
+                "rating": util.parse(err_type, "rating", letterboxd_dict, methods=dict_methods, datatype="int", parent="letterboxd_list", maximum=10, range_split="-") if "rating" in dict_methods else None,
                 "year": util.parse(err_type, "year", letterboxd_dict, methods=dict_methods, datatype="int", parent="letterboxd_list", minimum=1000, maximum=3000, range_split="-") if "year" in dict_methods else None
             }
             if not final["url"].startswith(base_url):


### PR DESCRIPTION
## Description

- Clarified that the Letterboxd `rating` filter users a 10 point scale, not 100 (i.e. 40-100 would never capture anything, 1-40 would always capture everything)
- Added an annotation to note filters which work with `/USERNAME/films/reviews/` URLs

## Type of Change

- [x] Documentation change (non-code changes affecting only the wiki)

## Checklist

- [x] Updated Documentation to reflect changes

Test yml below and log attached.

```
collections: 

#### /USERNAME/films/reviews/ URLs
  Fennessey Reviews Control:
    letterboxd_list_details: 
      url: https://letterboxd.com/seanfennessey/films/reviews/
      limit: 60

  Fennessey Reviews Rating:
    letterboxd_list_details: 
      url: https://letterboxd.com/seanfennessey/films/reviews/
      limit: 60
      rating: 9-10

  Fennessey Reviews Year:
    letterboxd_list_details: 
      url: https://letterboxd.com/seanfennessey/films/reviews/
      limit: 60
      year: 2014-2015

#### Integer Test
  Fennessey Alice 9-10:
    letterboxd_list_details: 
      url: https://letterboxd.com/seanfennessey/list/movies-alice-has-seen/detail/
      limit: 60
      rating: 9-10

  Fennessey Alice 11-100:
    letterboxd_list_details: 
      url: https://letterboxd.com/seanfennessey/list/movies-alice-has-seen/detail/
      limit: 60
      rating: 11-100

  Fennessey Reviews 11-100:
    letterboxd_list_details: 
      url: https://letterboxd.com/seanfennessey/films/reviews/
      limit: 60
      rating: 11-100
```
[meta.log](https://github.com/user-attachments/files/17267791/meta.log)