### PR TITLE
Add new sorting options and fix typo

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -247,6 +247,7 @@ remux
 repo
 repos
 rholder
+rogerebert
 rogerevert
 romani
 ruamel

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -248,7 +248,6 @@ repo
 repos
 rholder
 rogerebert
-rogerevert
 romani
 ruamel
 runtime

--- a/docs/files/builders/mdblist.md
+++ b/docs/files/builders/mdblist.md
@@ -45,13 +45,10 @@ The default `sort_by` when it's not specified is `rank.asc`.
 | Option                                        | Description                            |
 |:----------------------------------------------|:---------------------------------------|
 | `rank.asc`<br>`rank.desc`                     | Sort by MDBList Rank                   |
-| `title.asc`<br>`title.desc`                   | Sort by Title                          |
 | `score.asc`<br>`score.desc`                   | Sort by MDBList Score                  |
 | `score_average.asc`<br>`score_average.desc`   | Sort by MDBList Average Score          |
 | `released.asc`<br>`released.desc`             | Sort by Release Date                   |
 | `releasedigital.asc`<br>`releasedigital.desc` | Sort by Digital Release Date           |
-| `last_air_date.asc`<br>`last_air_date.desc`   | Sort by Last Air Date                  |
-| `runtime.asc`<br>`runtime.desc`               | Sort Runtime                           |
 | `imdbrating.asc`<br>`imdbrating.desc`         | Sort by IMDb Rating                    |
 | `imdbvotes.asc`<br>`imdbvotes.desc`           | Sort by IMDb Votes                     |
 | `imdbpopular.asc`<br>`imdbpopular.desc`       | Sort by IMDb Popular                   |
@@ -59,13 +56,20 @@ The default `sort_by` when it's not specified is `rank.asc`.
 | `rogerebert.asc`<br>`rogerebert.desc`         | Sort by RogerEbert Score               |
 | `rtomatoes.asc`<br>`rtomatoes.desc`           | Sort by Rotten Tomatoes Score          |
 | `rtaudience.asc`<br>`rtaudience.desc`         | Sort by Rotten Tomatoes Audience Score |
-| `letterrating.asc`<br>`letterrating.desc`     | Sort by Letterboxd Rating              |
-| `lettervotes.asc`<br>`lettervotes.desc`       | Sort by Letterboxd Votes               |
 | `metacritic.asc`<br>`metacritic.desc`         | Sort by Metacritic Score               |
 | `myanimelist.asc`<br>`myanimelist.desc`       | Sort by MyAnimeList Score              |
+| `letterrating.asc`<br>`letterrating.desc`     | Sort by Letterboxd Rating              |
+| `lettervotes.asc`<br>`lettervotes.desc`       | Sort by Letterboxd Votes               |
+| `last_air_date.asc`<br>`last_air_date.desc`   | Sort by Last Air Date                  |
+| `watched.asc`<br>`watched.desc`               | Sort by Last Watched Date              |
+| `rating.asc`<br>`rating.desc`                 | Sort by Users Rating                   |
+| `download.asc`<br>`download.desc`             | Sort by Downloaded                     |
+| `usort.asc`<br>`usort.desc`                   | Sort by User Sort                      |
+| `added.asc`<br>`added.desc`                   | Sort by Date Added                     |
+| `runtime.asc`<br>`runtime.desc`               | Sort by Runtime                        |
 | `budget.asc`<br>`budget.desc`                 | Sort by Budget                         |
 | `revenue.asc`<br>`revenue.desc`               | Sort by Revenue                        |
-| `added.asc`<br>`added.desc`                   | Sort by Date Added                     |
+| `title.asc`<br>`title.desc`                   | Sort by Title                          |
 | `random.asc`<br>`random.desc`                 | Sort by Random (Randomized Daily)      |
 
 For these sorts to be reflected in your collection you must use `collection_order: custom`.

--- a/docs/files/builders/mdblist.md
+++ b/docs/files/builders/mdblist.md
@@ -42,23 +42,31 @@ The default `sort_by` when it's not specified is `rank.asc`.
 
 ### Sort Options
 
