### PR TITLE
Add ability to update logos via metadata files

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -149,6 +149,7 @@ jinja
 jkirkcaldy
 johnfawkes
 jonnywong
+joost
 jpeg
 jpg
 json

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ Update tenacity requirement to 9.1.2
 # Important Changes
 
 # New Features
+Added `file_logo` and `url_logo` as metadata image options **credit to @Joost1991**
 
 # Docs
 

--- a/docs/files/metadata.md
+++ b/docs/files/metadata.md
@@ -510,8 +510,10 @@ You can add `.sync` to any tag attribute to sync all tags vs just appending the 
 | :---------------- | :----------------------------------------------- | :------------------------------------------------------------ |
 | `file_background` | Path to image in the file system.                | `Movies`, `Shows`, `Seasons`, `Episodes`, `Artists`, `Albums` |
 | `file_poster`     | Path to image in the file system.                | `Movies`, `Shows`, `Seasons`, `Episodes`, `Artists`, `Albums` |
+| `file_logo`       | Path to image in the file system.                | `Movies`, `Shows`, `Seasons`, `Episodes`                      | 
 | `url_background`  | URL of image publicly available on the internet. | `Movies`, `Shows`, `Seasons`, `Episodes`, `Artists`, `Albums` |
 | `url_poster`      | URL of image publicly available on the internet. | `Movies`, `Shows`, `Seasons`, `Episodes`, `Artists`, `Albums` |
+| `url_logo`        | URL of image publicly available on the internet. | `Movies`, `Shows`, `Seasons`, `Episodes`                      |
 
 ### Advanced Attributes
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -3516,7 +3516,7 @@ class CollectionBuilder:
                 self.backgrounds["style_data"] = f"https://theposterdb.com/api/assets/{style_data['tpdb_background']}"
 
         self.collection_poster = self.library.pick_image(self.obj.title, self.posters, self.library.prioritize_assets, self.library.download_url_assets, asset_location)
-        self.collection_background = self.library.pick_image(self.obj.title, self.backgrounds, self.library.prioritize_assets, self.library.download_url_assets, asset_location, is_poster=False)
+        self.collection_background = self.library.pick_image(self.obj.title, self.backgrounds, self.library.prioritize_assets, self.library.download_url_assets, asset_location, image_type="background")
 
         clean_temp = False
         if isinstance(self.collection_poster, KometaImage):
@@ -3525,7 +3525,7 @@ class CollectionBuilder:
             self.collection_poster = self.collection_poster.save(item_vars)
 
         if self.collection_poster or self.collection_background:
