### PR TITLE
Update kometa.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ Transform your media library with Kometa and discover its full potential! Connec
 -  We're constantly working on new features to take your library management experience to the next level.
 -  Consider sponsoring the project to allow us to continue building great features for you!
 
-## Demo Video
-
-The below YouTube video has been created by one of our community members to showcase some of the things that Kometa can do for you. 
-
-[![Kometa](https://img.youtube.com/vi/nTfCUtKWTYI/0.jpg)](https://www.youtube.com/watch?v=nTfCUtKWTYI "Kometa")
-
 ## Example Kometa Libraries 
 
 Here are some examples of the things you can achieve using Kometa!

--- a/kometa.py
+++ b/kometa.py
@@ -885,6 +885,9 @@ def run_collection(config, library, metadata, requested_collections):
                         library.status[str(mapping_name)]["status"] = f"{pre}Updated {', '.join(details_list)}"
 
             if builder.server_preroll is not None:
+                if isinstance(builder.server_preroll, list):
+                    builder.server_preroll = ';'.join(builder.server_preroll)
+
                 library.set_server_preroll(builder.server_preroll)
                 logger.info("")
                 logger.info(f"Plex Server Movie pre-roll video updated to {builder.server_preroll}")


### PR DESCRIPTION
Enhanced pre-roll handling in Kometa script:

- Fixed an issue where `server_preroll` was passed as a `list` instead of a semicolon-separated string.
- Added a check in `run_collection` to convert `server_preroll` from a list to a properly formatted string when necessary.
- Resolved `BadRequest` errors related to `CinemaTrailersPrerollID` when setting the Plex pre-roll video.
- Improved compatibility with the Plex API for pre-roll updates.

## Description

Please include a summary of the changes.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
- [] Updated the CHANGELOG with the changes
