### PR TITLE
fix: downgrade stale TVDb 4xx responses to debug-level log

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -55,3 +55,4 @@ Replace top-ten-pirated default list with an updated, kometa-controlled one.
 Streaming default's `run_definition` now honors `use_all: false`; previously dynamic keys without an explicit `use_<key>` ran regardless. #2922
 Overlay backdrops with `back_line_color` set but no `back_line_width` no longer crash; `back_line_width` now defaults to 1 in that case. #2645
 Fix trakt_chart watched/collected URLs to use /movies(shows)/watched(collected)/{period} and default period to "weekly"; fix recommended to use /recommendations/movies(shows). #3057
+TVDb 4xx responses (series/movie removed or merged on TVDb) now raise a dedicated `tvdb.NotFound` so the missing-show iteration and TVDb-filter paths log them at debug instead of error. Stale TVDb IDs returned by TMDb `external_ids` no longer spam logs or trigger webhook failure notifications. #3047

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -4284,6 +4284,9 @@ class CollectionBuilder:
                         else:
                             try:
                                 tvdb_item = self.config.TVDb.get_tvdb_obj(self.library.show_rating_key_map[item.ratingKey])
+                            except tvdb.NotFound as e:
+                                logger.debug(e)
+                                or_result = False
                             except Failed as e:
                                 logger.error(e)
                                 or_result = False
@@ -4394,6 +4397,12 @@ class CollectionBuilder:
                 i += 1
                 try:
                     title = self.config.TVDb.get_tvdb_obj(missing_id).title
+                except tvdb.NotFound as e:
+                    # TVDb ID is stale (e.g. TMDb still references a series that no
+                    # longer exists on TVDb). Not user-actionable; log at debug to
+                    # avoid spamming logs / triggering webhook error notifications.
+                    logger.debug(e)
+                    continue
                 except Failed as e:
                     logger.error(e)
                     continue
@@ -5067,6 +5076,9 @@ class CollectionBuilder:
                 if missing_id not in self.library.show_map:
                     try:
                         title = self.config.TVDb.get_tvdb_obj(missing_id).title
+                    except tvdb.NotFound as e:
+                        logger.debug(e)
+                        continue
                     except Failed as e:
                         logger.error(e)
                         continue

--- a/modules/tvdb.py
+++ b/modules/tvdb.py
@@ -9,6 +9,15 @@ from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_excepti
 
 logger = util.logger
 
+
+class NotFound(Failed):
+    """Raised when a TVDb resource (series/movie) is gone from TVDb (HTTP 4xx).
+
+    Distinct from Failed so callers can downgrade noisy log lines for IDs the
+    user did not control (e.g. stale TVDb IDs returned by TMDb external_ids).
+    """
+
+
 builders = ["tvdb_list", "tvdb_list_details", "tvdb_movie", "tvdb_movie_details", "tvdb_show", "tvdb_show_details"]
 base_url = "https://www.thetvdb.com"
 alt_url = "https://thetvdb.com"
@@ -55,6 +64,8 @@ class TVDbObj:
             item_url = f"{urls['movie_id' if is_movie else 'series_id']}{tvdb_id}"
             try:
                 data = self._tvdb.get_request(item_url)
+            except NotFound:
+                raise NotFound(f"TVDb Error: No {'Movie' if is_movie else 'Series'} found for TVDb ID: {tvdb_id} at {item_url}")
             except Failed:
                 raise Failed(f"TVDb Error: No {'Movie' if is_movie else 'Series'} found for TVDb ID: {tvdb_id} at {item_url}")
 
@@ -119,6 +130,11 @@ class TVDb:
     def get_request(self, tvdb_url):
         response = self.requests.get(tvdb_url, language=self.language)
         if response.status_code >= 400:
