### PR TITLE
Typo in Library Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ Transform your media library with Kometa and discover its full potential! Connec
 -  We're constantly working on new features to take your library management experience to the next level.
 -  Consider sponsoring the project to allow us to continue building great features for you!
 
-## Demo Video
-
-The below YouTube video has been created by one of our community members to showcase some of the things that Kometa can do for you. 
-
-[![Kometa](https://img.youtube.com/vi/nTfCUtKWTYI/0.jpg)](https://www.youtube.com/watch?v=nTfCUtKWTYI "Kometa")
-
 ## Example Kometa Libraries 
 
 Here are some examples of the things you can achieve using Kometa!

--- a/docs/config/libraries.md
+++ b/docs/config/libraries.md
@@ -405,7 +405,7 @@ The available attributes for each library are as follows:
             collection_files:
               - default: imdb
             settings:
-              asset_directory: config/asssets/Movies
+              asset_directory: config/assets/Movies
         ```
 
 ??? blank "`plex` - Used to override global [`plex` attributes](plex.md) for this library only.<a class="headerlink" href="#plex" title="Permanent link">¶</a>"


### PR DESCRIPTION
## Description

Found a type on a code box at the following URL:  https://kometa.wiki/en/latest/config/libraries/?h=asset_directory#attributes

Updated "asssets" to "assets". One too many Ss.

### Issues Fixed or Closed

Typo in code block.

## Type of Change

Please delete options that are not relevant.

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

Please delete options that are not relevant.

- [X] Updated Documentation to reflect changes