-            pu, bu = self.library.upload_images(self.obj, poster=self.collection_poster, background=self.collection_background)
+            pu, bu, lu = self.library.upload_images(self.obj, poster=self.collection_poster, background=self.collection_background)
             if pu or bu:
                 updated_details.append("Image")
 

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -893,6 +893,14 @@ class Cache:
                             location TEXT)"""
                         )
                         cursor.execute(
+                            f"""CREATE TABLE IF NOT EXISTS {table_name}_logos (
+                            key INTEGER PRIMARY KEY,
+                            rating_key TEXT UNIQUE,
+                            overlay TEXT,
+                            compare TEXT,
+                            location TEXT)"""
+                        )
+                        cursor.execute(
                             f"""CREATE TABLE IF NOT EXISTS {table_name}_overlays (
                             key INTEGER PRIMARY KEY,
                             rating_key TEXT UNIQUE,

--- a/modules/library.py
+++ b/modules/library.py
@@ -200,7 +200,7 @@ class Library(ABC):
                     logger.info("")
                     logger.separator(f"Skipping {e} Image File")
 
-    def upload_images(self, item, poster=None, background=None, overlay=False):
+    def upload_images(self, item, poster=None, background=None, logo=None, overlay=False):
         poster_uploaded = False
         if poster is not None:
             try:
@@ -234,13 +234,31 @@ class Library(ABC):
             except Failed:
                 logger.stacktrace()
                 logger.error(f"Metadata: {background.attribute} failed to update {background.message}")
+
+        logo_uploaded = False
+        if logo is not None:
+            try:
+                image_compare = None
+                if self.config.Cache:
+                    _, image_compare, _ = self.config.Cache.query_image_map(item.ratingKey, f"{self.image_table_name}_logos")
+                if not image_compare or str(logo.compare) != str(image_compare):
+                    logo_uploaded = self._upload_image(item, logo)
+                    logger.info(f"Metadata: {logo.attribute} updated {logo.message}")
+                elif self.show_asset_not_needed:
+                    logger.info(f"Metadata: {logo.prefix}logo update not needed")
+            except Failed:
+                logger.stacktrace()
+                logger.error(f"Metadata: {logo.attribute} failed to update {logo.message}")
+
         if self.config.Cache:
             if poster_uploaded:
                 self.config.Cache.update_image_map(item.ratingKey, self.image_table_name, "", poster.compare if poster else "")
             if background_uploaded:
                 self.config.Cache.update_image_map(item.ratingKey, f"{self.image_table_name}_backgrounds", "", background.compare)
+            if logo_uploaded:
+                self.config.Cache.update_image_map(item.ratingKey, f"{self.image_table_name}_logos", "", logo.compare)
 
-        return poster_uploaded, background_uploaded
+        return poster_uploaded, background_uploaded, logo_uploaded
 
     def get_id_from_maps(self, key):
         key = int(key)
@@ -275,8 +293,13 @@ class Library(ABC):
     def image_update(self, item, image, tmdb=None, title=None, poster=True):
         pass
 
-    def pick_image(self, title, images, prioritize_assets, download_url_assets, item_dir, is_poster=True, image_name=None):
-        image_type = "poster" if is_poster else "background"
+    def pick_image(self, title, images, prioritize_assets, download_url_assets, item_dir, is_poster=True, is_background=False, image_name=None):
+        image_type = "poster"
+        if not is_poster:
+            if is_background:
+                image_type = "background"
+            else:
+                image_type = "logo"
         if image_name is None:
             image_name = image_type
         if images:
@@ -303,7 +326,7 @@ class Library(ABC):
                                 logger.error(e)
                     if attr in ["asset_directory", f"pmm_{image_type}"]:
                         return images[attr]
-                    return ImageData(attr, images[attr], is_poster=is_poster, is_url=attr != f"file_{image_type}")
+                    return ImageData(attr, images[attr], is_poster=is_poster, is_background=is_background, is_url=attr != f"file_{image_type}")
 
     @abstractmethod
     def reload(self, item, force=False):

--- a/modules/library.py
+++ b/modules/library.py
@@ -293,13 +293,7 @@ class Library(ABC):
     def image_update(self, item, image, tmdb=None, title=None, poster=True):
         pass
 
-    def pick_image(self, title, images, prioritize_assets, download_url_assets, item_dir, is_poster=True, is_background=False, image_name=None):
-        image_type = "poster"
-        if not is_poster:
-            if is_background:
-                image_type = "background"
-            else:
-                image_type = "logo"
+    def pick_image(self, title, images, prioritize_assets, download_url_assets, item_dir, image_type="poster", image_name=None):
         if image_name is None:
             image_name = image_type
         if images:
@@ -321,12 +315,12 @@ class Library(ABC):
                             return images["asset_directory"]
                         else:
                             try:
-                                return self.config.Requests.download_image(title, images[attr], item_dir, session=self.session, is_poster=is_poster, filename=image_name)
+                                return self.config.Requests.download_image(title, images[attr], item_dir, session=self.session, image_type=image_type, filename=image_name)
                             except Failed as e:
                                 logger.error(e)
                     if attr in ["asset_directory", f"pmm_{image_type}"]:
                         return images[attr]
-                    return ImageData(attr, images[attr], is_poster=is_poster, is_background=is_background, is_url=attr != f"file_{image_type}")
+                    return ImageData(attr, images[attr], image_type=image_type, is_url=attr != f"file_{image_type}")
 
     @abstractmethod
     def reload(self, item, force=False):

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -813,12 +813,16 @@ class Plex(Library):
                 upload_success = self.validate_image_size(image)
                 if upload_success:
                     item.uploadPoster(filepath=image.location)
-            elif image.is_url:
+            elif image.is_background and image.is_url:
                 item.uploadArt(url=image.location)
-            else:
+            elif image.is_background:
                 upload_success = self.validate_image_size(image)
                 if upload_success:
                     item.uploadArt(filepath=image.location)
+            elif image.is_url:
+                item.uploadLogo(url=image.location)
+            else:
+                item.uploadLogo(filepath=image.location)
             self.reload(item, force=True)
             return upload_success
         except BadRequest as e:
@@ -838,6 +842,13 @@ class Plex(Library):
             item.uploadArt(url=image)
         else:
             item.uploadArt(filepath=image)
+
+    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type((BadRequest, NotFound, Unauthorized)))
+    def upload_logo(self, item, image, url=False):
+        if url:
+            item.uploadLogo(url=image)
+        else:
+            item.uploadLogo(filepath=image)
 
     @retry(stop=stop_after_attempt(6), wait=wait_fixed(10), retry=retry_if_not_exception_type(Failed))
     def get_actor_id(self, name):
