### PR TITLE
Update playlist.yml

### DIFF
--- a/defaults/playlist.yml
+++ b/defaults/playlist.yml
@@ -22,6 +22,8 @@ templates:
             value: https://www.imdb.com/list/ls566357882/
           - key: starwars
             value: https://www.imdb.com/list/ls501373412/
+          - key: startrek
+            value: https://www.imdb.com/list/ls525763569/
           - key: xmen
             value: https://www.imdb.com/list/ls567618635/
         # check2


### PR DESCRIPTION
nightly wiki has imdb list for star trek, but not in the yml.  adding

## Description
nightly wiki listed the imdb list for star trek, but not on the nightly build
Please include a summary of the changes.

### Issues Fixed or Closed

- Fixes #(2354)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
- [] Updated the CHANGELOG with the changes
