### PR TITLE
Friendlier tab message

### DIFF
--- a/modules/request.py
+++ b/modules/request.py
@@ -259,7 +259,11 @@ class YAML:
                     with open(self.path, encoding="utf-8") as fp:
                         self.data = self.yaml.load(fp)
         except ruamel.yaml.error.YAMLError as e:
-            e = str(e).replace("\n", "\n      ")
+            if "found character '\\t' that cannot start any token" in e.problem:
+                e = "Tabs are not allowed in YAML files; only spaces are allowed"
+            else:
+                e = str(e).replace("\n", "\n      ")
+            
             raise Failed(f"YAML Error: {e}")
         except Exception as e:
             raise Failed(f"YAML Error: {e}")

--- a/modules/request.py
+++ b/modules/request.py
@@ -260,7 +260,8 @@ class YAML:
                         self.data = self.yaml.load(fp)
         except ruamel.yaml.error.YAMLError as e:
             if "found character '\\t' that cannot start any token" in e.problem:
-                e = "Tabs are not allowed in YAML files; only spaces are allowed"
+                location = f"{e.args[3].name}; line {e.args[3].line + 1} column {e.args[3].column + 1}"
+                e = f"Tabs are not allowed in YAML files; only spaces are allowed.\nfirst tab character found at:\n{location}"
             else:
                 e = str(e).replace("\n", "\n      ")
             


### PR DESCRIPTION
## Description

Replaces:
```
| YAML Error: while scanning for the next token                                                      |
|       found character '\t' that cannot start any token                                             |
|         in "/home/chaz/kometa/config/test-config.yml", line 6, column 1                            |
```
with:
```
| YAML Error: Tabs are not allowed in YAML files; only spaces are allowed.                           |
| first tab character found at:                                                                      |
| /home/chaz/kometa/config/test-config.yml; line 6 column 1                                          |
```

Probably this can be generalized more if there are other things like this that can be expressed in a more user-friendly way.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
