### PR TITLE
Fix typo in builder.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,4 +77,4 @@ Fixes an issue where `show_missing` would display missing movies against show li
 Fixed an OMDb API issue where API key would intermittently be treated as invalid
 Fixed an issue where Kometa would try to upload and cache images larger than Plex allows (10mb is the upper limit)
 Fixes an issue where `use_subtitles` would ignore `flag_alignment: left`
-Fixed typo `radarr_tag_list` instead of `radarr_taglist` in `builder.py` (line 62) causing `Collection Error: radarr_taglist attribute is blank`
+Fixed typo `radarr_tag_list` instead of `radarr_taglist` in `builder` module (line 62) causing `Collection Error: radarr_taglist attribute is blank`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,4 +77,5 @@ Fixes an issue where `show_missing` would display missing movies against show li
 Fixed an OMDb API issue where API key would intermittently be treated as invalid
 Fixed an issue where Kometa would try to upload and cache images larger than Plex allows (10mb is the upper limit)
 Fixes an issue where `use_subtitles` would ignore `flag_alignment: left`
-Fixed typo `radarr_tag_list` instead of `radarr_taglist` in `builder` module (line 62) causing `Collection Error: radarr_taglist attribute is blank`
+Fixed typo `radarr_tag_list` instead of `radarr_taglist` in `builder` module causing `Collection Error: radarr_taglist attribute is blank`
+Fixed NoneError when using a blank `radarr_taglist` or `sonarr_taglist`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,3 +77,4 @@ Fixes an issue where `show_missing` would display missing movies against show li
 Fixed an OMDb API issue where API key would intermittently be treated as invalid
 Fixed an issue where Kometa would try to upload and cache images larger than Plex allows (10mb is the upper limit)
 Fixes an issue where `use_subtitles` would ignore `flag_alignment: left`
+Fixed typo `radarr_tag_list` instead of `radarr_taglist` in `builder.py` (line 62) causing `Collection Error: radarr_taglist attribute is blank`

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -59,7 +59,7 @@ item_false_details = ["item_lock_background", "item_lock_poster", "item_lock_tit
 item_bool_details = ["item_tmdb_season_titles", "revert_overlay", "item_assets", "item_refresh", "item_analyze"] + item_false_details
 item_details = ["non_item_remove_label", "item_label", "item_genre", "item_edition", "item_radarr_tag", "item_sonarr_tag", "item_refresh_delay"] + item_bool_details + list(plex.item_advance_keys.keys())
 none_details = ["label.sync", "item_label.sync", "item_genre.sync", "radarr_taglist", "sonarr_taglist", "item_edition"]
-none_builders = ["radarr_tag_list", "sonarr_taglist"]
+none_builders = ["radarr_taglist", "sonarr_taglist"]
 radarr_details = [
     "radarr_add_missing", "radarr_add_existing", "radarr_upgrade_existing", "radarr_monitor_existing", "radarr_folder", "radarr_monitor",
     "radarr_search", "radarr_availability", "radarr_quality", "radarr_tag", "item_radarr_tag", "radarr_ignore_cache",

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1356,7 +1356,7 @@ class CollectionBuilder:
         elif method_name == "radarr_tag":
             self.radarr_details["tag"] = util.get_list(method_data, lower=True)
         elif method_name == "radarr_taglist":
-            self.builders.append((method_name, util.get_list(method_data, lower=True)))
+            self.builders.append((method_name, util.get_list(method_data, lower=True, return_none=False)))
         elif method_name == "radarr_all":
             self.builders.append((method_name, True))
 
@@ -1378,7 +1378,7 @@ class CollectionBuilder:
         elif method_name == "sonarr_tag":
             self.sonarr_details["tag"] = util.get_list(method_data, lower=True)
         elif method_name == "sonarr_taglist":
-            self.builders.append((method_name, util.get_list(method_data, lower=True)))
+            self.builders.append((method_name, util.get_list(method_data, lower=True, return_none=False)))
         elif method_name == "sonarr_all":
             self.builders.append((method_name, True))
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -140,9 +140,9 @@ def add_dict_list(keys, value, dict_map):
         else:
             dict_map[key] = [int(value)]
 
-def get_list(data, lower=False, upper=False, split=True, int_list=False, trim=True):
+def get_list(data, lower=False, upper=False, split=True, int_list=False, trim=True, return_none=True):
     if split is True:               split = ","
-    if data is None:                return None
+    if data is None:                return None if return_none else []
     elif isinstance(data, list):    list_data = data
     elif isinstance(data, dict):    return [data]
     elif split is False:            list_data = [str(data)]


### PR DESCRIPTION
## Description

`builder.py` was refering to `radarr_tag_list` instead of `radarr_taglist`. 
This was causing the error `Collection Error: radarr_taglist attribute is blank`.

See this Discord thread for more details: [radarr_taglist attribute is blank](https://discord.com/channels/822460010649878528/1333858629002072074)

**Important note**: As described on the Discord thread, fixing the typo still raises `Unknown Error: argument of type 'NoneType' is not iterable` in my context. But I don't know if it's a subsequent bug of the typo somewhere in the codebase, or if the issue is coming from my own config/collection files.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] Updated the CHANGELOG with the changes
