### PR TITLE
Update kometa.py

### DIFF
--- a/kometa.py
+++ b/kometa.py
@@ -902,6 +902,10 @@ def run_collection(config, library, metadata, requested_collections):
                         library.status[str(mapping_name)]["status"] = f"{pre}Updated {', '.join(details_list)}"
 
             if builder.server_preroll is not None:
+                if isinstance(builder.server_preroll, list):
+                    delimiter = config.settings.get("preroll_delimiter", ';')  # Use default or configured value
+                    builder.server_preroll = delimiter.join(builder.server_preroll)
+                    
                 library.set_server_preroll(builder.server_preroll)
                 logger.info("")
                 logger.info(f"Plex Server Movie pre-roll video updated to {builder.server_preroll}")


### PR DESCRIPTION
This pull request introduces a feature to configure the delimiter used for server preroll paths in the Kometa script.

Key Changes:

Added support for a configurable delimiter (preroll_delimiter) in the YAML settings. Default delimiter is set to ;, but users can change it to a , or any other character via the settings section. Updated the logic to dynamically join the server_preroll list based on the configured delimiter. Benefits:

Provides flexibility for users who prefer different delimiters. Maintains compatibility with existing setups using the default ; delimiter.

## Description

Please include a summary of the changes.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

- [] New feature (non-breaking change which adds functionality)

## Checklist

- [] Updated the CHANGELOG with the changes
