### PR TITLE
Fix typo in builder.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,7 @@ Add `minimum_items_<<key>>` to universe Default file
 Added workaround to `Streaming` for TMDb issue with TMDb Discover
 
 # Bug Fixes
+Fixed `radarr_tag_list` typo in `builder.py`
 Fixed multiple anime `int()` Errors
 Fixed #2100 `verify_ssl` wasn't working when downloading images
 Fixed an issue with `delete_collections` where items were being deleted if they only matched one criteria vs all criteria

--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ Transform your media library with Kometa and discover its full potential! Connec
 -  We're constantly working on new features to take your library management experience to the next level.
 -  Consider sponsoring the project to allow us to continue building great features for you!
 
-## Demo Video
-
-The below YouTube video has been created by one of our community members to showcase some of the things that Kometa can do for you. 
-
-[![Kometa](https://img.youtube.com/vi/nTfCUtKWTYI/0.jpg)](https://www.youtube.com/watch?v=nTfCUtKWTYI "Kometa")
-
 ## Example Kometa Libraries 
 
 Here are some examples of the things you can achieve using Kometa!

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -59,7 +59,7 @@ item_false_details = ["item_lock_background", "item_lock_poster", "item_lock_tit
 item_bool_details = ["item_tmdb_season_titles", "revert_overlay", "item_assets", "item_refresh", "item_analyze"] + item_false_details
 item_details = ["non_item_remove_label", "item_label", "item_genre", "item_edition", "item_radarr_tag", "item_sonarr_tag", "item_refresh_delay"] + item_bool_details + list(plex.item_advance_keys.keys())
 none_details = ["label.sync", "item_label.sync", "item_genre.sync", "radarr_taglist", "sonarr_taglist", "item_edition"]
-none_builders = ["radarr_tag_list", "sonarr_taglist"]
+none_builders = ["radarr_taglist", "sonarr_taglist"]
 radarr_details = [
     "radarr_add_missing", "radarr_add_existing", "radarr_upgrade_existing", "radarr_monitor_existing", "radarr_folder", "radarr_monitor",
     "radarr_search", "radarr_availability", "radarr_quality", "radarr_tag", "item_radarr_tag", "radarr_ignore_cache",


### PR DESCRIPTION
## Description

`builder.py` was refering to `radarr_tag_list` instead of `radarr_taglist`. 
This was causing the error `Collection Error: radarr_taglist attribute is blank`, see Discord thread for more details: [radarr_taglist attribute is blank](https://discord.com/channels/822460010649878528/1333858629002072074)

**Important note**: As described on the Discord thread, fixing this still raises `Unknown Error: argument of type 'NoneType' is not iterable`. But I don't know if it's another bug related to the typo, or if the issue is coming from my config/collection files.

_PR Note: should this PR be based on a fork of Master or Nightly?_

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please delete options that are not relevant.

- [X] Updated the CHANGELOG with the changes
