### PR TITLE
[Test] Add Search/Filter Variables for Default Collections

### DIFF
--- a/defaults/both/studio.yml
+++ b/defaults/both/studio.yml
@@ -28,9 +28,9 @@ dynamic_collections:
     template_variables:
       search_term:
         default: studio.is
-      search_term2:
+      search_term_secondary:
         20th Century Studios: studio
-      search_value2:
+      search_value_secondary:
         20th Century Studios: 20th Century
       image:
         default: studio/<<key_encoded>>

--- a/defaults/templates.yml
+++ b/defaults/templates.yml
@@ -197,8 +197,18 @@ templates:
       limit_<<key>>: <<limit>>
       search_value: <<value>>
     optional:
-      - search_term2
-      - search_value2
+      - search_term_any1
+      - search_term_any2
+      - search_term_any3
+      - search_term_any4
+      - search_term_any5
+      - search_term_all1
+      - search_term_all2
+      - search_term_all3
+      - search_term_all4
+      - search_term_all5
+      - search_term_secondary
+      - search_value_secondary
       - limit
       - type
     smart_filter:
@@ -207,7 +217,18 @@ templates:
       type: <<type>>
       any:
         <<search_term>>: <<search_value>>
-        <<search_term2>>: <<search_value2>>
+        <<search_term_secondary>>: <<search_value_secondary>>
+        <<search_term_any1>>: <<search_value_any1>>
+        <<search_term_any2>>: <<search_value_any2>>
+        <<search_term_any3>>: <<search_value_any3>>
+        <<search_term_any4>>: <<search_value_any4>>
+        <<search_term_any5>>: <<search_value_any5>>
+        all:
+          <<search_term_all1>>: <<search_value_all1>>
+          <<search_term_all2>>: <<search_value_all2>>
+          <<search_term_all3>>: <<search_value_all3>>
+          <<search_term_all4>>: <<search_value_all4>>
+          <<search_term_all5>>: <<search_value_all5>>
 
   filter:
     default:
@@ -219,7 +240,11 @@ templates:
       filter_value: <<value>>
     optional:
       - limit
+      - filter_term1
       - filter_term2
+      - filter_term3
+      - filter_term4
+      - filter_term5
     smart_label:
       sort_by: <<sort_by_<<key>>>>
       limit: <<limit_<<key>>>>
@@ -229,7 +254,11 @@ templates:
     plex_all: true
     filters:
       <<filter_term>>: <<filter_value>>
+      <<filter_term1>>: <<filter_value1>>
       <<filter_term2>>: <<filter_value2>>
+      <<filter_term3>>: <<filter_value3>>
+      <<filter_term4>>: <<filter_value4>>
+      <<filter_term5>>: <<filter_value5>>
 
   mdb_smart:
     default:


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

This PR adds background functionality to support the user specifying addition plex search/filter criteria for overlays.

### Examples

#### Collection for each genre, but include Ted Lasso in every collection (`title: Ted Lasso` gets added to an `any` plex search)

```
libraries:
  TV Shows:
    collection_files:
      - default: genre
        template_variables:
          search_term_any1: title
          search_value_any1: Ted Lasso
```

#### Colleciton for each studio, but only played items (`plays.gte: 1` gets added to an `all` plex search):
```
libraries:
  TV Shows:
    collection_files:
      - default: studio
        template_variables:
          search_term_all1: plays.gte
          search_value_all1: 1
```

the available template variables are
`search_term_allX` where X is 1, 2, 3, 4 or 5
`search_term_anyX` where X is 1, 2, 3, 4 or 5

for files which use a `plex_all` builder with a filter, the available template variables are
`filter_termX` where X is 1, 2, 3, 4, 5

This will probably make more sense once I add documentation


## Related Issues [optional]


<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, Github will automatically close the issue.
-->
- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Ye
-->
- [ ] Yes
- [X] No
