### PR TITLE
Nightly

### DIFF
--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -88,6 +88,7 @@ settings:
   playlist_sync_to_users:
   playlist_exclude_users:
   playlist_report: false
+  preroll_delimiter: ';'  # Options: ',' or ';'
   verify_ssl: true
   custom_repo:
   overlay_artwork_filetype: jpg

--- a/kometa.py
+++ b/kometa.py
@@ -345,6 +345,7 @@ def start(attrs):
         stats = {"created": 0, "modified": 0, "deleted": 0, "added": 0, "unchanged": 0, "removed": 0, "radarr": 0, "sonarr": 0, "names": []}
         try:
             config = ConfigFile(my_requests, default_dir, attrs, secret_args)
+            logger.debug(f"Preroll Delimiter from config: {config.settings.get('preroll_delimiter', ';')}")
         except Exception as e:
             logger.stacktrace()
             logger.critical(e)
@@ -902,6 +903,10 @@ def run_collection(config, library, metadata, requested_collections):
                         library.status[str(mapping_name)]["status"] = f"{pre}Updated {', '.join(details_list)}"
 
             if builder.server_preroll is not None:
+                if isinstance(builder.server_preroll, list):
+                    delimiter = config.settings.get("preroll_delimiter", ';')  # Use default or configured value
+                    builder.server_preroll = delimiter.join(builder.server_preroll)
+                
                 library.set_server_preroll(builder.server_preroll)
                 logger.info("")
                 logger.info(f"Plex Server Movie pre-roll video updated to {builder.server_preroll}")

--- a/modules/config.py
+++ b/modules/config.py
@@ -161,6 +161,13 @@ class ConfigFile:
         logger.info(f"Using {self.config_path} as config")
         logger.clear_errors()
 
+        # Initialize self.data by loading the YAML configuration file
+        self.Requests = in_request
+        self.data = self.Requests.file_yaml(self.config_path).data
+        
+        # Now safely initialize self.settings
+        self.settings = self.data.get("settings", {})
+
         self._mediastingers = None
         self.Requests = in_request
         self.default_dir = default_dir


### PR DESCRIPTION
## Description

## Summary of Changes
### 1. Changes to config.py
Fixed Initialization Order in ConfigFile:
- Moved the initialization of self.settings to occur after self.data is properly initialized.
- Ensured self.data is loaded using self.Requests.file_yaml(self.config_path).data before referencing it.

### Purpose:
- Fixed potential AttributeError related to uninitialized self.data.
- Ensured the settings section of the configuration file is accessible via config.settings.

### 2. Changes to config.yml
Added preroll_delimiter Setting:
- Under settings, added the line:
 `preroll_delimiter: ';'  # Options: ',' or ';'`

### Purpose:
- Allows dynamic customization of the delimiter used for combining multiple pre-roll video paths.
- Provides clear guidance to users on acceptable values through an inline comment.

### 3. Changes to Kometa.py
Dynamic Handling of server_preroll:
- Updated the section handling server_preroll in run_collection to utilize the preroll_delimiter from the configuration file:
`if builder.server_preroll is not None:
    if isinstance(builder.server_preroll, list):
        delimiter = config.settings.get("preroll_delimiter", ';')  # Use default or configured value
        builder.server_preroll = delimiter.join(builder.server_preroll)
    library.set_server_preroll(builder.server_preroll)
    logger.info("")
    logger.info(f"Plex Server Movie pre-roll video updated to {builder.server_preroll}")`

- Logging Enhancements:
     - Added a log statement after configuration is loaded to display the preroll_delimiter value:
`logger.debug(f"Preroll Delimiter from config: {config.settings.get('preroll_delimiter', ';')}")`

###Purpose:
- Simplifies handling of pre-roll lists by dynamically joining file paths using the configured delimiter.
- Improves maintainability by making delimiter configuration external.

## How These Changes Help Import Lists
### Support for Pre-Roll Lists
Pre-roll lists like:
`server_preroll:`
`  - 'C:\pre\Norm\Norm1.mp4'`
`  - 'C:\pre\Norm\Norm2.mp4'`
     can now be automatically joined using the delimiter specified in config.yml.

### Dynamic Customization
Users can adjust the preroll_delimiter in the configuration file to match their specific needs, such as using ',' or ';'.

### Improved Compatibility
- Enables smooth integration of external templates or configurations for collections, such as:
`templates:
  Prerolls:   # Videos found here: https://prerolls.video/view
    build_collection: false`
- Ensures pre-roll paths are properly processed and applied to Plex server configurations.

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

- [] New feature (non-breaking change which adds functionality)

## Checklist
