### PR TITLE
perf: pre-compute frozensets for method-validation hot path in builder.py

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Bump setuptools to 82.0.1
 
 # Performance
 Use set lookup instead of list scan when checking collection membership in `add_to_collection` and `run_collections_again`, reducing complexity from O(n×m) to O(n).
+Pre-compute `frozenset`s for `all_builders + plex.searches` and `all_builders + smart_url_invalid` used in the method-validation hot path, eliminating per-call list allocation and reducing membership-test complexity from O(n) to O(1).
 
 # New Features
 Added `plex_csm` and `plex_csm0` sources to `mass_content_rating_update` (reads CSM age rating from Plex's own cached `commonSenseMedia.ageRatings`, no external API key required).

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -476,6 +476,8 @@ smart_url_invalid = (
     + radarr_details
     + sonarr_details
 )
+all_builders_and_searches = frozenset(all_builders + plex.searches)
+all_builders_and_smart_url_invalid = frozenset(all_builders + smart_url_invalid)
 custom_sort_builders = [
     "plex_search",
     "plex_watchlist",
@@ -1498,7 +1500,7 @@ class CollectionBuilder:
             logger.debug(f"Validating Method: {method_key}")
             logger.debug(f"Value: {method_data}")
             try:
-                if method_data is None and method_name in all_builders + plex.searches and method_final not in none_builders:
+                if method_data is None and method_name in all_builders_and_searches and method_final not in none_builders:
                     raise Failed(f"{self.Type} Error: {method_final} attribute is blank")
                 elif method_data is None and method_final not in none_details:
                     logger.warning(f"Collection Warning: {method_final} attribute is blank")
@@ -1538,7 +1540,7 @@ class CollectionBuilder:
                     raise Failed(f"{self.Type} Error: {method_final} attribute only allowed with smart collections")
                 elif self.collectionless and method_name not in collectionless_details:
                     raise Failed(f"{self.Type} Error: {method_final} attribute not allowed for Collectionless collection")
-                elif self.smart_url and method_name in all_builders + smart_url_invalid:
+                elif self.smart_url and method_name in all_builders_and_smart_url_invalid:
                     raise Failed(f"{self.Type} Error: {method_final} builder not allowed when using smart_filter")
                 elif not self.overlay and method_name in overlay_only:
                     raise Failed(f"{self.Type} Error: {method_final} attribute only allowed in an overlay file")


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Other

## Description

In the `CollectionBuilder` method-validation loop, two checks were creating a **new list on every call** by concatenating module-level constants at runtime:

```python
# Before — allocates and linearly scans a ~500-item list on every attribute validated
method_name in all_builders + plex.searches
method_name in all_builders + smart_url_invalid
```

Both operands are fixed at import time, so the concatenation result never changes. This PR pre-computes them once as module-level `frozenset`s:

```python
all_builders_and_searches = frozenset(all_builders + plex.searches)
all_builders_and_smart_url_invalid = frozenset(all_builders + smart_url_invalid)
```

The two hot-path lines are updated to use these sets instead.

**Impact:** The validation loop runs for every attribute of every collection on every Kometa run. A typical run with 100 collections × ~20 attributes hits these checks ~2,000 times. Each call previously allocated and scanned a list of ~500+ items (O(n)); it is now a single O(1) hash lookup with no allocation.

Zero behavioral change — this is a pure performance optimization.

## Related Issues

- Related Issue #

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] No — internal implementation change, no user-facing behavior affected

## Have you updated the CHANGELOG?

- [X] Yes