+            # 4xx — resource is gone from TVDb (e.g. series removed/merged). Raise
+            # NotFound so callers can decide to handle it quietly. 5xx remains
+            # a generic Failed (a transient TVDb outage, etc.).
+            if 400 <= response.status_code < 500:
+                raise NotFound(f"({response.status_code}) {response.reason}")
             raise Failed(f"({response.status_code}) {response.reason}")
         return html.fromstring(response.content)
 

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -1,0 +1,44 @@
+from types import SimpleNamespace
+
+import pytest
+
+from modules import tvdb
+from modules.util import Failed
+
+
+def _make_tvdb(response_status):
+    """Build a TVDb instance whose underlying requests.get returns the chosen status."""
+    fake_response = SimpleNamespace(
+        status_code=response_status,
+        reason="Mocked",
+        content=b"<html></html>",
+    )
+    fake_requests = SimpleNamespace(get=lambda url, language=None: fake_response)
+    return tvdb.TVDb(requests=fake_requests, cache=None, tvdb_language="eng", expiration=60)
+
+
+def test_notfound_is_failed_subclass():
+    # Callers that want to keep catching every TVDb failure as Failed should still work.
+    assert issubclass(tvdb.NotFound, Failed)
+
+
+def test_get_request_raises_notfound_on_4xx():
+    t = _make_tvdb(404)
+    with pytest.raises(tvdb.NotFound):
+        t.get_request("https://www.thetvdb.com/dereferrer/series/463160")
+
+
+def test_get_request_raises_failed_on_5xx():
+    t = _make_tvdb(503)
+    with pytest.raises(Failed) as excinfo:
+        t.get_request("https://www.thetvdb.com/dereferrer/series/81189")
+    # Must not be the NotFound subclass — 5xx is treated as transient.
+    assert not isinstance(excinfo.value, tvdb.NotFound)
+
+
+def test_tvdbobj_init_propagates_notfound_for_stale_id():
+    t = _make_tvdb(404)
+    with pytest.raises(tvdb.NotFound) as excinfo:
+        tvdb.TVDbObj(t, 463160, is_movie=False, ignore_cache=True)
+    assert "463160" in str(excinfo.value)
+    assert "No Series found" in str(excinfo.value)


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)

## Description

Closes #3047. The reporter saw ~137 `TVDb Error: No Series found for TVDb ID: ...` warnings per run from default collection files (franchise, streaming, network, etc.) and asked whether the IDs could be audited.

The fix path turned out to be different from auditing default files. I scanned the entire Kometa tree (every `.yml/.yaml/.json/.py/.md/.txt`) for any of the 136 unique stale IDs — **zero matches**. Same result for the remote data sources Kometa fetches at runtime: `Anime-IDs/anime_ids.json` matches just 1/136, `Mediastingers/stingers.yml` matches 0/136 (keyed by TMDb ID, not TVDb).

The IDs originate from TMDb's `external_ids` data for TMDb shows that the defaults reference. Kometa's `Convert.tmdb_to_tvdb()` reads those values, then later uses them when iterating missing shows (`builder.py` ~4396 / ~5076) and evaluating `tvdb_*` filters (`builder.py` ~4287). When the cached TMDb→TVDb mapping points at a series that no longer exists on thetvdb.com, `TVDbObj.__init__` raises `Failed` and the caller logs `logger.error(e)` — which the reporter says clutters logs and triggers Notifiarr/Discord failure notifications.

These IDs are not user-controlled, so an error is misleading. This PR:

- Adds `modules.tvdb.NotFound` (subclass of `Failed`) for HTTP 4xx responses from thetvdb.com dereferrer endpoints. 5xx still raises plain `Failed` (transient TVDb outage / parse error).
- Raises `NotFound` from `TVDb.get_request` on 4xx and propagates it through `TVDbObj.__init__`.
- In the three `builder.py` sites that scan IDs the user did not type (`missing_shows`, `run_again_shows`, `tvdb_f` filter), catches `NotFound` separately and logs at debug.

User-typed builders like `tvdb_show_details: <id>` are unchanged — those propagate `NotFound`/`Failed` to the outer handler so the user still gets the loud error if they typed an invalid ID.

Tested:

- `pytest tests/test_tvdb.py -v` → 4/4 passing (NotFound subclass, 4xx mapping, 5xx mapping, propagation).
- Full `pytest tests/` → no regressions vs unmodified `nightly` (the same 6 pre-existing failures in `test_builder.py` and `test_letterboxd.py` reproduce on a clean checkout).

## Related Issues

- Closes #3047

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] No (no user-facing config changes; the new exception is internal)

## Have you updated the CHANGELOG?

- [X] Yes