@@ -1324,7 +1335,7 @@ class Plex(Library):
     def item_images(self, item, group, alias, initial=False, asset_location=None, asset_directory=None, title=None, image_name=None, folder_name=None, style_data=None):
         if title is None:
             title = item.title
-        posters, backgrounds = util.get_image_dicts(group, alias)
+        posters, backgrounds, logos = util.get_image_dicts(group, alias)
         if style_data and "url_poster" in style_data and style_data["url_poster"]:
             posters["style_data"] = style_data["url_poster"]
         elif style_data and "tpdb_poster" in style_data and style_data["tpdb_poster"]:
@@ -1333,8 +1344,10 @@ class Plex(Library):
             backgrounds["style_data"] = style_data["url_background"]
         elif style_data and "tpdb_background" in style_data and style_data["tpdb_background"]:
             backgrounds["style_data"] = f"https://theposterdb.com/api/assets/{style_data['tpdb_background']}"
+        if style_data and "url_logo" in style_data and style_data["url_logo"]:
+            logos["style_data"] = style_data["url_logo"]
         try:
-            asset_poster, asset_background, item_dir, folder_name = self.find_item_assets(item, item_asset_directory=asset_location, asset_directory=asset_directory)
+            asset_poster, asset_background, item_dir, folder_name, asset_logo = self.find_item_assets(item, item_asset_directory=asset_location, asset_directory=asset_directory)
             if asset_poster:
                 posters["asset_directory"] = asset_poster
             if asset_background:
@@ -1345,11 +1358,13 @@ class Plex(Library):
             logger.warning(e)
         poster = self.pick_image(title, posters, self.prioritize_assets, self.download_url_assets, asset_location, image_name=image_name)
         background = self.pick_image(title, backgrounds, self.prioritize_assets, self.download_url_assets, asset_location,
-                                     is_poster=False, image_name=f"{image_name}_background" if image_name else image_name)
+                                     is_poster=False, is_background=True, image_name=f"{image_name}_background" if image_name else image_name)
+        logo = self.pick_image(title, logos, self.prioritize_assets, self.download_url_assets, asset_location,
+                                     is_poster=False, is_background=False, image_name=f"{image_name}_logo" if image_name else image_name)
         updated = False
-        if poster or background:
-            pu, bu = self.upload_images(item, poster=poster, background=background, overlay=True)
-            if pu or bu:
+        if poster or background or logo:
+            pu, bu, lu = self.upload_images(item, poster=poster, background=background, logo=logo, overlay=True)
+            if pu or bu or lu:
                 updated = True
         return asset_location, folder_name, updated
 
@@ -1388,8 +1403,8 @@ class Plex(Library):
                 for episode in self.query(season.episodes):
                     try:
                         if episode.seasonEpisode:
