### PR TITLE
Add trailing slash to `custom_repo` examples

### DIFF
--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -143,7 +143,7 @@ The location types are outlined as follows:
     ???+ example "Example"
 
         This is assuming the `custom_repo` setting is 
-        `https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12`.
+        `https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12/`.
         
         ```yaml
         libraries:

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -979,7 +979,7 @@ The available setting attributes which can be set at each level are outlined bel
     ???+ note
     
         Ensure you are using the raw GitHub link (i.e. 
-        https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12)
+        https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12/)
 
     <hr style="margin: 0px;">
     

--- a/docs/config/settings.md
+++ b/docs/config/settings.md
@@ -995,7 +995,7 @@ The available setting attributes which can be set at each level are outlined bel
         
         ```yaml
         settings:
-          custom_repo: https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12
+          custom_repo: https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12/
         ```
 
 ??? blank "`overlay_artwork_filetype` - Used to control the filetype used with overlay images.<a class="headerlink" href="#overlay-filetype" title="Permanent link">¶</a>"


### PR DESCRIPTION
## Description

A couple of examples for `custom_repo` omitted the required trailing slash. 

The following yaml (abbreviated):

```
libraries:

  Kometa-Oscars:
    collection_files:
    - repo: People

settings:
  custom_repo: https://github.com/Kometa-Team/Community-Configs/tree/master/meisnate12
```

Would result in:

```
URL Error: No file found at https://raw.githubusercontent.com/Kometa-Team/Community-Configs/master/meisnate12People.yml
```

## Type of Change

Please delete options that are not relevant.

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

Please delete options that are not relevant.

- [X] Updated Documentation to reflect changes
