### PR TITLE
Stop showing missing movies from show libraries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -59,3 +59,4 @@ Fixed an issue where custom repositories would not work correctly if the URL did
 Kometa will now check for `.yaml` extension in filenames if `.yml` is not found and vice-versa
 Kometa will no longer automatically sync playlists to all users if you do not specify who you want to sync them to. Only the server admin will receive playlists unless otherwise specified using `sync_to_users` or `playlist_sync_to_users`
 Fixes #2385 `tmdb_person` would pass an integer if the name started with an integer (i.e. `50 Cent` would pass `50` which resolved to `Catherine Deneuve`)
+Fixes an issue where `show_missing` would display missing movies against show libraries (closes #2351)

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3032,7 +3032,7 @@ class CollectionBuilder:
     def run_missing(self):
         added_to_radarr = 0
         added_to_sonarr = 0
-        if len(self.missing_movies) > 0:
+        if len(self.missing_movies) > 0 and self.library.is_movie:
             if self.details["show_missing"] is True:
                 logger.info("")
                 logger.separator(f"Missing Movies from Library: {self.library.name}", space=False, border=False)


### PR DESCRIPTION
## Description

PR fixes an issue when `show_missing: true` and a builder list is run against a show library, movies in the source list will be shown as missing - this issue does not exist on movie libraries.


### Issues Fixed or Closed

- Fixes #2351

## Type of Change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
- [X] Updated the CHANGELOG with the changes