-                            episode_poster, episode_background, _, _ = self.find_item_assets(episode, item_asset_directory=item_dir, asset_directory=asset_directory, folder_name=name)
-                            if episode_poster or episode_background:
+                            episode_poster, episode_background, _, _, episode_logo = self.find_item_assets(episode, item_asset_directory=item_dir, asset_directory=asset_directory, folder_name=name)
+                            if episode_poster or episode_background or episode_logo:
                                 found_episode = True
                                 if "Overlay" not in [la.tag for la in self.item_labels(episode)]:
                                     self.upload_images(episode, poster=episode_poster, background=episode_background)
@@ -1421,6 +1436,7 @@ class Plex(Library):
     def find_item_assets(self, item, item_asset_directory=None, asset_directory=None, folder_name=None):
         poster = None
         background = None
+        logo = None
 
         if asset_directory is None:
             asset_directory = self.asset_directory
@@ -1494,6 +1510,7 @@ class Plex(Library):
 
         poster_filter = os.path.join(item_asset_directory, f"{file_name}.*")
         background_filter = os.path.join(item_asset_directory, "background.*" if file_name == "poster" else f"{file_name}_background.*")
+        logo_filter = os.path.join(item_asset_directory, "logo.*" if file_name == "poster" else f"{file_name}_logo.*")
 
         poster_matches = util.glob_filter(poster_filter)
         if len(poster_matches) > 0:
@@ -1501,7 +1518,11 @@ class Plex(Library):
 
         background_matches = util.glob_filter(background_filter)
         if len(background_matches) > 0:
-            background = ImageData("asset_directory", os.path.abspath(background_matches[0]), prefix=prefix, is_poster=False, is_url=False)
+            background = ImageData("asset_directory", os.path.abspath(background_matches[0]), prefix=prefix, is_poster=False, is_background=True, is_url=False)
+
+        logo_matches = util.glob_filter(logo_filter)
+        if len(logo_matches) > 0:
+            logo = ImageData("asset_directory", os.path.abspath(logo_matches[0]), prefix=prefix, is_poster=False, is_url=False)
 
         if is_top_level and self.asset_folders and self.dimensional_asset_rename and (not poster or not background):
             for file in util.glob_filter(os.path.join(item_asset_directory, "*.*")):
@@ -1516,13 +1537,13 @@ class Plex(Library):
                         elif not background and _w > _h:
                             new_path = os.path.join(os.path.dirname(file), f"background{os.path.splitext(file)[1].lower()}")
                             os.rename(file, new_path)
-                            background = ImageData("asset_directory", os.path.abspath(new_path), prefix=prefix, is_poster=False, is_url=False)
+                            background = ImageData("asset_directory", os.path.abspath(new_path), prefix=prefix, is_poster=False, is_background=True, is_url=False)
                         if poster and background:
                             break
                     except OSError:
                         logger.error(f"Asset Error: Failed to open image: {file}")
 
-        return poster, background, item_asset_directory, folder_name
+        return poster, background, item_asset_directory, folder_name, logo
 
     def get_ids(self, item):
         tmdb_id = None

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1358,9 +1358,9 @@ class Plex(Library):
             logger.warning(e)
         poster = self.pick_image(title, posters, self.prioritize_assets, self.download_url_assets, asset_location, image_name=image_name)
         background = self.pick_image(title, backgrounds, self.prioritize_assets, self.download_url_assets, asset_location,
-                                     is_poster=False, is_background=True, image_name=f"{image_name}_background" if image_name else image_name)
+                                     image_type="background", image_name=f"{image_name}_background" if image_name else image_name)
         logo = self.pick_image(title, logos, self.prioritize_assets, self.download_url_assets, asset_location,
-                                     is_poster=False, is_background=False, image_name=f"{image_name}_logo" if image_name else image_name)
+                               image_type="logo", image_name=f"{image_name}_logo" if image_name else image_name)
         updated = False
         if poster or background or logo:
             pu, bu, lu = self.upload_images(item, poster=poster, background=background, logo=logo, overlay=True)
