### PR TITLE
Fix `Prime Video Defaults` when watch region is `NL`

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -212,6 +212,7 @@ namespace
 NAS
 natively
 nitsua
+NL
 Nokmål
 NOSUCHLIBRARY
 notifiarr

--- a/.github/ISSUE_TEMPLATE/2.defaults.yml
+++ b/.github/ISSUE_TEMPLATE/2.defaults.yml
@@ -2,7 +2,7 @@ name: Kometa Default Issue
 description: Post here if there is an issue with the Kometa defaults or for missing images for Kometa default overlays or posters.
 title: '[Defaults]: '
 labels: ['defaults']
-assignees: ['meisnate12', 'bullmoose20', 'YozoraXCII']
+assignees: ['meisnate12', 'bullmoose20', 'YozoraXCII', 'chazlarson']
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/3.docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/3.docs_request.yml
@@ -1,7 +1,7 @@
 name: Wiki Issue
 description: A request to update or improve Kometa's wiki
 labels: ['status:not-yet-viewed', 'documentation']
-assignees: 'meisnate12'
+assignees: ['meisnate12', 'chazlarson', 'YozoraXCII']
 
 body:
   - type: markdown

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,7 +17,7 @@ Added "undoing changes" page
 
 # Defaults
 Fixed incorrect content rating mappings in various Default files
-Fixes an issue where Prime Video overlays/collections would not be built when the `watch_region` is set to AU
+Fixes an issue where Prime Video overlays/collections would not be built when the `watch_region` is set to AU or NL
 Fixes an issue where Rotten Tomatoes Verified Hot wasn't working
 Updates `Alien vs Predator` and `X-Men` lists to new lists which include most recent releases
 Adds `style` template variable for Streaming and Chart defaults, allowing user to choose color or white logos for collection posters

--- a/defaults/both/streaming.yml
+++ b/defaults/both/streaming.yml
@@ -37,7 +37,7 @@ templates:
       final_tmdb_key:
         default: <<tmdb_key>>
         conditions:
-          - region: [CA, AU]
+          - region: [CA, AU, NL]
             tmdb_key: [9]
             value: 119
 

--- a/defaults/overlays/streaming.yml
+++ b/defaults/overlays/streaming.yml
@@ -93,7 +93,7 @@ templates:
       final_tmdb_key:
         default: <<tmdb_key>>
         conditions:
-          - region: [CA, AU]
+          - region: [CA, AU, NL]
             tmdb_key: [9]
             value: 119
       allowed_streaming:


### PR DESCRIPTION
## Description

Fixes `Prime Video` collection and overlays when watch region is set to `NL`

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
Updated the CHANGELOG with the changes
