### PR TITLE
add log file name prepend arg to allow multiple simultaneously kometa runs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Update tenacity requirement to 9.1.2
 # Important Changes
 
 # New Features
+- Add argument to prepend a string to the logfilename `--log-filename-prepend movies`
 
 # Docs
 

--- a/docs/kometa/environmental.md
+++ b/docs/kometa/environmental.md
@@ -438,6 +438,36 @@ Kometa will load those environment variables when it starts up, and you don't ha
             docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa --overlays-only
             ```
 
+??? blank "Log filename prepend&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`-lfp`/`--log-filename-prepend`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_LOG_FILENAME_PREPEND`<a class="headerlink" href="#log-filename-prepend" title="Permanent link">¶</a>"
+
+    <div id="log-filename-prepend" />Prepend a string to the log filename. 
+    Usefull if you want to run multiple instances of Kometa at the same time, 
+    or if you want to have a different log filename for each run.
+    Without this, the log is locked to the first instance of Kometa that runs, and all other instances will fail to write to the log file.
+
+    <hr style="margin: 0px;">
+
+    **Shell Flags:**  `-lfp` or `--log-filename-prepend` (ex. `--log-filename-prepend movies`)
+
+    **Environment Variable:** `KOMETA_LOG_FILENAME_PREPEND` (ex. `KOMETA_LOG_FILENAME_PREPEND=movies`)
+    
+    !!! example
+        === "Local Environment"
+            ```
+            # movies_meta.log
+            python kometa.py --log-filename-prepend movies --run-libraries "Movies"
+
+            # series_meta.log
+            python kometa.py --log-filename-prepend series --run-libraries "Series"
+            ```
+        === "Docker Environment"
+            ```
+            # movies_meta.log
+            docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa --log-filename-prepend movies --run-libraries "Movies"
+            # series_meta.log
+            docker run -it -v "X:\Media\Kometa\config:/config:rw" kometateam/kometa ---log-filename-prepend series --run-libraries "Series"
+            ```
+
 ??? blank "Run Collections&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`-rc`/`--run-collections`&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`KOMETA_RUN_COLLECTIONS`<a class="headerlink" href="#run-collections" title="Permanent link">¶</a>"
 
     <div id="run-collections" />Perform an [immediate run](#run) to run only the named collections, bypassing the time to run flag.

--- a/docs/kometa/logs.md
+++ b/docs/kometa/logs.md
@@ -10,6 +10,9 @@ hide:
 
 The meta.log file can be found within the `logs` folder of your Kometa config folder [right next to `config.yml`].
 
+You can prepend something to the logfile name with the argument `--log-filename-prepend movies` and the log filename will be `movies_meta.log`.      
+This will be necessary if you want to run multiple kometa instances simultaneously.
+
 `meta.log` is the most recent run of Kometa.
 
 As new log files are created, the old ones get a numeric suffix added: `meta-1.log`. **The most recent is always the one without a number at the end.**

--- a/kometa.py
+++ b/kometa.py
@@ -50,6 +50,7 @@ arguments = {
     "debug": {"args": "db", "type": "bool", "help": "Run with Debug Logs Reporting to the Command Window"},
     "trace": {"args": "tr", "type": "bool", "help": "Run with extra Trace Debug Logs"},
     "log-requests": {"args": ["lr", "log-request"], "type": "bool", "help": "Run with all Requests printed"},
+    "log-filename-prepend": {"args": ["lfp", "log-filename-prepend"], "type": "str", "default": "", "help": "Prepend to the log filename"},
     "timeout": {"args": "ti", "type": "int", "default": 180, "help": "Kometa Global Timeout (Default: 180)"},
     "no-verify-ssl": {"args": "nv", "type": "bool", "help": "Turns off Global SSL Verification"},
     "collections-only": {"args": ["co", "collection-only"], "type": "bool", "help": "Run only collection files"},
@@ -214,7 +215,7 @@ elif not os.path.exists(os.path.join(default_dir, "config.yml")):
 
 
 logger = MyLogger("Kometa", default_dir, run_args["width"], run_args["divider"][0], run_args["ignore-ghost"],
-                  run_args["tests"] or run_args["debug"], run_args["trace"], run_args["log-requests"])
+                  run_args["tests"] or run_args["debug"], run_args["trace"], run_args["log-requests"], run_args["log-filename-prepend"])
 
 from modules import util
 util.logger = logger

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -33,7 +33,7 @@ def log_namer(default_name):
 
 
 class MyLogger:
-    def __init__(self, logger_name, default_dir, screen_width, separating_character, ignore_ghost, is_debug, is_trace, log_requests):
+    def __init__(self, logger_name, default_dir, screen_width, separating_character, ignore_ghost, is_debug, is_trace, log_requests, log_filename_prepend=""):
         self.logger_name = logger_name
         self.default_dir = default_dir
         self.screen_width = screen_width
@@ -43,8 +43,9 @@ class MyLogger:
         self.log_requests = log_requests
         self.ignore_ghost = ignore_ghost
         self.log_dir = os.path.join(default_dir, LOG_DIR)
+        self.log_filename_prepend = log_filename_prepend+"_" if log_filename_prepend else ""
         self.playlists_dir = os.path.join(self.log_dir, PLAYLIST_DIR)
-        self.main_log = os.path.join(self.log_dir, MAIN_LOG)
+        self.main_log = os.path.join(self.log_dir, self.log_filename_prepend+MAIN_LOG)
         self.main_handler = None
         self.save_errors = False
         self.saved_errors = []
@@ -54,7 +55,7 @@ class MyLogger:
         self.playlists_handler = None
         self.secrets = []
         self.spacing = 0
-        self.playlists_log = os.path.join(self.playlists_dir, PLAYLISTS_LOG)
+        self.playlists_log = os.path.join(self.playlists_dir, self.log_filename_prepend+PLAYLISTS_LOG)
         if not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir, exist_ok=True)
         self._logger = logging.getLogger(None if self.log_requests else self.logger_name)