@@ -1518,11 +1518,11 @@ class Plex(Library):
 
         background_matches = util.glob_filter(background_filter)
         if len(background_matches) > 0:
-            background = ImageData("asset_directory", os.path.abspath(background_matches[0]), prefix=prefix, is_poster=False, is_background=True, is_url=False)
+            background = ImageData("asset_directory", os.path.abspath(background_matches[0]), prefix=prefix, image_type="background", is_url=False)
 
         logo_matches = util.glob_filter(logo_filter)
         if len(logo_matches) > 0:
-            logo = ImageData("asset_directory", os.path.abspath(logo_matches[0]), prefix=prefix, is_poster=False, is_url=False)
+            logo = ImageData("asset_directory", os.path.abspath(logo_matches[0]), prefix=prefix, image_type="logo", is_url=False)
 
         if is_top_level and self.asset_folders and self.dimensional_asset_rename and (not poster or not background):
             for file in util.glob_filter(os.path.join(item_asset_directory, "*.*")):
@@ -1537,7 +1537,7 @@ class Plex(Library):
                         elif not background and _w > _h:
                             new_path = os.path.join(os.path.dirname(file), f"background{os.path.splitext(file)[1].lower()}")
                             os.rename(file, new_path)
-                            background = ImageData("asset_directory", os.path.abspath(new_path), prefix=prefix, is_poster=False, is_background=True, is_url=False)
+                            background = ImageData("asset_directory", os.path.abspath(new_path), prefix=prefix, image_type="background", is_url=False)
                         if poster and background:
                             break
                     except OSError:

--- a/modules/poster.py
+++ b/modules/poster.py
@@ -6,19 +6,15 @@ from PIL import Image, ImageFont, ImageDraw, ImageColor
 logger = util.logger
 
 class ImageData:
-    def __init__(self, attribute, location, prefix="", is_poster=True, is_background=False, is_url=True, compare=None):
+    def __init__(self, attribute, location, prefix="", image_type="poster", is_url=True, compare=None):
         self.attribute = attribute
         self.location = location
         self.prefix = prefix
-        self.is_poster = is_poster
-        self.is_background = is_background
+        self.is_poster = image_type == "poster"
+        self.is_background = image_type == "background"
+        self.is_logo = image_type == "logo"
         self.is_url = is_url
         self.compare = compare if compare else location if is_url else os.stat(location).st_size
-        image_type = "poster"
-        if is_background:
-            image_type = "background"
-        elif not is_poster:
-            image_type = "logo"
         self.message = f"{prefix}{image_type} to [{'URL' if is_url else 'File'}] {location}"
 
     def __str__(self):
@@ -398,5 +394,5 @@ class KometaImage(ImageBase):
 
         pmm_image.save(image_path)
 
-        return ImageData(self.image_attr, image_path, is_url=False, compare=self.get_compare_string())
+        return ImageData(self.image_attr, image_path, is_url=False, image_type="poster", compare=self.get_compare_string())
 

--- a/modules/poster.py
+++ b/modules/poster.py
@@ -6,14 +6,20 @@ from PIL import Image, ImageFont, ImageDraw, ImageColor
 logger = util.logger
 
 class ImageData:
-    def __init__(self, attribute, location, prefix="", is_poster=True, is_url=True, compare=None):
+    def __init__(self, attribute, location, prefix="", is_poster=True, is_background=False, is_url=True, compare=None):
         self.attribute = attribute
         self.location = location
         self.prefix = prefix
         self.is_poster = is_poster
+        self.is_background = is_background
         self.is_url = is_url
         self.compare = compare if compare else location if is_url else os.stat(location).st_size
-        self.message = f"{prefix}{'poster' if is_poster else 'background'} to [{'URL' if is_url else 'File'}] {location}"
+        image_type = "poster"
+        if is_background:
+            image_type = "background"
+        elif not is_poster:
+            image_type = "logo"
+        self.message = f"{prefix}{image_type} to [{'URL' if is_url else 'File'}] {location}"
 
     def __str__(self):
         return str(self.__dict__)

