### PR TITLE
[Defaults] Update Network and Streaming to include `Paramount+ with Showtime`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,6 +21,7 @@ Fixes an issue where Prime Video overlays/collections would not be built when th
 Fixes an issue where Rotten Tomatoes Verified Hot wasn't working
 Updates `Alien vs Predator` and `X-Men` lists to new lists which include most recent releases
 Adds `style` template variable for Streaming and Chart defaults, allowing user to choose color or white logos for collection posters
+Added `Paramount+ with Showtime` to both `Paramount+` and `Showtime` for Networks and Streaming, any existing weighting is unchanged.
 
 # Bug Fixes
 Fixed the `cast` search option for the `imdb_search` builder

--- a/defaults/both/streaming.yml
+++ b/defaults/both/streaming.yml
@@ -139,7 +139,7 @@ dynamic_collections:
         hulu: 15
         netflix: 8
         now: 39
-        paramount: 531
+        paramount: 531|1770
         peacock: 387
         amazon: 9
         showtime: 37

--- a/defaults/overlays/network.yml
+++ b/defaults/overlays/network.yml
@@ -739,7 +739,7 @@ overlays:
 
   Paramount+:
     variables: { weight: 10}
-    template: [name: standard, name: networks]
+    template: [name: standard, {name: networks, search: [Paramount+, Paramount+ with Showtime]}]
 
   PBS:
     variables: { weight: 10}
@@ -831,7 +831,7 @@ overlays:
 
   Showtime:
     variables: { weight: 10}
-    template: [name: standard, name: networks]
+    template: [name: standard, {name: networks, search: [Showtime, Paramount+ with Showtime]}]
 
   Shudder:
     variables: { weight: 10}

--- a/defaults/overlays/streaming.yml
+++ b/defaults/overlays/streaming.yml
@@ -148,7 +148,7 @@ overlays:
     template: [name: standard, name: mdb_streaming]
 
   Paramount:
-    variables: {key: paramount, tmdb_key: 531, weight: 90}
+    variables: {key: paramount, tmdb_key: 531|1770, weight: 90}
     template: [name: standard, name: mdb_streaming]
 
   AppleTV:
@@ -160,7 +160,7 @@ overlays:
     template: [name: standard, name: mdb_streaming]
 
   Showtime:
-    variables: {key: showtime, tmdb_key: 37, weight: 60}
+    variables: {key: showtime, tmdb_key: 531|1770, weight: 60}
     template: [name: standard, name: mdb_streaming]
 
   discovery+:

--- a/defaults/show/network.yml
+++ b/defaults/show/network.yml
@@ -455,8 +455,12 @@ dynamic_collections:
         - Network 10
       Nickelodeon:
         - Nick at Nite
+      Paramount+:
+        - Paramount+ with Showtime
       ReelzChannel:
         - Reelz
+      Showtime:
+        - Paramount+ with Showtime
       Sky:
         - Sky One
         - Sky Atlantic
@@ -481,7 +485,6 @@ dynamic_collections:
         - sky Travel
         - Sky Vision
         - Sky News Weather Channel
-        - SkyShowtime
       Smithsonian:
         - Smithsonian Channel
         - Smithsonian Earth


### PR DESCRIPTION
## Description

Includes `Paramount+ with Showtime` in both `Paramount+` and `Showtime` for Networks and Streaming. 

No changes to weighting set, meaning Paramount+ will likely win in most scenarios unless user has set specific weighting.

### Issues Fixed or Closed

Closes #2367

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

Please delete options that are not relevant.

- Updated Documentation to reflect changes
- Updated the CHANGELOG with the changes
