### PR TITLE
fix: expand default language list in languages overlay

### DIFF
--- a/defaults/overlays/languages.yml
+++ b/defaults/overlays/languages.yml
@@ -178,7 +178,7 @@ templates:
   flags:
     default:
       use_<<key>>: <<use>>
-      languages: ["en", "de", "fr", "es", "pt", "ja"]
+      languages: ["en", "de", "fr", "es", "pt", "ja", "ko", "zh", "da", "ru", "it", "hi", "nl", "sv", "tr", "pl", "cs", "uk", "hu", "ar", "bg", "el", "fi", "hr", "ro", "sk"]
     conditionals:
       use:
         default: false


### PR DESCRIPTION
## Summary

- The `languages` overlay template defaulted to only 6 languages: `["en", "de", "fr", "es", "pt", "ja"]`
- Any language not in this list had `use_<lang>` default to `false`, causing its `run_definition` check to fail — the overlay would never run, even if the language was properly tagged in Plex
- This affected Hungarian, Korean, Russian, Italian, Chinese, and ~50 other defined languages out of the box
- Expanded the default list to 26 languages covering the most commonly-encountered languages in media libraries; all added languages have flag images in the repo

The `overlay_limit: 3` cap ensures this doesn't change how many flags appear per item — it just means more languages are eligible to show up when a title actually uses them.

Closes #2648

## Languages added to defaults
`ko` `zh` `da` `ru` `it` `hi` `nl` `sv` `tr` `pl` `cs` `uk` `hu` `ar` `bg` `el` `fi` `hr` `ro` `sk`

## Test plan
- [ ] Run Kometa with default `languages` overlay on a library containing Hungarian, Korean, or Russian titles — flags should now appear without any `template_variables` override
- [ ] Verify existing configs with explicitly set `languages:` template variable are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)