### PR TITLE
Add Start Time, End Time and Run Time to Summary of run.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,4 +37,5 @@ Modifies default value presentation for default metadata files.
 Fixes an issue causing IMDB collection to fail due to duplicate keys
 Removed Blog from the Navigation due to lack of time for updating/maintaining it
 Fixes #2354 by updating version of tmdbapi dependency
+Added Start Time, End Time and Run Time to Summary of run. Date of Start/End Time now only displays if the Start and End are on different dates.
 

--- a/kometa.py
+++ b/kometa.py
@@ -428,7 +428,14 @@ def start(attrs):
             logger.stacktrace()
             logger.error(f"Report Error: {e}")
 
-        logger.separator(f"Finished {start_type}Run\n{version_line}\nFinished: {end_time.strftime('%H:%M:%S %Y-%m-%d')} Run Time: {run_time}")
+        if start_time.date() == end_time.date():
+            start_str = start_time.strftime('%H:%M:%S')
+            end_str = end_time.strftime('%H:%M:%S')
+        else:
+            start_str = start_time.strftime('%H:%M:%S %Y-%m-%d')
+            end_str = end_time.strftime('%H:%M:%S %Y-%m-%d')
+
+        logger.separator(f"Finished {start_type}Run\n{version_line}\nStart Time: {start_str}        End Time: {end_str}        Run Time: {run_time}")
         logger.remove_main_handler()
     except Exception as e:
         logger.stacktrace()


### PR DESCRIPTION
## Description

Adds Start Time, End Time and Run Time to Summary of run. 

Date of Start/End Time now only displays if the Start and End are on different dates.

If the Start/End is on the same day:

![image](https://github.com/user-attachments/assets/aaf86091-8320-416d-8d28-3a46d48a702f)

If the Start/End is on a different day (i.e. overnight run):

![image](https://github.com/user-attachments/assets/b1df8f85-e1f4-46b0-b909-3b1a13e19cea)

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

Please delete options that are not relevant.

- Updated the CHANGELOG with the changes
