### PR TITLE
Add support for 'posteritem' class in XPath query

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -263,6 +263,7 @@ pokémon
 popeadam
 popularplex
 portainer
+posteritem
 powershell
 pre
 prepend
@@ -401,6 +402,7 @@ wizarding
 wolof
 www
 xmark
+XPath
 xmen
 xyz
 yaml

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,4 +19,4 @@ Add Movistar Plus + as streaming service
 
 
 # Bug Fixes
-Fixes 2765; apparent letterboxd change
+Fixed Letterboxd list functionality by adding support for 'posteritem' class in XPath selector (fixes #2765)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,4 +19,4 @@ Add Movistar Plus + as streaming service
 
 
 # Bug Fixes
-
+Fixes 2765; apparent letterboxd change

--- a/modules/letterboxd.py
+++ b/modules/letterboxd.py
@@ -28,7 +28,7 @@ class Letterboxd:
         if "ajax" not in list_url:
             list_url = list_url.replace("https://letterboxd.com/films", "https://letterboxd.com/films/ajax")
         response = self._request(list_url, language)
-        letterboxd_ids = response.xpath("//li[contains(@class, 'poster-container') or contains(@class, 'film-detail')]/div/@data-film-id")
+        letterboxd_ids = response.xpath("//li[contains(@class, 'poster-container') or contains(@class, 'film-detail') or contains(@class, 'posteritem')]/div/@data-film-id")
         items = []
         for letterboxd_id in letterboxd_ids:
             slugs = response.xpath(f"//div[@data-film-id='{letterboxd_id}']/@data-target-link")


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

Adds a class to the xpath selector to restore letterboxd list functionality.

## Related Issues [optional]

<!--
    For pull requests that relate or close an issue, please include them below. 
    We like to follow [GitHub's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

    For example having the text: "closes #1234" would connect the current pull request to issue 1234.
    And when the merged pull request reaches the master branch, GitHub will automatically close the issue.
-->

- Closes #2765

## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No need

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No
