### PR TITLE
Correct typo libraries.md

### DIFF
--- a/docs/config/libraries.md
+++ b/docs/config/libraries.md
@@ -405,7 +405,7 @@ The available attributes for each library are as follows:
             collection_files:
               - default: imdb
             settings:
-              asset_directory: config/asssets/Movies
+              asset_directory: config/assets/Movies
         ```
 
 ??? blank "`plex` - Used to override global [`plex` attributes](plex.md) for this library only.<a class="headerlink" href="#plex" title="Permanent link">¶</a>"


### PR DESCRIPTION
## Description

I found a type on a code box at the following URL: https://kometa.wiki/en/latest/config/libraries/?h=asset_directory#attributes

Updated "asssets" to "assets". One too many Ss.

## Type of Change

Please delete options that are not relevant.

- [X] Documentation change (non-code changes affecting only the wiki)

## Checklist

Please delete options that are not relevant.

- [X] Updated Documentation to reflect changes

