### PR TITLE
Remove duplicate style keys from IMDB collection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,3 +23,4 @@ Fixes an issue where episode overlays sometimes wouldn't be added
 Fixes an issue with IMDb Parental Labels not working
 Fixes an issue where OMDb returned `N/A` as the content rating
 Fixes an issue where `plex_collectionless` doesn't work if the item was added to a collection in the same run
+Fixes an issue causing IMDB collection to fail due to duplicate keys

--- a/defaults/chart/imdb.yml
+++ b/defaults/chart/imdb.yml
@@ -20,7 +20,6 @@ collections:
     variables:
       style: color
       key: popular
-      style: color
     template:
       - name: imdb_chart
         chart: popular
@@ -33,7 +32,6 @@ collections:
     variables:
       style: color
       key: top
-      style: color
     template:
       - name: imdb_chart
         chart: top
@@ -46,7 +44,6 @@ collections:
     variables:
       style: color
       key: lowest
-      style: color
     imdb_chart: lowest_rated
     template:
       - name: shared


### PR DESCRIPTION
## Description

Remove the second style keys from the imdb collection yaml

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Updated the CHANGELOG with the changes
