### PR TITLE
Orderly error and no cache on too-large image

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,7 @@ Add `trakt`, `omdb_metascore`, `omdb_tomatoes` ratings sources for mass operatio
 Add `trakt` ratings source for mass episode operations.
 Added GitHub token validation during config validation.
 add `plex` ratings source for mass operations.
+Orderly error and no caching on too-large image
 
 # Docs
 Added "getting started" page

--- a/modules/library.py
+++ b/modules/library.py
@@ -212,8 +212,7 @@ class Library(ABC):
                         self.reload(item, force=True)
                         if overlay and "Overlay" in [la.tag for la in self.item_labels(item)]:
                             item.removeLabel("Overlay")
-                    self._upload_image(item, poster)
-                    poster_uploaded = True
+                    poster_uploaded = self._upload_image(item, poster)
                     logger.info(f"Metadata: {poster.attribute} updated {poster.message}")
                 elif self.show_asset_not_needed:
                     logger.info(f"Metadata: {poster.prefix}poster update not needed")
@@ -228,8 +227,7 @@ class Library(ABC):
                 if self.config.Cache:
                     _, image_compare, _ = self.config.Cache.query_image_map(item.ratingKey, f"{self.image_table_name}_backgrounds")
                 if not image_compare or str(background.compare) != str(image_compare):
-                    self._upload_image(item, background)
-                    background_uploaded = True
+                    background_uploaded = self._upload_image(item, background)
                     logger.info(f"Metadata: {background.attribute} updated {background.message}")
                 elif self.show_asset_not_needed:
                     logger.info(f"Metadata: {background.prefix}background update not needed")


### PR DESCRIPTION
## Description

No reason to throw a 500 on a too-big image when we can check for this.

```
|     1 | Image too large: config/posters/asset-15M.png, bytes 16186478, MAX 10480000                |
```

Max size is defined as a constant in plex.py at a little below 10Mb

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] Updated the CHANGELOG with the changes
