### PR TITLE
Security tweaks

### DIFF
--- a/docs/kometa/environmental.md
+++ b/docs/kometa/environmental.md
@@ -321,6 +321,8 @@ Kometa will load those environment variables when it starts up, and you don't ha
     ???+ note
 
         set to false if your log file shows any errors similar to "SSL: CERTIFICATE_VERIFY_FAILED"
+        
+        IMPORTANT: This will disable TLS checks for all outbound services (TMDb, Trakt, MAL, etc.). Only flip this switch if you are comfortable with this.
 
     <hr style="margin: 0px;">
 

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -393,7 +393,7 @@ class Cache:
                     cursor.execute("SELECT DISTINCT library FROM image_map")
                     for library in cursor.fetchall():
                         table_name = self.get_image_table_name(library["library"])
-                        cursor.execute(f"SELECT DISTINCT * FROM image_map WHERE library='{library['library']}'")
+                        cursor.execute("SELECT DISTINCT * FROM image_map WHERE library=?", (library["library"],)).
                         for row in cursor.fetchall():
                             if row["type"] == "poster":
                                 final_table = table_name if row["type"] == "poster" else f"{table_name}_backgrounds"


### PR DESCRIPTION
<!--
    For Work In Progress Pull Requests, please use the Draft PR feature,
    see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

    For a timely review/response, please avoid force-pushing additional
    commits if your PR already received reviews or comments.

    Before submitting a Pull Request, please ensure you've done the following:
    - ✅ Test your changes locally to prove they work prior to submitting PRs.
    - 👷‍♀️ Create small PRs. In most cases this will be possible.
    - 📝 Use descriptive commit messages.
    - 📗 Update the CHANGELOG and Documentation where necessary.
-->

## What type of PR is this?

<!--
    Type X in the brackets of any relevant option, for example:
    - [X] Bug Fix (non-breaking change which fixes an issue)
-->
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [X] Other 

## Description

Addresses two minor security issues found by Lictor-AI.

```
Two LOW findings worth a cleanup pass:

  1. modules/cache.py:396 — one unparameterized SQL query in a one-time migration path.
  Five-minute fix: change the f-string to cursor.execute("SELECT DISTINCT * FROM image_map
  WHERE library=?", (library["library"],)). Every other query in the file is already
  parameterized correctly.
  2. Global SSL verification flag — the --no-verify-ssl / verify_ssl: false setting disables
   TLS checks for all outbound services (TMDb, Trakt, MAL, etc.), not just Plex. Worth a
  documentation note so users understand the full scope when they enable it.
```
## Have you updated the Documentation to reflect changes (if necessary)?

<!--
    If your PR warrants Documentation changes, you are expected to make the relevant changes.
    Failure to do so will result in your PR not being approved.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [X] Yes
- [ ] No

## Have you updated the CHANGELOG?

<!--
    Any PR that goes beyond a minor tweak (i.e. replacing a value, fixing a typo) should have a CHANGELOG entry.
    We may ask you to update the CHANGELOG if you haven't done so.
    Type X in the brackets of any relevant option, for example:
    - [X] Yes
-->
- [ ] Yes
- [X] No
