### PR TITLE
fix: accept "popcorn" as alias for "tomatoesaudience" in MDBList ratings

### DIFF
--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -65,7 +65,7 @@ class MDbObj:
                 self.trakt_rating = util.check_num(rating["value"])
             elif rating["source"] == "tomatoes":
                 self.tomatoes_rating = util.check_num(rating["value"])
-            elif rating["source"] == "tomatoesaudience":
+            elif rating["source"] in ("tomatoesaudience", "popcorn"):
                 self.tomatoesaudience_rating = util.check_num(rating["value"])
             elif rating["source"] == "tmdb":
                 self.tmdb_rating = util.check_num(rating["value"])


### PR DESCRIPTION
## Summary

MDBList renamed the Rotten Tomatoes audience score field from `tomatoesaudience` to `popcorn` in their API. This caused `mdb_tomatoesaudience` to silently return no value for all items since the source name check no longer matched.

**Change:** Accept both `"tomatoesaudience"` and `"popcorn"` as valid source names when parsing MDBList rating data, storing the value in `tomatoesaudience_rating` either way.

This is a one-line backward-compatible fix — existing configs using `mdb_tomatoesaudience` continue to work, and the fix handles both the old and new field names from the API.

Closes #3110

## Test plan

- [ ] Run Kometa with `mdb_tomatoesaudience` overlay/filter on a collection and verify scores are populated
- [ ] Confirm existing configs with `mdb_tomatoesaudience` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)