### PR TITLE
Append imdb ID to OMDb API query to resolve ongoing OMDb API issue

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -62,3 +62,4 @@ Kometa will now check for `.yaml` extension in filenames if `.yml` is not found 
 Kometa will no longer automatically sync playlists to all users if you do not specify who you want to sync them to. Only the server admin will receive playlists unless otherwise specified using `sync_to_users` or `playlist_sync_to_users`
 Fixes #2385 `tmdb_person` would pass an integer if the name started with an integer (i.e. `50 Cent` would pass `50` which resolved to `Catherine Deneuve`)
 Fixes an issue where `show_missing` would display missing movies against show libraries (closes #2351)
+Fixed an OMDb API issue where API key would intermittently be treated as invalid

--- a/modules/omdb.py
+++ b/modules/omdb.py
@@ -72,7 +72,7 @@ class OMDb:
             if omdb_dict and expired is False:
                 return OMDbObj(imdb_id, omdb_dict)
         logger.trace(f"IMDb ID: {imdb_id}")
-        response = self.requests.get(base_url, params={"i": imdb_id, "apikey": self.apikey})
+        response = self.requests.get(f"{base_url}?i={imdb_id}&apikey={self.apikey}&")
         if response.status_code < 400:
             omdb = OMDbObj(imdb_id, response.json())
             if self.cache and not ignore_cache:

--- a/modules/omdb.py
+++ b/modules/omdb.py
@@ -72,7 +72,7 @@ class OMDb:
             if omdb_dict and expired is False:
                 return OMDbObj(imdb_id, omdb_dict)
         logger.trace(f"IMDb ID: {imdb_id}")
-        response = self.requests.get(f"{base_url}?i={imdb_id}&apikey={self.apikey}&")
+        response = self.requests.get(base_url, params={"apikey": self.apikey, "i": imdb_id})
         if response.status_code < 400:
             omdb = OMDbObj(imdb_id, response.json())
             if self.cache and not ignore_cache:


### PR DESCRIPTION
Fixes an issue where OMDb would intermittently say an apikey is invalid if the apikey is the last parameter passed (see https://github.com/omdbapi/OMDb-API/issues/316)

Resolved by appending the imdb id (`tt0080684`) to the query as suggested in above link and in #2452 

Closes #2452 