### PR TITLE
Added Aymara language = Bolivian flag to audio/subtitle overlay languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ Transform your media library with Kometa and discover its full potential! Connec
 -  We're constantly working on new features to take your library management experience to the next level.
 -  Consider sponsoring the project to allow us to continue building great features for you!
 
-## Demo Video
-
-The below YouTube video has been created by one of our community members to showcase some of the things that Kometa can do for you. 
-
-[![Kometa](https://img.youtube.com/vi/nTfCUtKWTYI/0.jpg)](https://www.youtube.com/watch?v=nTfCUtKWTYI "Kometa")
-
 ## Example Kometa Libraries 
 
 Here are some examples of the things you can achieve using Kometa!

--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -618,13 +618,17 @@ overlays:
     template: [name: flags, name: standard]
 
   khmer:
-    variables: {key: km, text: KM, weight: 15, country: kh}
+    variables: {key: km, text: KM, weight: 16, country: kh}
     template: [name: flags, name: standard]
 
   limburgish:
-    variables: {key: li, text: LI, weight: 16, country: be}
+    variables: {key: li, text: LI, weight: 17, country: be}
     template: [name: flags, name: standard]
 
   irish:
-    variables: {key: ga, text: GA, weight: 17, country: ie}
+    variables: {key: ga, text: GA, weight: 18, country: ie}
+    template: [name: flags, name: standard]
+    
+  aymara:
+    variables: {key: ay, text: AY, weight: 19, country: bo}
     template: [name: flags, name: standard]

--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -624,3 +624,7 @@ overlays:
   limburgish:
     variables: {key: li, text: LI, weight: 16, country: be}
     template: [name: flags, name: standard]
+
+  irish:
+    variables: {key: ga, text: GA, weight: 17, country: ie}
+    template: [name: flags, name: standard]

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -94,6 +94,7 @@ Supported library types: Movie & Show
 | Mongolian                | `mn`  | `14`   | `mn`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Khmer                    | `kh`  | `15`   | `kh`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Limburgish               | `li`  | `16`   | `be`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Irish                    | `ga`  | `17`   | `ie`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 
 
 ??? tip "Square Style (click to expand)"

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -92,9 +92,10 @@ Supported library types: Movie & Show
 | Bambara                  | `bm`  | `12`   | `ml`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Afrikaans                | `af`  | `13`   | `af`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Mongolian                | `mn`  | `14`   | `mn`         |  :fontawesome-solid-circle-xmark:{ .red }  |
-| Khmer                    | `kh`  | `15`   | `kh`         |  :fontawesome-solid-circle-xmark:{ .red }  |
-| Limburgish               | `li`  | `16`   | `be`         |  :fontawesome-solid-circle-xmark:{ .red }  |
-| Irish                    | `ga`  | `17`   | `ie`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Khmer                    | `kh`  | `16`   | `kh`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Limburgish               | `li`  | `17`   | `be`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Irish                    | `ga`  | `18`   | `ie`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Aymara                   | `ay`  | `19`   | `bo`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 
 
 ??? tip "Square Style (click to expand)"


### PR DESCRIPTION
## Description

Added Aymara language = Bolivian flag to audio/subtitle overlay languages doc and yml.
Fixed minor issue with a duplicate weighting

## Type of Change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
- [] Documentation change (non-code changes affecting only the wiki)
- 
## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
