### PR TITLE
Fail when user puts definitions in the config.yml

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -220,8 +220,25 @@ class ConfigFile:
         replace_attr(self.data, "save_missing", "plex")
         if self.data["libraries"]:
             for library in self.data["libraries"]:
+
                 if not self.data["libraries"][library]:
                     continue
+
+                def fail_on_definition(found_this):
+                    raise Failed(f"The '{library}' library config contains {found_this} definitions. These belong in external YAML files, not in the config.yml.")
+                if "collections" in self.data["libraries"][library]:
+                    fail_on_definition("collections")
+                if "dynamic_collections" in self.data["libraries"][library]:
+                    fail_on_definition("dynamic_collections")
+                if "metadata" in self.data["libraries"][library]:
+                    fail_on_definition("metadata")
+                if "overlays" in self.data["libraries"][library]:
+                    fail_on_definition("overlays")
+                if "templates" in self.data["libraries"][library]:
+                    fail_on_definition("templates")
+                if "playlists" in self.data["libraries"][library]:
+                    fail_on_definition("playlists")
+
                 if "metadata_path" in self.data["libraries"][library]:
                     logger.warning("Config Warning: metadata_path has been deprecated and split into collection_files and metadata_files, Please visit the wiki to learn more about this transition.")
                     path_dict = self.data["libraries"][library].pop("metadata_path")


### PR DESCRIPTION
## Description

Fails when the user puts collection or other definitions directly in config.yml, as:

```yaml
libraries:
  Many-Movies:
    collections:
      Remove Streaming Label:
        build_collection: false
        item_label.remove: Apple TV+ Movies
        plex_search:
          all:
            label: Apple TV+ Movies

    collection_files:
      - default: streaming
...
```

This change makes that a critical error:
```
|========================================= Critical Summary =========================================|
|                                                                                                    |
| Count | Message                                                                                    |
|=======|============================================================================================|
|     1 | The 'Many-Movies' library config contains collections definitions. These belong in external YAML files, not in the config.yml. |
```

## Type of Change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
