### PR TITLE
perf: use set lookup for collection membership checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,9 @@ Bump pillow to 12.2.0
 Bump requests to 2.33.1
 Bump setuptools to 82.0.1
 
+# Performance
+Use set lookup instead of list scan when checking collection membership in `add_to_collection` and `run_collections_again`, reducing complexity from O(n×m) to O(n).
+
 # New Features
 Added `plex_csm` and `plex_csm0` sources to `mass_content_rating_update` (reads CSM age rating from Plex's own cached `commonSenseMedia.ageRatings`, no external API key required).
 Switching to using GraphQL for IMDB charts retrieval, with a fallback to the old method if the GraphQL request fails. #3006

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4096,6 +4096,7 @@ class CollectionBuilder:
         logger.separator(f"Adding to {self.name} {self.Type}", space=False, border=False)
         logger.info("")
         name, collection_items = self.library.get_collection_name_and_items(self.obj if self.obj else self.name, self.smart_label_collection)
+        collection_item_keys = {ci.ratingKey for ci in collection_items}
         total = self.limit if self.limit and len(self.found_items) > self.limit else len(self.found_items)
         spacing = len(str(total)) * 2 + 1
         amount_added = 0
@@ -4106,10 +4107,10 @@ class CollectionBuilder:
                 logger.info(f"{self.Type} Limit reached")
                 self.found_items = self.found_items[: i - 1]
                 break
-            current_operation = "=" if item in collection_items else "+"
+            current_operation = "=" if item.ratingKey in collection_item_keys else "+"
             number_text = f"{i}/{total}"
             logger.info(f"{number_text:>{spacing}} | {name} {self.Type} | {current_operation} | {util.item_title(item)}")
-            if item in collection_items:
+            if item.ratingKey in collection_item_keys:
                 self.remove_item_map[item.ratingKey] = None
                 amount_unchanged += 1
             else:
@@ -5009,6 +5010,7 @@ class CollectionBuilder:
     def run_collections_again(self):
         self.obj = self.library.get_collection(self.name, force_search=True)
         name, collection_items = self.library.get_collection_name_and_items(self.obj, self.smart_label_collection)
+        collection_item_keys = {ci.ratingKey for ci in collection_items}
         self.created = False
         rating_keys = []
         amount_added = 0
@@ -5029,7 +5031,7 @@ class CollectionBuilder:
                 except Failed as e:
                     logger.error(e)
                     continue
-                if current in collection_items:
+                if current.ratingKey in collection_item_keys:
                     logger.info(f"{name} {self.Type} | = | {util.item_title(current)}")
                 else:
                     self.library.alter_collection(current, name, smart_label_collection=self.smart_label_collection)


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [X] Performance (non-breaking change which improves speed or resource usage)
- [ ] Refactor (non-breaking change which improves code quality)
- [ ] Documentation (changes to documentation only)
- [ ] Other

## Description

In `add_to_collection()` and `run_collections_again()`, collection membership was tested with `item in collection_items` where `collection_items` is a plain Python list of PlexAPI objects. Python's `in` operator on a list is O(n), so checking every found item against the existing collection is O(n×m) — scanning the full collection list for each candidate.

Fix: build a `set` of `ratingKey` integers from `collection_items` once before the loop, then test with `item.ratingKey in collection_item_keys` which is O(1).

```python
# Before — O(n×m)
name, collection_items = self.library.get_collection_name_and_items(...)
for item in self.found_items:
    if item in collection_items:  # scans the whole list every time
        ...

# After — O(n)
name, collection_items = self.library.get_collection_name_and_items(...)
collection_item_keys = {ci.ratingKey for ci in collection_items}
for item in self.found_items:
    if item.ratingKey in collection_item_keys:  # O(1) set lookup
        ...
```

`ratingKey` is the correct equality proxy — it is the unique Plex integer identifier, and is already used as the dict key in `remove_item_map`. For a 2,000-item collection with 10,000 found items, this reduces roughly 20 million comparisons to ~12,000.

The same pattern is applied in `run_collections_again()` which had the same issue on a smaller scale.

## Related Issues

N/A

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [X] No

## Have you updated the CHANGELOG?

- [X] Yes
- [ ] No