### PR TITLE
omdb returns "N/A" when content rating isn't available

### DIFF
--- a/modules/operations.py
+++ b/modules/operations.py
@@ -499,7 +499,13 @@ class Operations:
                                 break
                             try:
                                 if option == "omdb":
-                                    new_rating = omdb_obj().content_rating # noqa
+                                    _rating = omdb_obj().content_rating # noqa
+                                    if not _rating:
+                                        new_rating = None
+                                    elif _rating == "N/A":
+                                        new_rating = None
+                                    else:
+                                        new_rating = _rating
                                 elif option == "mdb":
                                     _rating = mdb_obj().content_rating # noqa
                                     new_rating = _rating if _rating else None


### PR DESCRIPTION
omdb returns "N/A" when content rating isn't available, this terminates the alternate source tries, and also populates the Plex database with useless "N/A" values (these display as "A" on the Plex Web view.

## Description

This change checks for "N/A" received from OMDb and replaces it with `None`; thus allowing the alternative rating sources (if specified) to have a go.

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
