### PR TITLE
fix: correct trakt_chart URL patterns for watched, collected, and recommended

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -45,4 +45,4 @@ TMDB language now reflected in mass_poster_update; cache extension
 Reduce size of FILMIN logo
 Replace top-ten-pirated default list with an updated, kometa-controlled one.
 Overlay backdrops with `back_line_color` set but no `back_line_width` no longer crash; `back_line_width` now defaults to 1 in that case. #2645
-Addresses new URL and response structure for two Trakt lists. #3057
+Fix trakt_chart watched/collected URLs to use /movies(shows)/watched(collected)/{period} and default period to "weekly"; fix recommended to use /recommendations/movies(shows). #3057

--- a/modules/trakt.py
+++ b/modules/trakt.py
@@ -448,17 +448,14 @@ class Trakt:
         return self._parse(items, typeless=True, item_type="movie" if is_movie else "show")
 
     def _charts(self, chart_type, is_movie, params, time_period=None, ignore_other=False):
-        chart_url = f"/{'movies' if is_movie else 'shows'}/{chart_type}"
-        chart_url = f"/{chart_url}/{time_period}" if time_period else chart_url
-        # https://api.trakt.tv/recommendations/movies?ignore_collected=false&ignore_watchlisted=false
-        # https://api.trakt.tv/recommendations/shows?ignore_collected=false&ignore_watchlisted=false
+        media = "movies" if is_movie else "shows"
         if chart_type == "recommended":
-            chart_url = f"/recommendations/{'movies' if is_movie else 'shows'}"
-
-        if chart_type == "watched":
-            chart_url = f"/users/me/watched/{'movies' if is_movie else 'shows'}"
-
-        items = self._request(f"{chart_url}", params=params)
+            chart_url = f"/recommendations/{media}"
+        elif time_period:
+            chart_url = f"/{media}/{chart_type}/{time_period}"
+        else:
+            chart_url = f"/{media}/{chart_type}"
+        items = self._request(chart_url, params=params)
         return self._parse(items, typeless=chart_type == "popular", item_type="movie" if is_movie else "show", ignore_other=ignore_other)
 
     def get_people(self, data):
@@ -491,8 +488,11 @@ class Trakt:
                     final_dict["chart"] = util.parse(err_type, "chart", trakt_dict, methods=dict_methods, parent=method_name, options=["recommended", "watched", "anticipated", "collected", "trending", "popular"])
                     final_dict["limit"] = util.parse(err_type, "limit", trakt_dict, methods=dict_methods, parent=method_name, datatype="int", default=10)
                     final_dict["time_period"] = None
-                    if final_dict["chart"] in ["recommended", "watched", "collected"] and "time_period" in dict_methods:
-                        final_dict["time_period"] = util.parse(err_type, "time_period", trakt_dict, methods=dict_methods, parent=method_name, default="weekly", options=periods)
+                    if final_dict["chart"] in ["watched", "collected"]:
+                        if "time_period" in dict_methods:
+                            final_dict["time_period"] = util.parse(err_type, "time_period", trakt_dict, methods=dict_methods, parent=method_name, default="weekly", options=periods)
+                        else:
+                            final_dict["time_period"] = "weekly"
                     if "query" in dict_methods:
                         final_dict["query"] = util.parse(err_type, "query", trakt_dict, methods=dict_methods, parent=method_name)
                     if "years" in dict_methods:


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)

## Description

The Trakt API changed several chart endpoint URLs, causing 404 errors for `trakt_chart` with `watched`, `collected`, and `recommended`. The nightly branch had a partial fix that introduced a new bug (routing `watched` to the user's personal watch history instead of the community chart).

**Root causes fixed:**

1. **`watched` pointed to wrong endpoint** — the partial fix used `/users/me/watched/{media}` (personal history) instead of the community chart at `/{media}/watched/{period}`.

2. **`watched` and `collected` with no `time_period` still 404** — Trakt now requires a period segment in the URL. When users omit `time_period`, it now defaults to `weekly` (matching the previous `default="weekly"` in the parser).

3. **Double-slash URL bug** — the old `f"/{chart_url}/{time_period}"` prepended an extra `/` since `chart_url` already started with `/`. Rewritten cleanly.

4. **`recommended` URL** — already correct in nightly (`/recommendations/{media}`); preserved as-is.

**Changes in `modules/trakt.py`:**
- `_charts()`: rewritten URL construction — `recommended` → `/recommendations/{media}`, all others → `/{media}/{chart_type}[/{period}]`
- `validate_chart()`: `watched` and `collected` now always get a `time_period` (default `"weekly"`); `recommended` no longer parsed for `time_period` since the endpoint doesn't use it

## Related Issues

- Closes #3057

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

- [X] Yes
- [ ] No