### PR TITLE
Default back_line_width to 1 when back_line_color is set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -36,3 +36,4 @@ Fixing "list index out of range" error when processing imdb charts #3006
 TMDB language now reflected in mass_poster_update; cache extension
 Reduce size of FILMIN logo
 Replace top-ten-pirated default list with an updated, kometa-controlled one.
+Overlay backdrops with `back_line_color` set but no `back_line_width` no longer crash; `back_line_width` now defaults to 1 in that case. #2645

--- a/modules/overlay.py
+++ b/modules/overlay.py
@@ -173,8 +173,8 @@ class Overlay:
                     raise Failed(f"Overlay Error: overlay {attr}: {self.data[attr]} invalid")
         self.back_color = color("back_color")
         self.back_radius = util.parse("Overlay", "back_radius", self.data["back_radius"], datatype="int", parent="overlay") if "back_radius" in self.data and self.data["back_radius"] else None
-        self.back_line_width = util.parse("Overlay", "back_line_width", self.data["back_line_width"], datatype="int", parent="overlay") if "back_line_width" in self.data and self.data["back_line_width"] else None
         self.back_line_color = color("back_line_color")
+        self.back_line_width = util.parse("Overlay", "back_line_width", self.data["back_line_width"], datatype="int", parent="overlay") if "back_line_width" in self.data and self.data["back_line_width"] else (1 if self.back_line_color else None)
         self.back_padding = util.parse("Overlay", "back_padding", self.data["back_padding"], datatype="int", parent="overlay", minimum=0, default=0) if "back_padding" in self.data else 0
         self.back_align = util.parse("Overlay", "back_align", self.data["back_align"], parent="overlay", default="center", options=["left", "right", "center", "top", "bottom"]) if "back_align" in self.data else "center"
         self.back_box = None


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other 

## Description

PIL's `ImageDraw.rectangle` and `rounded_rectangle` require an int for the `width` argument. `modules/overlay.py:176` initialised `self.back_line_width` to `None` when `back_line_width` was not in the user's config. If the user set `back_line_color` but not `back_line_width`, `has_back` was True (line 189) and the draw at lines 407/409 called PIL with `width=None`, crashing with:

```
TypeError: 'NoneType' object cannot be interpreted as an integer
```

**Implementation:** swapped the two assignments at lines 175-176 so `back_line_color` is parsed first, then defaulted `back_line_width` to 1 when `back_line_color` is set but `back_line_width` was not provided. Behaviour for any other combination is unchanged: width remains None when neither is set, and any user-supplied width is respected.

**Why default 1 (not 0):** PIL's `ImageDraw` outline default is 1px. The existing truthy guard `if "back_line_width" in self.data and self.data["back_line_width"]` already coerced `back_line_width: 0` to None, so this fix does not regress any value a user could previously set explicitly.

**Tested:** verified by inspection that `width=1` reaches both `rectangle` and `rounded_rectangle` calls when `back_line_color` is set without `back_line_width`. `pyspelling --config .spellcheck.yml` passes locally. No new tests — there are no existing overlay tests in `tests/` to extend.

## Related Issues [optional]

- Closes #2645

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [x] No

## Have you updated the CHANGELOG?

- [x] Yes
- [ ] No
