### PR TITLE
Check if `tmdb_person` is an int or a string (i.e. "50 Cent")

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -56,3 +56,4 @@ Added Start Time, Finished and Run Time to Summary of run.
 Fixed an issue where custom repositories would not work correctly if the URL did not end in a trailing `/` character.
 Kometa will now check for `.yaml` extension in filenames if `.yml` is not found and vice-versa
 Kometa will no longer automatically sync playlists to all users if you do not specify who you want to sync them to. Only the server admin will receive playlists unless otherwise specified using `sync_to_users` or `playlist_sync_to_users`
+Fixes #2385 `tmdb_person` would pass an integer if the name started with an integer (i.e. `50 Cent` would pass `50` which resolved to `Catherine Deneuve`)

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -800,7 +800,15 @@ class CollectionBuilder:
                     try:
                         if not first_person:
                             first_person = tmdb_person
-                        person = self.config.TMDb.get_person(util.regex_first_int(tmdb_person, "TMDb Person ID"))
+                        # Added logic to allow names like "50 Cent" to be passed as a string rather than it passing "50" as the ID to use.
+                        if tmdb_person.isdigit():
+                            person = self.config.TMDb.get_person(int(tmdb_person))
+                        else:
+                            results = self.config.TMDb.search_people(tmdb_person)
+                            if not results:
+                                raise Failed(f"TMDb Error: No results for '{tmdb_person}'")
+                            result_index = len(results) - 1 if self.tmdb_person_offset >= len(results) else self.tmdb_person_offset
+                            person = results[result_index]
                         valid_names.append(person.name)
                         if person.biography:
                             self.summaries["tmdb_person"] = person.biography


### PR DESCRIPTION
## Description

Fixes an issue where `tmdb_person` would pass an integer if the name started with an integer (i.e. `50 Cent` would pass `50` which resolved to `Catherine Deneuve`)

### Issues Fixed or Closed

- Fixes #2385 

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

- [] Updated Documentation to reflect changes
- [X] Updated the CHANGELOG with the changes
