### PR TITLE
[Docs Test] Make contents full-width

### DIFF
--- a/docs/assets/css/extra.css
+++ b/docs/assets/css/extra.css
@@ -105,7 +105,6 @@ table tr td code {
 
 @media only screen and (min-width: 76.25em) {
     .md-main__inner {
-        max-width: 80%;
         margin-top: 0;
     }
 
@@ -120,6 +119,16 @@ table tr td code {
         -webkit-transform: none;
         transform: none;
     }
+}
+
+.md-grid {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 100%;
+}
+
+.md-content {
+    border-left: 2px solid #2f2f2f;
 }
 
 @keyframes heart {


### PR DESCRIPTION
## Description

Just as a test, gets rid of left and right free space, moving contents to use full real estate of the screen.


## Type of Change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation change (non-code changes affecting only the wiki)
- [] Infrastructure change (changes related to the github repo, build process, or the like)

## Checklist

Please delete options that are not relevant.

- [] Updated Documentation to reflect changes
- [] Updated the CHANGELOG with the changes