--- a/modules/request.py
+++ b/modules/request.py
@@ -90,7 +90,7 @@ class Requests:
             import urllib3
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
-    def download_image(self, title, image_url, download_directory, session=None, is_poster=True, filename=None):
+    def download_image(self, title, image_url, download_directory, session=None, image_type="poster", filename=None):
         response = self.get_image(image_url, session=session)
         new_image = os.path.join(download_directory, f"{filename}") if filename else download_directory
         if response.headers["Content-Type"] == "image/jpeg":
@@ -101,7 +101,7 @@ class Requests:
             new_image += ".png"
         with open(new_image, "wb") as handler:
             handler.write(response.content)
-        return ImageData("asset_directory", new_image, prefix=f"{title}'s ", is_poster=is_poster, is_url=False)
+        return ImageData("asset_directory", new_image, prefix=f"{title}'s ", image_type=image_type, is_url=False)
 
     def file_yaml(self, path_to_file, check_empty=False, create=False, start_empty=False):
         return YAML(path=path_to_file, check_empty=check_empty, create=create, start_empty=start_empty)

--- a/modules/util.py
+++ b/modules/util.py
@@ -121,17 +121,20 @@ start_time = None
 def get_image_dicts(group, alias):
     posters = {}
     backgrounds = {}
+    logos = {}
 
-    for attr in ["url_poster", "file_poster", "url_background", "file_background"]:
+    for attr in ["url_poster", "file_poster", "url_background", "file_background", "file_logo", "url_logo"]:
         if attr in alias:
             if group[alias[attr]]:
                 if "poster" in attr:
                     posters[attr] = group[alias[attr]]
-                else:
+                elif "background" in attr:
                     backgrounds[attr] = group[alias[attr]]
+                else:
+                    logos[attr] = group[alias[attr]]
             else:
                 logger.error(f"Metadata Error: {attr} attribute is blank")
-    return posters, backgrounds
+    return posters, backgrounds, logos
 
 def add_dict_list(keys, value, dict_map):
     for key in keys:


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [X] Documentation Update
- [ ] Other 

## Description

This will add the option to update the clear logos in Plex. These logos are used in the new Plex Experience apps. It can be set either via the filesystem or via an url. It uses the recently added `uploadLogo` method, added in the PlexAPI (https://python-plexapi.readthedocs.io/en/latest/modules/mixins.html#plexapi.mixins.LogoMixin.uploadLogo).

Can be tested by adding it to the metadata section of a movie, show, season or episode.

Example:

```
metadata:
  Seizoen 2025:
    f1_season: 2025
    f1_language: nl
    round_prefix: true
    shorten_gp: true
    seasons:
      1:
        file_logo: "config/assets/2025/01-aus/logo.png"
        summary: "The 2025 Formula 1 season kicks off at Melbourne’s iconic Albert Park Circuit. With unpredictable weather, strategic drama, and high-stakes action, the Australian Grand Prix sets the tone for an exciting year ahead in Formula 1."
      2:
        file_logo: "config/assets/2025/season02-logo.png"
        summary: "The season’s second stop brings Formula 1 back to Shanghai International Circuit for the first sprint weekend of the year. Teams navigate changing conditions and evolving tactics as they adjust to the pace of a rapidly unfolding championship."
      3:
        file_logo: "config/assets/2025/season03-logo.png"
        summary: "The 2025 Formula 1 season heads to the legendary Suzuka Circuit for the Japanese Grand Prix. With its figure-eight layout and demanding corners, drivers face one of the toughest tests on the calendar as teams push the limits in pursuit of early-season momentum."
      4:
        file_logo: "config/assets/2025/season04-logo.png"
        episodes:
          1:
            file_poster: "config/assets/2025/season04-e01-background.jpg"
          2:
            file_poster: "config/assets/2025/season04-e02-background.jpg"
```

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->
None

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Ye
-->
- [X] Yes
- [ ] No