-| Option                                        | Description                    |
-|:----------------------------------------------|:-------------------------------|
-| `rank.asc`<br>`rank.desc`                     | Sort by MDBList Rank           |
-| `score.asc`<br>`score.desc`                   | Sort by MDBList Score          |
-| `score_average.asc`<br>`score_average.desc`   | Sort by MDBList Average Score  |
-| `released.asc`<br>`released.desc`             | Sort by Release Date           |
-| `imdbrating.asc`<br>`imdbrating.desc`         | Sort by IMDb Rating            |
-| `imdbvotes.asc`<br>`imdbvotes.desc`           | Sort by IMDb Votes             |
-| `imdbpopular.asc`<br>`imdbpopular.desc`       | Sort by IMDb Popular           |
-| `tmdbpopular.asc`<br>`tmdbpopular.desc`       | Sort by TMDb Popular           |
-| `rogerebert.asc`<br>`rogerebert.desc`         | Sort by RogerEvert Score       |
-| `rtomatoes.asc`<br>`rtomatoes.desc`           | Sort by Rotten Tomatoes Score  |
-| `metacritic.asc`<br>`metacritic.desc`         | Sort by Metacritic Score       |
-| `myanimelist.asc`<br>`myanimelist.desc`       | Sort by MyAnimeList Score      |
-| `budget.asc`<br>`budget.desc`                 | Sort by Budget                 |
-| `revenue.asc`<br>`revenue.desc`               | Sort by Revenue                |
-| `added.asc`<br>`added.desc`                   | Sort by Date Added             |
+| Option                                        | Description                            |
+|:----------------------------------------------|:---------------------------------------|
+| `rank.asc`<br>`rank.desc`                     | Sort by MDBList Rank                   |
+| `title.asc`<br>`title.desc`                   | Sort by Title                          |
+| `score.asc`<br>`score.desc`                   | Sort by MDBList Score                  |
+| `score_average.asc`<br>`score_average.desc`   | Sort by MDBList Average Score          |
+| `released.asc`<br>`released.desc`             | Sort by Release Date                   |
+| `releasedigital.asc`<br>`releasedigital.desc` | Sort by Digital Release Date           |
+| `last_air_date.asc`<br>`last_air_date.desc`   | Sort by Last Air Date                  |
+| `runtime.asc`<br>`runtime.desc`               | Sort Runtime                           |
+| `imdbrating.asc`<br>`imdbrating.desc`         | Sort by IMDb Rating                    |
+| `imdbvotes.asc`<br>`imdbvotes.desc`           | Sort by IMDb Votes                     |
+| `imdbpopular.asc`<br>`imdbpopular.desc`       | Sort by IMDb Popular                   |
+| `tmdbpopular.asc`<br>`tmdbpopular.desc`       | Sort by TMDb Popular                   |
+| `rogerebert.asc`<br>`rogerebert.desc`         | Sort by RogerEbert Score               |
+| `rtomatoes.asc`<br>`rtomatoes.desc`           | Sort by Rotten Tomatoes Score          |
+| `rtaudience.asc`<br>`rtaudience.desc`         | Sort by Rotten Tomatoes Audience Score |
+| `letterrating.asc`<br>`letterrating.desc`     | Sort by Letterboxd Rating              |
+| `lettervotes.asc`<br>`lettervotes.desc`       | Sort by Letterboxd Votes               |
+| `metacritic.asc`<br>`metacritic.desc`         | Sort by Metacritic Score               |
+| `myanimelist.asc`<br>`myanimelist.desc`       | Sort by MyAnimeList Score              |
+| `budget.asc`<br>`budget.desc`                 | Sort by Budget                         |
+| `revenue.asc`<br>`revenue.desc`               | Sort by Revenue                        |
+| `added.asc`<br>`added.desc`                   | Sort by Date Added                     |
+| `random.asc`<br>`random.desc`                 | Sort by Random (Randomized Daily)      |
 
 For these sorts to be reflected in your collection you must use `collection_order: custom`.
 

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -9,9 +9,9 @@ logger = util.logger
 
 builders = ["mdblist_list"]
 sort_names = [
-    "rank", "score", "score_average", "released", "imdbrating", "imdbvotes", "imdbpopular", "tmdbpopular",
-    "rogerebert", "rtomatoes", "rtaudience", "metacritic", "myanimelist", "letterrating", "lettervotes", 
-    "updated", "last_air_date", "watched", "rating", "usort", "added", "runtime", "budget", "revenue", "title"
+    "rank", "score", "score_average", "released", "releaseddigital", "imdbrating", "imdbvotes", "imdbpopular",
+    "tmdbpopular", "rogerebert", "rtomatoes", "rtaudience", "metacritic", "myanimelist", "letterrating", "lettervotes",
+    "last_air_date", "watched", "rating", "download", "usort", "added", "runtime", "budget", "revenue", "title", "random"
 ]
 list_sorts = [f"{s}.asc" for s in sort_names] + [f"{s}.desc" for s in sort_names]
 base_url = "https://mdblist.com/lists"
@@ -197,12 +197,12 @@ class MDBList:
             sort_by = "rank.asc"
             if "sort_by" in dict_methods:
                 if mdb_dict[dict_methods["sort_by"]] is None:
-                    logger.warning(f"{error_type} Warning: mdb_list sort_by attribute is blank using score as default")
+                    logger.warning(f"{error_type} Warning: mdb_list sort_by attribute is blank using the default rank.asc")
                 elif mdb_dict[dict_methods["sort_by"]].lower() in sort_names:
                     logger.warning(f"{error_type} Warning: mdb_list sort_by attribute {mdb_dict[dict_methods['sort_by']]} is missing .desc or .asc defaulting to .desc")
                     sort_by = f"{mdb_dict[dict_methods['sort_by']].lower()}.desc"
                 elif mdb_dict[dict_methods["sort_by"]].lower() not in list_sorts:
-                    logger.warning(f"{error_type} Warning: mdb_list sort_by attribute {mdb_dict[dict_methods['sort_by']]} not valid score as default. Options: {', '.join(list_sorts)}")
+                    logger.warning(f"{error_type} Warning: mdb_list sort_by attribute {mdb_dict[dict_methods['sort_by']]} not valid using the default rank.asc. Options: {', '.join(list_sorts)}")
                 else:
                     sort_by = mdb_dict[dict_methods["sort_by"]].lower()
             valid_lists.append({"url": mdb_url, "limit": list_count, "sort_by": sort_by})


### PR DESCRIPTION
## Description

Documented recently-added MDBList sorting options. Screenshot of MDBList developer mentioning new options:
https://discord.com/channels/822460010649878528/822460010649878531/1333236913733374026
I tested this with `random.asc` and it works as expected. 

### Issues Fixed or Closed

- Fixes #(issue)

## Type of Change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
- [x] Documentation change (non-code changes affecting only the wiki)

## Checklist

Please delete options that are not relevant.

- [x] Updated Documentation to reflect changes
