### PR TITLE
Don't hit Plex for sort title we already have

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -87,3 +87,4 @@ Fixed NoneError when using a blank `radarr_taglist` or `sonarr_taglist`.
 Fixes an issue with boolean filter matching.
 Fixes an issue where the decade default collection names were incorrect.
 Fixes the playlist default to automatically work with a supplied list.
+Remove an unecessary request to Plex while processing overlays.

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -608,7 +608,7 @@ class Overlays:
                                 properties[prop_name].keys.append(item.ratingKey)
                     if added_titles:
                         logger.info(f"{len(added_titles)} Items found for {prop_name}")
-                        logger.trace(f"Titles Found: {[self.library.get_item_sort_title(a, atr='title') for a in added_titles]}")
+                        logger.trace(f"Titles Found: {[a.titleSort for a in added_titles]}")
                     else:
                         logger.warning(f"No Items found for {prop_name}")
                     logger.info("")


### PR DESCRIPTION
## Description

Removes an unnecessary request to Plex while processing overlays.

Here in `overlays.py` at line 609:
```
                    if added_titles:
                        logger.info(f"{len(added_titles)} Items found for {prop_name}")
                        logger.trace(f"Titles Found: {[self.library.get_item_sort_title(a, atr='title') for a in added_titles]}")
```
`added_titles` is a list of Plex objects which already contain the sort title.  There's no need to hit Plex to ask for it.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] Updated the CHANGELOG with the changes
