### PR TITLE
[feat] Add ntfy notification agent

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -198,6 +198,7 @@ nl
 nokmål
 nosuchlibrary
 notifiarr
+ntfy
 num
 nynorsk
 oauth

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -30,6 +30,7 @@ Added `plex` ratings source for mass operations.
 Added IMDb Interests (sub-genres) to `imdb_search` builder
 Allow `server_preroll` to accept a list
 Changed default `overlay_artwork_filetype` to `webp_lossy` and `overlay_artwork_quality` to 90
+Added `ntfy` as a notification option
 
 # Docs
 Added "getting started" page

--- a/config/config.yml.template
+++ b/config/config.yml.template
@@ -114,6 +114,10 @@ notifiarr:
 gotify:
   url: http://192.168.1.12:80
   token: ####################################
+ntfy:
+  url: http://192.168.1.12:80
+  token: ####################################
+  topic: kometa
 anidb:                               # Not required for AniDB builders unless you want mature content
   username: ######
   password: ######

--- a/docs/config/gotify.md
+++ b/docs/config/gotify.md
@@ -1,7 +1,7 @@
 # Gotify Attributes
 
 Configuring [Gotify](https://gotify.net/) is optional but can allow you to send the [webhooks](webhooks.md) 
-straight to gotify.
+straight to Gotify.
 
 A `gotify` mapping is in the root of the config file.
 
@@ -18,7 +18,7 @@ gotify:
 | `url`     | Gotify Server Url        | :fontawesome-solid-circle-check:{ .green } |
 | `token`   | Gotify Application Token | :fontawesome-solid-circle-check:{ .green } |
 
-Once you have added the apikey your config.yml you have to add `gotify` to any [webhook](webhooks.md) to send that 
+Once you have added the configuration data your config.yml you have to add `gotify` to any [webhook](webhooks.md) to send that 
 notification to Gotify.
 
 ```yaml

--- a/docs/config/ntfy.md
+++ b/docs/config/ntfy.md
@@ -2,15 +2,42 @@
 
 Configuring [ntfy](https://ntfy.sh/) is optional but can allow you to send the [webhooks](webhooks.md) straight to ntfy.
 
-A `ntfy` mapping is in the root of the config file.
+## Setup
 
-Below is a `ntfy` mapping example and the full set of attributes:
+Users can either use the [public ntfy server](https://ntfy.sh), or [host their own ntfy server](https://docs.ntfy.sh/install/).
+
+### Retrieving Access Token and Topic
+
+#### Using the Public Server
+
+1. Visit https://ntfy.sh/login and login or sign up for an account (it's free).
+2. Select "[Account](https://ntfy.sh/account)" from the side menu and scroll to "Access Tokens" to generate an access token.
+3. Copy the access token and paste it into the `token` attribute in your config file. Enter `https://ntfy.sh` into the `url` attribute.
+4. Click "Subscribe to topic" from the side menu and enter a topic name.
+   - Pro subscribers can reserve specific topics, but any free tier user can subscribe and publish to any non-reserved topic.
+   - Common topics such as `kometa` are likely already reserved or at least used by other public ntfy users (and these topics may be visible to the general public). It's recommended to use a random topic name to keep your notifications semi-private.
+5. Enter the topic name into the `topic` attribute in the config file.
+
+
+#### Using a Self-Hosted Server
+
+If you are a standard (non-admin) user of a [ntfy server other than the official one](https://docs.ntfy.sh/integrations/#alternative-ntfy-servers), you can follow the same steps as above, but with the server URL and token provided by the server.
+
+If you are an admin of your own ntfy server, you can follow these steps:
+
+1. Follow the [installation instructions](https://docs.ntfy.sh/install/) to set up your own ntfy server.
+2. Follow the same steps above for creating an account and access token, or use the `ntfy` command line tool to [create a user](https://docs.ntfy.sh/config/#users-and-roles) and [generate an access token](https://docs.ntfy.sh/config/#access-tokens).
+3. Follow the same steps as above for generating/reserving a topic, but with the server URL and token provided by your server.
+
+### Configuring `ntfy` in the Config File
+
+Use the URL, topic and token to configure `ntfy` in the root of the config file:
 
 ```yaml
 ntfy:
-  url: ####################################
-  token: ####################################
-  topic: kometa
+  url: https://ntfy.sh  # or a different ntfy server URL
+  token: tk_thisismyaccesstoken
+  topic: kometa  # or a different topic name
 ```
 
 | Attribute | Allowed Values         |                  Required                  |
@@ -19,7 +46,7 @@ ntfy:
 | `token`   | ntfy User Access Token | :fontawesome-solid-circle-check:{ .green } |
 | `topic`   | ntfy Topic             | :fontawesome-solid-circle-check:{ .green } |
 
-Once you have added the configuration data your config.yml you have to add `ntfy` to any [webhook](webhooks.md) to send that notification to ntfy.
+Once you have added the configuration data to your `config.yml`, you can add `ntfy` to any [webhook](webhooks.md) to send that notification to ntfy.
 
 ```yaml
 webhooks:

--- a/docs/config/ntfy.md
+++ b/docs/config/ntfy.md
@@ -1,0 +1,31 @@
+# ntfy Attributes
+
+Configuring [ntfy](https://ntfy.sh/) is optional but can allow you to send the [webhooks](webhooks.md) straight to ntfy.
+
+A `ntfy` mapping is in the root of the config file.
+
+Below is a `ntfy` mapping example and the full set of attributes:
+
+```yaml
+ntfy:
+  url: ####################################
+  token: ####################################
+  topic: kometa
+```
+
+| Attribute | Allowed Values         |                  Required                  |
+|:----------|:-----------------------|:------------------------------------------:|
+| `url`     | ntfy Server Url        | :fontawesome-solid-circle-check:{ .green } |
+| `token`   | ntfy User Access Token | :fontawesome-solid-circle-check:{ .green } |
+| `topic`   | ntfy Topic             | :fontawesome-solid-circle-check:{ .green } |
+
+Once you have added the configuration data your config.yml you have to add `ntfy` to any [webhook](webhooks.md) to send that notification to ntfy.
+
+```yaml
+webhooks:
+  error: ntfy
+  version: ntfy
+  run_start: ntfy
+  run_end: ntfy
+  changes: ntfy
+```

--- a/docs/config/overview.md
+++ b/docs/config/overview.md
@@ -27,6 +27,7 @@ requirements for setup that can be found by clicking the links within the table 
 | [`mdblist`](mdblist.md)                     | :fontawesome-solid-circle-xmark:{ .red }                              |
 | [`notifiarr`](notifiarr.md)                 | :fontawesome-solid-circle-xmark:{ .red }                              |
 | [`gotify`](gotify.md)                       | :fontawesome-solid-circle-xmark:{ .red }                              |
+| [`ntfy`](ntfy.md)                           | :fontawesome-solid-circle-xmark:{ .red }              |
 | [`anidb`](anidb.md)                         | :fontawesome-solid-circle-xmark:{ .red }                              |
 | [`radarr`](radarr.md)                       | :fontawesome-solid-circle-xmark:{ .red }                              |
 | [`sonarr`](sonarr.md)                       | :fontawesome-solid-circle-xmark:{ .red }                              |

--- a/docs/config/webhooks.md
+++ b/docs/config/webhooks.md
@@ -34,6 +34,7 @@ webhooks:
     run_start:
       - notifiarr
       - gotify
+      - ntfy
     run_end:
       - https://www.myspecialdomain.com/kometa
       - https://www.myotherdomain.com/kometa
@@ -42,6 +43,7 @@ webhooks:
   
 * To send notifications to [Notifiarr](notifiarr.md) just add `notifiarr` to a webhook instead of the webhook url.
 * To send notifications to [Gotify](gotify.md) just add `gotify` to a webhook instead of the webhook url.
+* To send notifications to [ntfy](ntfy.md) just add `ntfy` to a webhook instead of the webhook url.
 
 ## Error Notifications
 

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -28,6 +28,9 @@
         "gotify": {
             "$ref": "#/definitions/gotify-api"
         },
+        "ntfy": {
+            "$ref": "#/definitions/ntfy-api"
+        },
         "anidb": {
             "$ref": "#/definitions/anidb-api"
         },
@@ -306,6 +309,27 @@
                 "token"
             ],
             "title": "gotify"
+        },
+        "ntfy-api": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "url": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                },
+                "topic": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "url",
+                "token",
+                "topic"
+            ],
+            "title": "ntfy"
         },
         "anidb-api": {
             "type": "object",
@@ -1532,7 +1556,7 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-                "^(?!plex|tmdb|tautulli|webhooks|omdb|mdblist|notifiarr|gotify|anidb|radarr|sonarr|trakt|mal).+$": {
+                "^(?!plex|tmdb|tautulli|webhooks|omdb|mdblist|notifiarr|gotify|ntfy|anidb|radarr|sonarr|trakt|mal).+$": {
                     "additionalProperties": false,
                     "properties": {
                         "metadata_files": {

--- a/json-schema/prototype_config.yml
+++ b/json-schema/prototype_config.yml
@@ -487,6 +487,10 @@ notifiarr:
 gotify:
   url: http://192.168.1.12:80
   token: Enter Gotify token
+ntfy:
+  url: http://192.168.1.12:80
+  token: Enter ntfy access token
+  topic: Enter ntfy topic
 anidb:                           # Not required for AniDB builders unless you want mature content
   username: Enter AniDB Username
   password: Enter AniDB Password

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
           - MDBList: config/mdblist.md
           - Notifiarr: config/notifiarr.md
           - Gotify: config/gotify.md
+          - ntfy: config/ntfy.md
           - AniDB: config/anidb.md
           - Radarr: config/radarr.md
           - Sonarr: config/sonarr.md

--- a/modules/gotify.py
+++ b/modules/gotify.py
@@ -1,8 +1,9 @@
 from json import JSONDecodeError
-from modules import util
+from modules import util, webhooks
 from modules.util import Failed
 
 logger = util.logger
+
 
 class Gotify:
     def __init__(self, requests, params):
@@ -33,67 +34,5 @@ class Gotify:
         return response_json
 
     def notification(self, json):
-        message = ""
-        if json["event"] == "run_end":
-            title = "Run Completed"
-            message = f"Start Time: {json['start_time']}\n" \
-                      f"End Time: {json['end_time']}\n" \
-                      f"Run Time: {json['run_time']}\n" \
-                      f"Collections Created: {json['collections_created']}\n" \
-                      f"Collections Modified: {json['collections_modified']}\n" \
-                      f"Collections Deleted: {json['collections_deleted']}\n" \
-                      f"Items Added: {json['items_added']}\n" \
-                      f"Items Removed: {json['items_removed']}"
-            if json["added_to_radarr"]:
-                message += f"\n{json['added_to_radarr']} Movies Added To Radarr"
-            if json["added_to_sonarr"]:
-                message += f"\n{json['added_to_sonarr']} Movies Added To Sonarr"
-        elif json["event"] == "run_start":
-            title = "Run Started"
-            message = json["start_time"]
-        elif json["event"] == "version":
-            title = "New Version Available"
-            message = f"Current: {json['current']}\n" \
-                      f"Latest: {json['latest']}\n" \
-                      f"Notes: {json['notes']}"
-        elif json["event"] == "delete":
-            if "library_name" in json:
-                title = "Collection Deleted"
-            else:
-                title = "Playlist Deleted"
-            message = json["message"]
-        else:
-            new_line = "\n"
-            if "server_name" in json:
-                message += f"{new_line if message else ''}Server: {json['server_name']}"
-            if "library_name" in json:
-                message += f"{new_line if message else ''}Library: {json['library_name']}"
-            if "collection" in json:
-                message += f"{new_line if message else ''}Collection: {json['collection']}"
-            if "playlist" in json:
-                message += f"{new_line if message else ''}Playlist: {json['playlist']}"
-            if json["event"] == "error":
-                if "collection" in json:
-                    title_name = "Collection"
-                elif "playlist" in json:
-                    title_name = "Playlist"
-                elif "library_name" in json:
-                    title_name = "Library"
-                else:
-                    title_name = "Global"
-                title = f"{'Critical ' if json['critical'] else ''}{title_name} Error"
-                message += f"{new_line if message else ''}Error Message: {json['error']}"
-            else:
-                title = f"{'Collection' if 'collection' in json else 'Playlist'} {'Created' if json['created'] else 'Modified'}"
-                if json['radarr_adds']:
-                    message += f"{new_line if message else ''}{len(json['radarr_adds'])} Radarr Additions:"
-                if json['sonarr_adds']:
-                    message += f"{new_line if message else ''}{len(json['sonarr_adds'])} Sonarr Additions:"
-                message += f"{new_line if message else ''}{len(json['additions'])} Additions:"
-                for add_dict in json['additions']:
-                    message += f"\n{add_dict['title']}"
-                message += f"{new_line if message else ''}{len(json['removals'])} Removals:"
-                for add_dict in json['removals']:
-                    message += f"\n{add_dict['title']}"
-
+        message, title, _ = webhooks.get_message(json)
         self._request(json={"message": message, "title": title})

--- a/modules/ntfy.py
+++ b/modules/ntfy.py
@@ -1,4 +1,4 @@
-from modules import util
+from modules import util, webhooks
 from modules.util import Failed
 
 logger = util.logger
@@ -13,12 +13,6 @@ class Ntfy:
 
         logger.secret(self.url)
         logger.secret(self.token)
-        logger.secret(self.topic)
-
-        self.headers = {
-            'Authorization': f'Bearer {self.token}',
-            'Icon': 'https://kometa.wiki/en/latest/assets/icon.png',
-        }
 
         self._test_url()
 
@@ -30,10 +24,13 @@ class Ntfy:
             raise Failed("ntfy Error: Invalid details")
 
     def _request(self, message: str, title: str = None, priority: int = 3):
-        headers = self.headers.copy()
-        headers['Priority'] = str(priority)
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Icon": "https://kometa.wiki/en/latest/assets/icon.png",
+            "Priority": str(priority)
+        }
         if title:
-            headers['Title'] = title
+            headers["Title"] = title
 
         response = self.requests.post(f"{self.url}/{self.topic}", headers=headers, data=message)
 
@@ -43,76 +40,5 @@ class Ntfy:
         return response
 
     def notification(self, json):
-        message = ""
-        title = None
-        priority = 3
-
-        if json["event"] == "run_end":
-            priority = 4
-            title = "Run Completed"
-            message = f"Start Time: {json['start_time']}\n" \
-                      f"End Time: {json['end_time']}\n" \
-                      f"Run Time: {json['run_time']}\n" \
-                      f"Collections Created: {json['collections_created']}\n" \
-                      f"Collections Modified: {json['collections_modified']}\n" \
-                      f"Collections Deleted: {json['collections_deleted']}\n" \
-                      f"Items Added: {json['items_added']}\n" \
-                      f"Items Removed: {json['items_removed']}"
-            if json["added_to_radarr"]:
-                message += f"\n{json['added_to_radarr']} Movies Added To Radarr"
-            if json["added_to_sonarr"]:
-                message += f"\n{json['added_to_sonarr']} Movies Added To Sonarr"
-        elif json["event"] == "run_start":
-            priority = 4
-            title = "Run Started"
-            message = json["start_time"]
-        elif json["event"] == "version":
-            priority = 2
-            title = "New Version Available"
-            message = f"Current: {json['current']}\n" \
-                      f"Latest: {json['latest']}\n" \
-                      f"Notes: {json['notes']}"
-        elif json["event"] == "delete":
-            priority = 3
-            if "library_name" in json:
-                title = "Collection Deleted"
-            else:
-                title = "Playlist Deleted"
-            message = json["message"]
-        else:
-            new_line = "\n"
-            if "server_name" in json:
-                message += f"{new_line if message else ''}Server: {json['server_name']}"
-            if "library_name" in json:
-                message += f"{new_line if message else ''}Library: {json['library_name']}"
-            if "collection" in json:
-                message += f"{new_line if message else ''}Collection: {json['collection']}"
-            if "playlist" in json:
-                message += f"{new_line if message else ''}Playlist: {json['playlist']}"
-            if json["event"] == "error":
-                if "collection" in json:
-                    title_name = "Collection"
-                elif "playlist" in json:
-                    title_name = "Playlist"
-                elif "library_name" in json:
-                    title_name = "Library"
-                else:
-                    title_name = "Global"
-                priority = 5
-                title = f"{'Critical ' if json['critical'] else ''}{title_name} Error"
-                message += f"{new_line if message else ''}Error Message: {json['error']}"
-            else:
-                priority = 3
-                title = f"{'Collection' if 'collection' in json else 'Playlist'} {'Created' if json['created'] else 'Modified'}"
-                if json['radarr_adds']:
-                    message += f"{new_line if message else ''}{len(json['radarr_adds'])} Radarr Additions:"
-                if json['sonarr_adds']:
-                    message += f"{new_line if message else ''}{len(json['sonarr_adds'])} Sonarr Additions:"
-                message += f"{new_line if message else ''}{len(json['additions'])} Additions:"
-                for add_dict in json['additions']:
-                    message += f"\n{add_dict['title']}"
-                message += f"{new_line if message else ''}{len(json['removals'])} Removals:"
-                for add_dict in json['removals']:
-                    message += f"\n{add_dict['title']}"
-
+        message, title, priority = webhooks.get_message(json)
         self._request(message=message, title=title, priority=priority)

--- a/modules/ntfy.py
+++ b/modules/ntfy.py
@@ -1,0 +1,118 @@
+from modules import util
+from modules.util import Failed
+
+logger = util.logger
+
+
+class Ntfy:
+    def __init__(self, requests, params):
+        self.requests = requests
+        self.token = params["token"]
+        self.url = params["url"].rstrip("/")
+        self.topic = params["topic"]
+
+        logger.secret(self.url)
+        logger.secret(self.token)
+        logger.secret(self.topic)
+
+        self.headers = {
+            'Authorization': f'Bearer {self.token}',
+            'Icon': 'https://kometa.wiki/en/latest/assets/icon.png',
+        }
+
+        self._test_url()
+
+    def _test_url(self):
+        try:
+            self._request(message="Kometa - Testing ntfy Access", priority=1)
+        except Exception:
+            logger.stacktrace()
+            raise Failed("ntfy Error: Invalid details")
+
+    def _request(self, message: str, title: str = None, priority: int = 3):
+        headers = self.headers.copy()
+        headers['Priority'] = str(priority)
+        if title:
+            headers['Title'] = title
+
+        response = self.requests.post(f"{self.url}/{self.topic}", headers=headers, data=message)
+
+        if not response:
+            raise Failed(f"({response.status_code} [{response.reason}]) {response.content}")
+
+        return response
+
+    def notification(self, json):
+        message = ""
+        title = None
+        priority = 3
+
+        if json["event"] == "run_end":
+            priority = 4
+            title = "Run Completed"
+            message = f"Start Time: {json['start_time']}\n" \
+                      f"End Time: {json['end_time']}\n" \
+                      f"Run Time: {json['run_time']}\n" \
+                      f"Collections Created: {json['collections_created']}\n" \
+                      f"Collections Modified: {json['collections_modified']}\n" \
+                      f"Collections Deleted: {json['collections_deleted']}\n" \
+                      f"Items Added: {json['items_added']}\n" \
+                      f"Items Removed: {json['items_removed']}"
+            if json["added_to_radarr"]:
+                message += f"\n{json['added_to_radarr']} Movies Added To Radarr"
+            if json["added_to_sonarr"]:
+                message += f"\n{json['added_to_sonarr']} Movies Added To Sonarr"
+        elif json["event"] == "run_start":
+            priority = 4
+            title = "Run Started"
+            message = json["start_time"]
+        elif json["event"] == "version":
+            priority = 2
+            title = "New Version Available"
+            message = f"Current: {json['current']}\n" \
+                      f"Latest: {json['latest']}\n" \
+                      f"Notes: {json['notes']}"
+        elif json["event"] == "delete":
+            priority = 3
+            if "library_name" in json:
+                title = "Collection Deleted"
+            else:
+                title = "Playlist Deleted"
+            message = json["message"]
+        else:
+            new_line = "\n"
+            if "server_name" in json:
+                message += f"{new_line if message else ''}Server: {json['server_name']}"
+            if "library_name" in json:
+                message += f"{new_line if message else ''}Library: {json['library_name']}"
+            if "collection" in json:
+                message += f"{new_line if message else ''}Collection: {json['collection']}"
+            if "playlist" in json:
+                message += f"{new_line if message else ''}Playlist: {json['playlist']}"
+            if json["event"] == "error":
+                if "collection" in json:
+                    title_name = "Collection"
+                elif "playlist" in json:
+                    title_name = "Playlist"
+                elif "library_name" in json:
+                    title_name = "Library"
+                else:
+                    title_name = "Global"
+                priority = 5
+                title = f"{'Critical ' if json['critical'] else ''}{title_name} Error"
+                message += f"{new_line if message else ''}Error Message: {json['error']}"
+            else:
+                priority = 3
+                title = f"{'Collection' if 'collection' in json else 'Playlist'} {'Created' if json['created'] else 'Modified'}"
+                if json['radarr_adds']:
+                    message += f"{new_line if message else ''}{len(json['radarr_adds'])} Radarr Additions:"
+                if json['sonarr_adds']:
+                    message += f"{new_line if message else ''}{len(json['sonarr_adds'])} Sonarr Additions:"
+                message += f"{new_line if message else ''}{len(json['additions'])} Additions:"
+                for add_dict in json['additions']:
+                    message += f"\n{add_dict['title']}"
+                message += f"{new_line if message else ''}{len(json['removals'])} Removals:"
+                for add_dict in json['removals']:
+                    message += f"\n{add_dict['title']}"
+
+        self._request(message=message, title=title, priority=priority)

--- a/modules/webhooks.py
+++ b/modules/webhooks.py
@@ -5,7 +5,7 @@ from modules.util import Failed
 logger = util.logger
 
 class Webhooks:
-    def __init__(self, config, system_webhooks, library=None, notifiarr=None, gotify=None):
+    def __init__(self, config, system_webhooks, library=None, notifiarr=None, gotify=None, ntfy=None):
         self.config = config
         self.requests = self.config.Requests
         self.error_webhooks = system_webhooks["error"] if "error" in system_webhooks else []
@@ -16,6 +16,7 @@ class Webhooks:
         self.library = library
         self.notifiarr = notifiarr
         self.gotify = gotify
+        self.ntfy = ntfy
 
     def _request(self, webhooks, json):
         logger.trace("")
@@ -35,6 +36,9 @@ class Webhooks:
             elif webhook == "gotify":
                 if self.gotify:
                     self.gotify.notification(json)
+            elif webhook == "ntfy":
+                if self.ntfy:
+                    self.ntfy.notification(json)
             else:
                 if webhook.startswith("https://discord.com/api/webhooks"):
                     json = self.discord(json)

--- a/modules/webhooks.py
+++ b/modules/webhooks.py
@@ -4,6 +4,78 @@ from modules.util import Failed
 
 logger = util.logger
 
+def get_message(json):
+    message = ""
+    priority = 3
+    if json["event"] == "run_end":
+        priority = 4
+        title = "Run Completed"
+        message = f"Start Time: {json['start_time']}\n" \
+                  f"End Time: {json['end_time']}\n" \
+                  f"Run Time: {json['run_time']}\n" \
+                  f"Collections Created: {json['collections_created']}\n" \
+                  f"Collections Modified: {json['collections_modified']}\n" \
+                  f"Collections Deleted: {json['collections_deleted']}\n" \
+                  f"Items Added: {json['items_added']}\n" \
+                  f"Items Removed: {json['items_removed']}"
+        if json["added_to_radarr"]:
+            message += f"\n{json['added_to_radarr']} Movies Added To Radarr"
+        if json["added_to_sonarr"]:
+            message += f"\n{json['added_to_sonarr']} Movies Added To Sonarr"
+    elif json["event"] == "run_start":
+        priority = 4
+        title = "Run Started"
+        message = json["start_time"]
+    elif json["event"] == "version":
+        priority = 2
+        title = "New Version Available"
+        message = f"Current: {json['current']}\n" \
+                  f"Latest: {json['latest']}\n" \
+                  f"Notes: {json['notes']}"
+    elif json["event"] == "delete":
+        if "library_name" in json:
+            title = "Collection Deleted"
+        else:
+            title = "Playlist Deleted"
+        message = json["message"]
+    else:
+        new_line = "\n"
+        if "server_name" in json:
+            message += f"{new_line if message else ''}Server: {json['server_name']}"
+        if "library_name" in json:
+            message += f"{new_line if message else ''}Library: {json['library_name']}"
+        if "collection" in json:
+            message += f"{new_line if message else ''}Collection: {json['collection']}"
+        if "playlist" in json:
+            message += f"{new_line if message else ''}Playlist: {json['playlist']}"
+        if json["event"] == "error":
+            if "collection" in json:
+                title_name = "Collection"
+            elif "playlist" in json:
+                title_name = "Playlist"
+            elif "library_name" in json:
+                title_name = "Library"
+            else:
+                title_name = "Global"
+            priority = 5
+            title = f"{'Critical ' if json['critical'] else ''}{title_name} Error"
+            message += f"{new_line if message else ''}Error Message: {json['error']}"
+        else:
+            title = f"{'Collection' if 'collection' in json else 'Playlist'} {'Created' if json['created'] else 'Modified'}"
+            if json['radarr_adds']:
+                message += f"{new_line if message else ''}{len(json['radarr_adds'])} Radarr Additions:"
+            if json['sonarr_adds']:
+                message += f"{new_line if message else ''}{len(json['sonarr_adds'])} Sonarr Additions:"
+            message += f"{new_line if message else ''}{len(json['additions'])} Additions:"
+            for add_dict in json['additions']:
+                message += f"\n{add_dict['title']}"
+            message += f"{new_line if message else ''}{len(json['removals'])} Removals:"
+            for add_dict in json['removals']:
+                message += f"\n{add_dict['title']}"
+
+    return message, title, priority
+
+
 class Webhooks:
     def __init__(self, config, system_webhooks, library=None, notifiarr=None, gotify=None, ntfy=None):
         self.config = config


### PR DESCRIPTION
## Description

Added [ntfy](https://ntfy.sh) as configurable notification agent (virtually the same as gotify)

Example config:

```
ntfy:
  url: https://ntfy.sh  # Or your self-hosted instance
  topic: kometa
  token: tk_youruseraccesstoken
...
webhooks:
  # When PMM starts running
  run_start: ntfy
  # When PMM finishes running
  run_end: ntfy
  # When PMM encounters an error
  error: ntfy
  # When a change is made to a collection
  changes: ntfy
  # When a collection is deleted
  delete: ntfy
  # When there is a new version of PMM available
  version: ntfy
```

What users will see (desktop and mobile app):
![image](https://github.com/user-attachments/assets/7b0e1a80-29dd-4fed-be20-fb0c8eea5fb4)
![Screenshot_20250122-233331](https://github.com/user-attachments/assets/e3de93f6-41d2-4522-a18f-5bd65d5e7d7d)

ntfy has five different available priority levels:
- The testing message to verify access is sent at the lowest priority (1)
- New version available (2)
- Changes/deletions (3)
- Run start/end (4)
- Error sent at the highest priority (5)

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation change (non-code changes affecting only the wiki)
- [ ] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [x] Updated Documentation to reflect changes
- [x] Updated the CHANGELOG with the changes
