### PR TITLE
Prevent Verified Hot Overlay running on Show Libraries

### DIFF
--- a/.github/workflows/validate-pull.yml
+++ b/.github/workflows/validate-pull.yml
@@ -56,7 +56,7 @@ jobs:
             done
 
       - name: Get all changed files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v46
         id: changed_files
         with:
           files: |

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,8 +8,9 @@ Update pathvalidate requirement to 3.2.3
 Update pillow requirement to 11.1.0
 Update plexapi requirement to 4.16.1
 Update psutil requirement to 7.0.0
+Update pywin32 requirement to 310
 Update ruamel-yaml requirement to 0.18.9
-Update setuptools requirement to 75.8.2
+Update setuptools requirement to 76.1.0
 Update tmdbapis requirement to 1.2.28
 
 # Important Changes

--- a/defaults/overlays/ratings.yml
+++ b/defaults/overlays/ratings.yml
@@ -76,6 +76,7 @@ templates:
         conditions:
           - image_level: Top
             rating<<rating_num>>_image: rt_popcorn
+            library_type: movie
             value: https://mdblist.com/lists/k0meta/verifiedhot<<library_type>>s
           - image_level: Top
             rating<<rating_num>>_image: rt_tomato

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,10 @@ PlexAPI==4.16.1
 psutil==7.0.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.0.1
-pywin32==308; sys_platform == 'win32'
+pywin32==310; sys_platform == 'win32'
 requests==2.32.3
 ruamel.yaml==0.18.10
 schedule==1.2.2
-setuptools==75.8.2
+setuptools==76.1.0
 tenacity==9.0.0
 tmdbapis==1.2.28


### PR DESCRIPTION
## Description

Prevent Verified Hot Overlay run on Show libraries since only Movies are included by Rotten Tomatoes.

Also updated some requirements

## Checklist

Please delete options that are not relevant.

- [X] Updated the CHANGELOG with the changes
