### PR TITLE
Drop support for Python 3.8 (Minimum Version now 3.9)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ Update pillow requirement to 11.0.0
 Update psutil requirement to 6.1.0
 Update setuptools requirement to 75.3.0
 
+# Important Changes
+Python 3.8 is no longer supported. The minimum version of Python required is now 3.9.
+
 # New Features
 Added the `character` search option to the `imdb_search` builder
 Added ability to use Show-level ratings at the season and episode level for Overlays if the original source does not provide ratings at the season or episode level. This is accomplished using (Special Text Variables)[https://kometa.wiki/en/latest/files/overlays/#special-text-variables] but is not yet available for the `Ratings` Defaults file.

--- a/docs/kometa/install/local.md
+++ b/docs/kometa/install/local.md
@@ -89,7 +89,7 @@ First let's check if it's installed already [type this into your terminal]:
 python3 --version
 ```
 
-If this doesn't return a version between `3.9` and `3.12`, you'll need to installed a supprted version of Python.
+If this doesn't return a version between `3.9` and `3.12`, you'll need to installed a supported version of Python.
 
 === ":fontawesome-brands-linux: Linux"
 

--- a/docs/kometa/install/local.md
+++ b/docs/kometa/install/local.md
@@ -11,7 +11,7 @@ This article will walk you through getting Kometa set up and running.  It will c
 
 The specific steps you will be taking:
 
-1. Verify that Python 3.8 or better is installed and install it if not
+1. Verify that Python 3.9 or better is installed and install it if not
 2. Verify that the Git tools are installed and install them if not
 3. Use `git` to retrieve the code
 4. Install requirements [extra bits of code required for Kometa]
@@ -89,7 +89,7 @@ First let's check if it's installed already [type this into your terminal]:
 python3 --version
 ```
 
-If this doesn't return `3.8.0` or higher, you'll need to get Python 3 installed.
+If this doesn't return `3.9.0` or higher, you'll need to get Python 3 installed.
 
 === ":fontawesome-brands-linux: Linux"
 
@@ -109,11 +109,11 @@ If this doesn't return `3.8.0` or higher, you'll need to get Python 3 installed.
     ```
     Depending on the version of Python, you may need to use one or the other.  If this works, you're ready to go, jsut substitute `python` for `python3` in the couple places it appears below.
     
-    Go to http://www.python.org/download and download the next-to-latest minor version of Python for Windows in 32 or 64-bit as appropriate for your system [probably 64-bit].  As this is written, that's 3.10, while the latest is 3.11.
+    Go to http://www.python.org/download and download the next-to-latest minor version of Python for Windows in 32 or 64-bit as appropriate for your system [probably 64-bit].  As this is written, that's 3.10, while the latest is 3.12.
     
     #### Why the next-to-latest?
     
-    There is one dependency [`lxml`] that lags behind new Python releases; this will cause a failure when installing requirements in a moment if the newest Python version is too new [at time of writing the current is 3.11, and the requirements install fails on the lxml library].  You can avoid this by using the next-to-latest release.  At some point this will no longer be a problem, but that is outside the control of Kometa.
+    There is one dependency [`lxml`] that lags behind new Python releases; this will cause a failure when installing requirements in a moment if the newest Python version is too new [at time of writing the current is 3.12, and the requirements install fails on the lxml library].  You can avoid this by using the next-to-latest release.  At some point this will no longer be a problem, but that is outside the control of Kometa.
     
     Once downloaded, run the installer.  Tick “Add to path” checkbox at the bottom and click “Install Now”.
     

--- a/docs/kometa/install/local.md
+++ b/docs/kometa/install/local.md
@@ -11,7 +11,7 @@ This article will walk you through getting Kometa set up and running.  It will c
 
 The specific steps you will be taking:
 
-1. Verify that the version of Python installed is between 3.9 and 3.12.
+1. Verify that the version of Python installed is between 3.9 and 3.13.
 2. Verify that the Git tools are installed and install them if not
 3. Use `git` to retrieve the code
 4. Install requirements [extra bits of code required for Kometa]
@@ -89,7 +89,7 @@ First let's check if it's installed already [type this into your terminal]:
 python3 --version
 ```
 
-If this doesn't return a version between `3.9` and `3.12`, you'll need to installed a supported version of Python.
+If this doesn't return a version between `3.9` and `3.13`, you'll need to installed a supported version of Python.
 
 === ":fontawesome-brands-linux: Linux"
 
@@ -109,7 +109,7 @@ If this doesn't return a version between `3.9` and `3.12`, you'll need to instal
     ```
     Depending on the version of Python, you may need to use one or the other.  If this works, you're ready to go, just substitute `python` for `python3` in the couple places it appears below.
     
-    Go to http://www.python.org/download and download Python 3.12.  **Kometa has not been tested and may be non-functional on any version of Python beyond 3.12**
+    Go to http://www.python.org/download and download Python 3.13.  **Kometa has not been tested and may be non-functional on any version of Python beyond 3.13**
     
     Once downloaded, run the installer.  Tick “Add to path” checkbox at the bottom and click “Install Now”.
     

--- a/docs/kometa/install/local.md
+++ b/docs/kometa/install/local.md
@@ -11,7 +11,7 @@ This article will walk you through getting Kometa set up and running.  It will c
 
 The specific steps you will be taking:
 
-1. Verify that Python 3.9 or better is installed and install it if not
+1. Verify that the version of Python installed is between 3.9 and 3.12.
 2. Verify that the Git tools are installed and install them if not
 3. Use `git` to retrieve the code
 4. Install requirements [extra bits of code required for Kometa]
@@ -89,7 +89,7 @@ First let's check if it's installed already [type this into your terminal]:
 python3 --version
 ```
 
-If this doesn't return `3.9.0` or higher, you'll need to get Python 3 installed.
+If this doesn't return a version between `3.9` and `3.12`, you'll need to installed a supprted version of Python.
 
 === ":fontawesome-brands-linux: Linux"
 
@@ -107,13 +107,9 @@ If this doesn't return `3.9.0` or higher, you'll need to get Python 3 installed.
     ```
     python --version
     ```
-    Depending on the version of Python, you may need to use one or the other.  If this works, you're ready to go, jsut substitute `python` for `python3` in the couple places it appears below.
+    Depending on the version of Python, you may need to use one or the other.  If this works, you're ready to go, just substitute `python` for `python3` in the couple places it appears below.
     
-    Go to http://www.python.org/download and download the next-to-latest minor version of Python for Windows in 32 or 64-bit as appropriate for your system [probably 64-bit].  As this is written, that's 3.10, while the latest is 3.12.
-    
-    #### Why the next-to-latest?
-    
-    There is one dependency [`lxml`] that lags behind new Python releases; this will cause a failure when installing requirements in a moment if the newest Python version is too new [at time of writing the current is 3.12, and the requirements install fails on the lxml library].  You can avoid this by using the next-to-latest release.  At some point this will no longer be a problem, but that is outside the control of Kometa.
+    Go to http://www.python.org/download and download Python 3.12.  **Kometa has not been tested and may be non-functional on any version of Python beyond 3.12**
     
     Once downloaded, run the installer.  Tick “Add to path” checkbox at the bottom and click “Install Now”.
     

--- a/docs/kometa/install/overview.md
+++ b/docs/kometa/install/overview.md
@@ -37,7 +37,7 @@ If you are using unRAID, Kubernetes, QNAP, or Synology refer to the following ba
 
 ## Local Install Overview
 
-Kometa is compatible with Python 3.8 through 3.11. Later versions may function but are untested.
+Kometa is compatible with Python 3.9 through 3.12. Later versions may function but are untested.
 
 These are high-level steps which assume the user has knowledge of python and pip, and the general ability to troubleshoot issues. For a detailed step-by-step walkthrough, refer to the [Local Walkthrough](local.md) guide.
 

--- a/docs/kometa/install/overview.md
+++ b/docs/kometa/install/overview.md
@@ -37,7 +37,7 @@ If you are using unRAID, Kubernetes, QNAP, or Synology refer to the following ba
 
 ## Local Install Overview
 
-Kometa is compatible with Python 3.9 through 3.12. Later versions may function but are untested.
+Kometa is compatible with Python 3.9 through 3.12. **Kometa has not been tested and may be non-functional on any version of Python beyond 3.12**
 
 These are high-level steps which assume the user has knowledge of python and pip, and the general ability to troubleshoot issues. For a detailed step-by-step walkthrough, refer to the [Local Walkthrough](local.md) guide.
 

--- a/docs/kometa/install/overview.md
+++ b/docs/kometa/install/overview.md
@@ -37,7 +37,7 @@ If you are using unRAID, Kubernetes, QNAP, or Synology refer to the following ba
 
 ## Local Install Overview
 
-Kometa is compatible with Python 3.9 through 3.12. **Kometa has not been tested and may be non-functional on any version of Python beyond 3.12**
+Kometa is compatible with Python 3.9 through 3.13. **Kometa has not been tested and may be non-functional on any version of Python beyond 3.13**
 
 These are high-level steps which assume the user has knowledge of python and pip, and the general ability to troubleshoot issues. For a detailed step-by-step walkthrough, refer to the [Local Walkthrough](local.md) guide.
 

--- a/kometa.py
+++ b/kometa.py
@@ -4,8 +4,8 @@ from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime
 from modules.logs import MyLogger
 
-if sys.version_info[0] != 3 or sys.version_info[1] < 8:
-    print("Version Error: Version: %s.%s.%s incompatible please use Python 3.8+" % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
+if sys.version_info[0] != 3 or sys.version_info[1] < 9:
+    print("Python Version %s.%s.%s has been detected and is not supported. Kometa requires a minimum of Python 3.9.0." % (sys.version_info[0], sys.version_info[1], sys.version_info[2]))
     sys.exit(0)
 
 try:
@@ -16,7 +16,7 @@ try:
     from plexapi.exceptions import NotFound
     from plexapi.video import Show, Season
 except (ModuleNotFoundError, ImportError) as ie:
-    print(f"Requirements Error: Requirements are not installed ({ie})")
+    print(f"Requirements Error: Requirements are not installed.\nPlease follow the documentation for instructions on installing requirements. ({ie})")
     sys.exit(0)
 
 system_versions = {
@@ -185,7 +185,7 @@ if run_args["run-collections"]:
     run_args["collections-only"] = True
 
 if run_args["width"] < 90 or run_args["width"] > 300:
-    print(f"Argument Error: width argument invalid: {run_args['width']} must be an integer between 90 and 300 using the default 100")
+    print(f"Argument Error: width argument invalid: {run_args['width']} must be an integer between 90 and 300. Using the default value of 100")
     run_args["width"] = 100
 
 if run_args["config"] and os.path.exists(run_args["config"]):

--- a/modules/config.py
+++ b/modules/config.py
@@ -945,9 +945,9 @@ class ConfigFile:
                                 elif op == "metadata_backup":
                                     default_path = os.path.join(default_dir, f"{str(library_name)}_Metadata_Backup.yml")
                                     if "path" not in input_dict:
-                                        logger.warning(f"Config Warning: path attribute not found using default: {default_path}")
+                                        logger.warning(f"Config Warning: path attribute not found. Using the default value: {default_path}")
                                     elif "path" in input_dict and not input_dict["path"]:
-                                        logger.warning(f"Config Warning: path attribute blank using default: {default_path}")
+                                        logger.warning(f"Config Warning: path attribute not found. Using the default value: {default_path}")
                                     else:
                                         default_path = input_dict["path"]
                                     section_final[op] = {

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -1169,7 +1169,7 @@ class MetadataFile(DataFile):
                         elif "title_format" in methods:
                             title_format = util.parse("Config", "title_format", dynamic, parent=map_name, methods=methods, default=default_title_format)
                         if "<<key_name>>" not in title_format and "<<title>>" not in title_format:
-                            logger.error(f"Config Error: <<key_name>> not in title_format: {title_format} using default: {default_title_format}")
+                            logger.error(f"Config Error: <<key_name>> not in title_format: {title_format}. Using the default value: {default_title_format}")
                             title_format = default_title_format
                         if "post_format_override" in methods:
                             methods["title_override"] = methods.pop("post_format_override")


### PR DESCRIPTION
## Description

As plexapi has now dropped support for Python 3.8 (see #2325), it makes sense for Kometa to follow suit to avoid any compatibility issues for users. This PR makes the minimum supported version 3.9.0, and documentation has been updated to reflect this.

Also removed text about using "next-to-latest" versions of Python, instead instructing users to use a version between 3.9 and 3.13 (which I have tested is functional as part of this update)

## Type of Change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation change (non-code changes affecting only the wiki)

## Checklist

Please delete options that are not relevant.

- Updated Documentation to reflect changes
- Updated the CHANGELOG with the changes
