### PR TITLE
Add progress logging when processing imdb episode ratings (Closes #2785)

### DIFF
--- a/modules/imdb.py
+++ b/modules/imdb.py
@@ -760,7 +760,9 @@ class IMDb:
     def episode_ratings(self):
         if self._episode_ratings is None:
             self._episode_ratings = {}
-            for imdb_id, parent_id, season_num, episode_num in self._interface("episode"):
+            logger.info("Processing IMDb rating for episodes. This may take a while...")
+            all_eps = self._interface("episode")
+            for i, (imdb_id, parent_id, season_num, episode_num) in enumerate(all_eps):
                 if imdb_id not in self.ratings:
                     continue
                 if parent_id not in self._episode_ratings:
@@ -768,6 +770,8 @@ class IMDb:
                 if season_num not in self._episode_ratings[parent_id]:
                     self._episode_ratings[parent_id][season_num] = {}
                 self._episode_ratings[parent_id][season_num][episode_num] = self.ratings[imdb_id]
+                logger.ghost(f"Processing IMDb rating for episodes: {i / len(all_eps) * 100:6.2f}%")
+            logger.exorcise()
         return self._episode_ratings
 
     def get_rating(self, imdb_id):


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

When imdb interfaces are downloaded and processed, all that's visible on stdout is Downloading IMDb Interface: 99.88% even though kometa is actually processing the data (into a dict in memory). For small libraries this isn't an issue, but for large libraries, this can look like a hang.

Additional logging would help alleviate the confusion.

## Related Issues [optional]

- Closes #2785

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

- [ ] Yes
- [X] No
