### PR TITLE
Added Aymara language = Bolivian flag to audio/subtitle overlay langu…

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -243,6 +243,7 @@ PlexCollection
 PlexPosters
 PNG
 Pokémon
+popeadam
 popularplex
 portainer
 Powershell

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -35,6 +35,7 @@ Fixes an issue where Rotten Tomatoes Verified Hot wasn't working
 Updates `Alien vs Predator` and `X-Men` lists to new lists which include most recent releases
 Adds `style` template variable for Streaming and Chart defaults, allowing user to choose color or white logos for collection posters
 Added `Paramount+ with Showtime` to both `Paramount+` and `Showtime` for Networks and Streaming, any existing weighting is unchanged.
+Added Aymara language with Bolivian flag to audio/subtitle overlay languages (credit to popeadam)
 
 # Bug Fixes
 Fixed the `cast` search option for the `imdb_search` builder

--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -618,13 +618,17 @@ overlays:
     template: [name: flags, name: standard]
 
   khmer:
-    variables: {key: km, text: KM, weight: 15, country: kh}
+    variables: {key: km, text: KM, weight: 16, country: kh}
     template: [name: flags, name: standard]
 
   limburgish:
-    variables: {key: li, text: LI, weight: 16, country: be}
+    variables: {key: li, text: LI, weight: 17, country: be}
     template: [name: flags, name: standard]
 
   irish:
-    variables: {key: ga, text: GA, weight: 17, country: ie}
+    variables: {key: ga, text: GA, weight: 18, country: ie}
+    template: [name: flags, name: standard]
+
+  aymara:
+    variables: {key: ay, text: AY, weight: 19, country: bo}
     template: [name: flags, name: standard]

--- a/docs/defaults/overlays/languages.md
+++ b/docs/defaults/overlays/languages.md
@@ -92,9 +92,10 @@ Supported library types: Movie & Show
 | Bambara                  | `bm`  | `12`   | `ml`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Afrikaans                | `af`  | `13`   | `af`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 | Mongolian                | `mn`  | `14`   | `mn`         |  :fontawesome-solid-circle-xmark:{ .red }  |
-| Khmer                    | `kh`  | `15`   | `kh`         |  :fontawesome-solid-circle-xmark:{ .red }  |
-| Limburgish               | `li`  | `16`   | `be`         |  :fontawesome-solid-circle-xmark:{ .red }  |
-| Irish                    | `ga`  | `17`   | `ie`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Khmer                    | `kh`  | `16`   | `kh`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Limburgish               | `li`  | `17`   | `be`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Irish                    | `ga`  | `18`   | `ie`         |  :fontawesome-solid-circle-xmark:{ .red }  |
+| Aymara                   | `ay`  | `19`   | `bo`         |  :fontawesome-solid-circle-xmark:{ .red }  |
 
 
 ??? tip "Square Style (click to expand)"


### PR DESCRIPTION
## Description

Added Aymara language = Bolivian flag to audio/subtitle overlay]

### Issues Fixed or Closed

- Fixes #2407 (supersedes)

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

Please delete options that are not relevant.

- Updated Documentation to reflect changes
- Updated the CHANGELOG with the changes
