### PR TITLE
feat: Add conditions for ES region and Amazon Prime Video id

### DIFF
--- a/defaults/both/streaming.yml
+++ b/defaults/both/streaming.yml
@@ -39,7 +39,7 @@ templates:
       final_tmdb_key:
         default: <<tmdb_key>>
         conditions:
-          - region: [CA, AU, NL]
+          - region: [CA, AU, NL, ES]
             tmdb_key: [9]
             value: 119
 

--- a/defaults/overlays/streaming.yml
+++ b/defaults/overlays/streaming.yml
@@ -94,7 +94,7 @@ templates:
       final_tmdb_key:
         default: <<tmdb_key>>
         conditions:
-          - region: [CA, AU, NL]
+          - region: [CA, AU, NL, ES]
             tmdb_key: [9]
             value: 119
       allowed_streaming:
@@ -104,6 +104,9 @@ templates:
             value: False
           - region.not: GB
             tmdb_key: [103, 41, 2300, 39]
+            value: False
+          - region.not: ES
+            tmdb_key: [149, 339, 2241]
             value: False
           - region.not: CA
             tmdb_key: [230]


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

In Spain, Amazon Prime Video uses ID 119.

Additionally, a restriction has been introduced so that, outside the Spanish region, overlays for the Movistar streaming service cannot be run.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [x] No

## Have you updated the CHANGELOG?

- [ ] Yes
- [x] No
