### PR TITLE
Fixes `custom_repo` when URL does not end in a `/` character

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,3 +38,4 @@ Fixes an issue causing IMDB collection to fail due to duplicate keys
 Removed Blog from the Navigation due to lack of time for updating/maintaining it
 Fixes #2354 by updating version of tmdbapi dependency
 Added Start Time, Finished and Run Time to Summary of run.
+Fixed an issue where custom repositories would not work correctly if the URL did not end in a trailing `/` character.

--- a/modules/config.py
+++ b/modules/config.py
@@ -488,6 +488,8 @@ class ConfigFile:
             repo = self.general["custom_repo"]
             if "https://github.com/" in repo:
                 repo = repo.replace("https://github.com/", "https://raw.githubusercontent.com/").replace("/tree/", "/")
+                if not repo.endswith("/"):
+                    repo += "/"
             self.custom_repo = repo
 
         if not self.general["verify_ssl"]:


### PR DESCRIPTION
## Description

Fixed an issue where custom repositories would not work correctly if the URL did not end in a trailing `/` character.

### Issues Fixed or Closed

- Fixes #2369 (Supercedes 2369)

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete options that are not relevant.

- Updated the CHANGELOG with the changes
