### PR TITLE
Sort title tweak

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -87,3 +87,4 @@ Fixed NoneError when using a blank `radarr_taglist` or `sonarr_taglist`.
 Fixes an issue with boolean filter matching.
 Fixes an issue where the decade default collection names were incorrect.
 Fixes the playlist default to automatically work with a supplied list.
+Remove an unecessary request to Plex while processing overlays.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -87,4 +87,4 @@ Fixed NoneError when using a blank `radarr_taglist` or `sonarr_taglist`.
 Fixes an issue with boolean filter matching.
 Fixes an issue where the decade default collection names were incorrect.
 Fixes the playlist default to automatically work with a supplied list.
-Remove an unecessary request to Plex while processing overlays.
+Remove an unnecessary request to Plex while processing overlays.

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -877,7 +877,7 @@ class Operations:
 
                     for ep in item.episodes():
                         ep = self.library.reload(ep)
-                        item_title = self.library.get_item_sort_title(ep, atr="title")
+                        item_title = self.library.get_item_sort_title(ep)
                         logger.info("")
                         logger.info(f"Processing {item_title}")
                         item_edits = ""

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -877,7 +877,7 @@ class Operations:
 
                     for ep in item.episodes():
                         ep = self.library.reload(ep)
-                        item_title = self.library.get_item_sort_title(ep)
+                        item_title = self.library.get_item_display_title(ep)
                         logger.info("")
                         logger.info(f"Processing {item_title}")
                         item_edits = ""

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -41,7 +41,7 @@ class Overlays:
                     logger.separator(f"Removing {old_overlay.title}")
                     logger.info("")
                     for i, item in enumerate(label_items, 1):
