### PR TITLE
fix: redact default values before logging config fallback warnings

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -601,6 +601,8 @@ class ConfigFile:
                     message = message + "\n" + options
                 raise Failed(f"Config Error: {message}")
             if do_print:
+                if default is not None:
+                    logger.secret(default)
                 logger.warning(f"Config Warning: {message}")
                 if final_value and test_list is not None and final_value not in test_list:
                     logger.warning(options)


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)

## Description

When a library uses a partial settings override (e.g. Sonarr/Radarr defined globally but partially overridden per-library), `check_for_attribute()` emits a `"X sub-attribute Y not found using Z as default"` warning for each missing key. This fires **before** the service connection is initialised, which means `logger.secret()` hasn't been called for that library's token yet — so the raw API key is printed in plain text.

**Root cause:** The redaction in `logs.py` works by replacing registered secrets in log messages at emit time. The warning happens before the secret is registered, so nothing is redacted.

**Fix:** Call `logger.secret(default)` immediately before `logger.warning(...)` inside `check_for_attribute()`. This registers the value in the logger's redaction list so it is masked in the same message that would otherwise expose it.

```
Before:
  Config Warning: sonarr sub-attribute token not found using abc123secrettoken as default

After:
  Config Warning: sonarr sub-attribute token not found using (redacted) as default
```

The change is 2 lines and is confined entirely to the warning-print path — it has no effect on non-sensitive defaults (booleans, strings like `"all"`, `False`, etc. are harmless to register as secrets).

## Related Issues

- Closes #2705

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] No — this is an internal logging fix with no user-facing config changes.

## Have you updated the CHANGELOG?

- [ ] No — minor fix, but happy to add an entry if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)