@@ -120,7 +121,7 @@ class MyLogger:
         os.makedirs(collection_dir, exist_ok=True)
         if library_key not in self.collection_handlers:
             self.collection_handlers[library_key] = {}
-        self.collection_handlers[library_key][collection_key] = self._get_handler(os.path.join(collection_dir, COLLECTION_LOG))
+        self.collection_handlers[library_key][collection_key] = self._get_handler(os.path.join(collection_dir, self.log_filename_prepend+COLLECTION_LOG))
         self._logger.addHandler(self.collection_handlers[library_key][collection_key])
 
     def remove_collection_handler(self, library_key, collection_key):
@@ -130,7 +131,7 @@ class MyLogger:
     def add_playlist_handler(self, playlist_key):
         playlist_dir = os.path.join(self.playlists_dir, playlist_key)
         os.makedirs(playlist_dir, exist_ok=True)
-        self.playlist_handlers[playlist_key] = self._get_handler(os.path.join(playlist_dir, PLAYLIST_LOG))
+        self.playlist_handlers[playlist_key] = self._get_handler(os.path.join(playlist_dir, self.log_filename_prepend+PLAYLIST_LOG))
         self._logger.addHandler(self.playlist_handlers[playlist_key])
 
     def remove_playlist_handler(self, playlist_key):


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [x] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Add an optional argument `--log-filename-prepend` to allow prepending a custom string to the log file name. This enables running multiple Kometa instances simultaneously - for example, one instance per library - without file access conflicts.

Without this option, all instances try to write to the same default `meta.log`, which leads to file locking issues or write errors, especially on systems where the log file cannot be shared (e.g., Windows). Using a unique log file per instance solves this problem and improves parallel execution and debugging.

**Example usage:**
```bash
python kometa.py --run-libraries "Movies" --log-filename-prepend movies
python kometa.py --run-libraries "Series" --log-filename-prepend series
```

This will generate `movies_meta.log` and `series_meta.log` respectively.

## Related Issues [optional]
- Related Issue -
- Closes -

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [x] Yes
- [ ] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Ye
-->
- [ ] Yes
- [x] No