-                        item_title = self.library.get_item_sort_title(item, atr="title")
+                        item_title = self.library.get_item_sort_title(item)
                         logger.ghost(f"Restoring {old_overlay.title}: {i}/{len(label_items)} {item_title}")
                         self.remove_overlay(item, item_title, old_overlay.title, [
                             os.path.join(self.library.overlay_folder, old_overlay.title[:-8], f"{item.ratingKey}.png")
@@ -58,7 +58,7 @@ class Overlays:
         if remove_overlays:
             logger.separator(f"Removing {'All ' if self.library.remove_overlays else ''}Overlays for the {self.library.name} Library")
             for i, item in enumerate(remove_overlays, 1):
-                item_title = self.library.get_item_sort_title(item, atr="title")
+                item_title = self.library.get_item_sort_title(item)
                 logger.ghost(f"Restoring: {i}/{len(remove_overlays)} {item_title}")
                 self.remove_overlay(item, item_title, "Overlay", [
                     os.path.join(self.library.overlay_backup, f"{item.ratingKey}.png"),
@@ -82,8 +82,8 @@ class Overlays:
                     raise Failed
                 return _trakt_ratings
 
-            for i, (over_key, (item, over_names)) in enumerate(sorted(key_to_overlays.items(), key=lambda io: self.library.get_item_sort_title(io[1][0])), 1):
-                item_title = self.library.get_item_sort_title(item, atr="title")
+            for i, (over_key, (item, over_names)) in enumerate(sorted(key_to_overlays.items(), key=lambda io: self.library.get_item_sort_title(io[1][0], sort=True)), 1):
+                item_title = self.library.get_item_sort_title(item)
                 try:
                     logger.ghost(f"Overlaying: {i}/{len(key_to_overlays)} {item_title}")
                     image_compare = None
@@ -597,19 +597,6 @@ class Overlays:
                             else:
                                 raise Failed(e)
 
-                    def get_log_title(item):
-                        try:
-                            log_title = item.titleSort
-                            if item.type == 'episode':
-                                # Happy Days S01E01
-                                log_title = item.grandparentTitle + " " + item.seasonEpisode.upper()
-                            if item.type == 'season':
-                                # Happy Days Season 1
-                                log_title = item.parentTitle + " " + item.titleSort
-                        except:
-                            log_title = "UNKNOWN"
-                        return log_title
-
                     added_titles = []
                     if builder.found_items:
                         for item in builder.found_items:
@@ -621,7 +608,7 @@ class Overlays:
                                 properties[prop_name].keys.append(item.ratingKey)
                     if added_titles:
                         logger.info(f"{len(added_titles)} Items found for {prop_name}")
-                        logger.trace(f"Titles Found: {[get_log_title(a) for a in added_titles]}")
+                        logger.trace(f"Titles Found: {[self.library.get_item_sort_title(a) for a in added_titles]}")
                     else:
                         logger.warning(f"No Items found for {prop_name}")
                     logger.info("")

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -41,7 +41,7 @@ class Overlays:
                     logger.separator(f"Removing {old_overlay.title}")
                     logger.info("")
                     for i, item in enumerate(label_items, 1):
-                        item_title = self.library.get_item_sort_title(item)
+                        item_title = self.library.get_item_display_title(item)
                         logger.ghost(f"Restoring {old_overlay.title}: {i}/{len(label_items)} {item_title}")
                         self.remove_overlay(item, item_title, old_overlay.title, [
                             os.path.join(self.library.overlay_folder, old_overlay.title[:-8], f"{item.ratingKey}.png")
@@ -58,7 +58,7 @@ class Overlays:
         if remove_overlays:
             logger.separator(f"Removing {'All ' if self.library.remove_overlays else ''}Overlays for the {self.library.name} Library")
             for i, item in enumerate(remove_overlays, 1):
-                item_title = self.library.get_item_sort_title(item)
+                item_title = self.library.get_item_display_title(item)
                 logger.ghost(f"Restoring: {i}/{len(remove_overlays)} {item_title}")
                 self.remove_overlay(item, item_title, "Overlay", [
                     os.path.join(self.library.overlay_backup, f"{item.ratingKey}.png"),
@@ -82,8 +82,8 @@ class Overlays:
                     raise Failed
                 return _trakt_ratings
 
-            for i, (over_key, (item, over_names)) in enumerate(sorted(key_to_overlays.items(), key=lambda io: self.library.get_item_sort_title(io[1][0], sort=True)), 1):
-                item_title = self.library.get_item_sort_title(item)
+            for i, (over_key, (item, over_names)) in enumerate(sorted(key_to_overlays.items(), key=lambda io: self.library.get_item_display_title(io[1][0], sort=True)), 1):
+                item_title = self.library.get_item_display_title(item)
                 try:
                     logger.ghost(f"Overlaying: {i}/{len(key_to_overlays)} {item_title}")
                     image_compare = None
@@ -608,7 +608,7 @@ class Overlays:
                                 properties[prop_name].keys.append(item.ratingKey)
                     if added_titles:
                         logger.info(f"{len(added_titles)} Items found for {prop_name}")
-                        logger.trace(f"Titles Found: {[self.library.get_item_sort_title(a) for a in added_titles]}")
+                        logger.trace(f"Titles Found: {[self.library.get_item_display_title(a) for a in added_titles]}")
                     else:
                         logger.warning(f"No Items found for {prop_name}")
                     logger.info("")

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -608,7 +608,7 @@ class Overlays:
                                 properties[prop_name].keys.append(item.ratingKey)
                     if added_titles:
                         logger.info(f"{len(added_titles)} Items found for {prop_name}")
-                        logger.trace(f"Titles Found: {[self.library.get_item_sort_title(a, atr='title') for a in added_titles]}")
+                        logger.trace(f"Titles Found: {[a.titleSort for a in added_titles]}")
                     else:
                         logger.warning(f"No Items found for {prop_name}")
                     logger.info("")

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -597,6 +597,19 @@ class Overlays:
                             else:
                                 raise Failed(e)
 
+                    def get_log_title(item):
+                        try:
+                            log_title = item.titleSort
+                            if item.type == 'episode':
+                                # Happy Days S01E01
+                                log_title = item.grandparentTitle + " " + item.seasonEpisode.upper()
+                            if item.type == 'season':
+                                # Happy Days Season 1
+                                log_title = item.parentTitle + " " + item.titleSort
+                        except:
+                            log_title = "UNKNOWN"
+                        return log_title
+
                     added_titles = []
                     if builder.found_items:
                         for item in builder.found_items:
@@ -608,7 +621,7 @@ class Overlays:
                                 properties[prop_name].keys.append(item.ratingKey)
                     if added_titles:
                         logger.info(f"{len(added_titles)} Items found for {prop_name}")
-                        logger.trace(f"Titles Found: {[a.titleSort for a in added_titles]}")
+                        logger.trace(f"Titles Found: {[get_log_title(a) for a in added_titles]}")
                     else:
                         logger.warning(f"No Items found for {prop_name}")
                     logger.info("")

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1674,7 +1674,7 @@ class Plex(Library):
 
         return map_key, attrs
 
-    def get_item_sort_title(self, item_to_sort, sort=False):
+    def get_item_display_title(self, item_to_sort, sort=False):
         if isinstance(item_to_sort, Album):
             return f"{item_to_sort.artist().titleSort if sort else item_to_sort.parentTitle} Album {item_to_sort.titleSort if sort else item_to_sort.title}"
         elif isinstance(item_to_sort, Season):

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1674,15 +1674,15 @@ class Plex(Library):
 
         return map_key, attrs
 
-    def get_item_sort_title(self, item_to_sort, atr="titleSort"):
+    def get_item_sort_title(self, item_to_sort, sort=False):
         if isinstance(item_to_sort, Album):
-            return f"{getattr(item_to_sort.artist(), atr)} Album {getattr(item_to_sort, atr)}"
+            return f"{item_to_sort.artist().titleSort if sort else item_to_sort.parentTitle} Album {item_to_sort.titleSort if sort else item_to_sort.title}"
         elif isinstance(item_to_sort, Season):
-            return f"{getattr(item_to_sort.show(), atr)} Season {item_to_sort.seasonNumber}"
+            return f"{item_to_sort.show().titleSort if sort else item_to_sort.parentTitle} Season {item_to_sort.seasonNumber}"
         elif isinstance(item_to_sort, Episode):
-            return f"{getattr(item_to_sort.show(), atr)} {item_to_sort.seasonEpisode.upper()}"
+            return f"{item_to_sort.show().titleSort if sort else item_to_sort.grandparentTitle} {item_to_sort.seasonEpisode.upper()}"
         else:
-            return getattr(item_to_sort, atr)
+            return item_to_sort.titleSort if sort else item_to_sort.title
 
     def split(self, text):
         attribute, modifier = os.path.splitext(str(text).lower())


### PR DESCRIPTION
## Description

Removes an unnecessary request to Plex while processing overlays.

Here in `overlays.py` at line 609:
```
                    if added_titles:
                        logger.info(f"{len(added_titles)} Items found for {prop_name}")
                        logger.trace(f"Titles Found: {[self.library.get_item_sort_title(a, atr='title') for a in added_titles]}")
```
`added_titles` is a list of Plex objects which already contain the sort title.  There's no need to hit Plex to ask for it.

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [X] Updated the CHANGELOG with the changes
