### PR TITLE
Count all deleted collections in run-end notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `audio_codec` track builder
+- Include collections deleted by the `delete_collections` library operation in the run-end notification total.
 - Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.
 
 ## [v2.4.8] - 2026-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `audio_codec` track builder
-- Include collections deleted by the `delete_collections` library operation in the run-end notification total.
+- Include collections removed by the `delete_collections` library operation, the `--delete-collections` CLI option, dynamic collection sync, and `delete_collections_named` in the run-end notification total.
 - Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.
 
 ## [v2.4.8] - 2026-08-15

--- a/kometa.py
+++ b/kometa.py
@@ -1087,7 +1087,7 @@ def run_libraries(config) -> tuple[LibraryRunStatus, bool]:
                 logger.info("")
                 for collection in library.get_all_collections():
                     try:
-                        library.delete(collection)
+                        library.delete_collection(collection)
                         logger.info(f"Collection {collection.title} Deleted")
                     except Failed as e:
                         logger.error(e)
@@ -1344,7 +1344,6 @@ def run_collection(config, library, metadata, requested_collections):
                 if builder.details["delete_below_minimum"] and builder.obj:
                     logger.info("")
                     logger.info(builder.delete())
-                    library.stats["deleted"] += 1
                     delete_status = f"Deleted; {delete_status}"
                 library.status[str(mapping_name)]["status"] = delete_status
 
@@ -1407,7 +1406,6 @@ def run_collection(config, library, metadata, requested_collections):
         except NotScheduled as e:
             logger.info(e)
             if str(e).endswith("and was deleted"):
-                library.stats["deleted"] += 1
                 library.status[str(mapping_name)]["status"] = "Deleted Not Scheduled"
             elif str(e).startswith("Skipped because run_definition"):
                 library.status[str(mapping_name)]["status"] = "Skipped Run Definition"

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1267,7 +1267,7 @@ class CollectionBuilder:
             for del_col in util.parse(self.Type, "delete_collections_named", self.data, datatype="strlist", methods=methods):
                 try:
                     del_obj = self.library.get_collection(del_col, force_search=True)
-                    self.library.delete(del_obj)
+                    self.library.delete_collection(del_obj)
                     logger.info(f"Collection: {del_obj.title} deleted")
                 except Failed as e:
                     if str(e).startswith("Plex Error: Failed to delete"):
@@ -5698,7 +5698,7 @@ class CollectionBuilder:
                 except Failed:
                     output += f"\nPlaylist not found on User {user}"
         elif self.obj:
-            self.library.delete(self.obj)
+            self.library.delete_collection(self.obj)
         if self.obj:
             self.deleted = True
         return output

--- a/modules/meta.py
+++ b/modules/meta.py
@@ -1455,7 +1455,7 @@ class MetadataFile(DataFile):
                             self.collections[other_name] = col
                         for _, col in sync.items():
                             try:
-                                self.library.delete(col)
+                                self.library.delete_collection(col)
                                 logger.info(f"{map_name} Dynamic Collection: {col.title} Deleted")
                             except Failed as e:
                                 logger.error(e)

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -1620,8 +1620,7 @@ class Operations:
 
                 if should_be_deleted(col, labels, configured, managed, None if col.smart and ignore_smart else less):
                     try:
-                        self.library.delete(col)
-                        self.library.stats["deleted"] += 1
+                        self.library.delete_collection(col)
                         logger.info(f"{col.title} Deleted")
                     except Failed as e:
                         logger.error(e)

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -1621,6 +1621,7 @@ class Operations:
                 if should_be_deleted(col, labels, configured, managed, None if col.smart and ignore_smart else less):
                     try:
                         self.library.delete(col)
+                        self.library.stats["deleted"] += 1
                         logger.info(f"{col.title} Deleted")
                     except Failed as e:
                         logger.error(e)

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1026,6 +1026,11 @@ class Plex(Library):
             self.notify_delete(delete_message or f"{'Playlist' if is_playlist else 'Collection'} {obj.title} deleted", playlist=is_playlist)
         return result
 
+    def delete_collection(self, obj, notify=True, delete_message=None):
+        result = self.delete(obj, notify=notify, delete_message=delete_message)
+        self.stats["deleted"] += 1
+        return result
+
     @PLEX_RETRY
     def query_data(self, method, data):
         return method(data)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -877,7 +877,7 @@ class TestDelete:
 
                 self.Webhooks = _Webhooks(self)
 
-            def delete(self, item):
+            def delete_collection(self, item):
                 self.deleted_items.append(item)
 
             def item_reload(self, item):
@@ -912,7 +912,7 @@ class TestDelete:
             (("label", items[0]), {"remove_tags": "Smart"}),
             (("label", items[1]), {"remove_tags": "Smart"}),
         ]
-        library.delete.assert_called_once_with(builder.obj)
+        library.delete_collection.assert_called_once_with(builder.obj)
         assert builder.deleted is True
 
     def test_no_obj_returns_empty_string(self):

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -289,10 +289,15 @@ def test_delete_collections_counts_successful_deletions_in_run_stats():
     library.get_all_collections.return_value = collections
     library.item_labels.return_value = [SimpleNamespace(tag="Kometa")]
 
+    def delete_collection(_collection):
+        library.stats["deleted"] += 1
+
+    library.delete_collection.side_effect = delete_collection
+
     Operations(config=MagicMock(), library=library).run_operations()
 
     assert library.stats["deleted"] == 2
-    assert library.delete.call_count == 2
+    assert library.delete_collection.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -271,6 +271,31 @@ def test_collection_names_used_not_collections():
 
 
 # ---------------------------------------------------------------------------
+# delete_collections run-end statistics
+# ---------------------------------------------------------------------------
+
+
+def test_delete_collections_counts_successful_deletions_in_run_stats():
+    """Library-operation deletions must be included in the run-end notification total."""
+    collections = [make_col("Biopic Movies"), make_col("Musical Movies")]
+    library = make_title_test_library([])
+    library.name = "Movies"
+    library.items_library_operation = False
+    library.delete_collections = {"managed": True, "configured": None, "less": None, "ignore_empty_smart_collections": True}
+    library.collection_names = []
+    library.collection_files = []
+    library.assets_for_all_collections = False
+    library.stats = {"deleted": 0}
+    library.get_all_collections.return_value = collections
+    library.item_labels.return_value = [SimpleNamespace(tag="Kometa")]
+
+    Operations(config=MagicMock(), library=library).run_operations()
+
+    assert library.stats["deleted"] == 2
+    assert library.delete.call_count == 2
+
+
+# ---------------------------------------------------------------------------
 # remove_title_parentheses batching (run_operations / items_library_operation)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -372,7 +372,7 @@ def make_title_test_library(items):
         setattr(library, flag, False)
 
     library.get_all.return_value = items
-    library.reload.side_effect = lambda item: item
+    library.reload.side_effect = lambda item, **_: item
     library.item_has_ignore_label.return_value = False
     library.get_ids.return_value = (None, None, None)
     library.load_list_from_cache.side_effect = lambda keys: [items_by_key[k] for k in keys]

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -47,6 +47,7 @@ def make_plex(**attrs) -> Plex:
     plex.filter_attr_cache = attrs.pop("filter_attr_cache", {})
     plex.collection_names = attrs.pop("collection_names", [])
     plex.collection_files = attrs.pop("collection_files", [])
+    plex.stats = attrs.pop("stats", {"deleted": 0})
     plex.config = attrs.pop("config", SimpleNamespace(notify=MagicMock(), notify_delete=MagicMock()))
 
     # Required by Plex class
@@ -453,6 +454,24 @@ class TestDelete:
             plex.delete(item)
 
         mock_config.notify_delete.assert_not_called()
+
+    def test_delete_collection_increments_run_stats_after_success(self):
+        item = make_plex_item(type="collection")
+        plex = make_plex()
+
+        plex.delete_collection(item)
+
+        assert plex.stats["deleted"] == 1
+
+    def test_delete_collection_does_not_increment_run_stats_after_failure(self):
+        item = make_plex_item(type="collection")
+        plex = make_plex()
+        plex.query = MagicMock(side_effect=RuntimeError("delete failed"))
+
+        with pytest.raises(Failed, match="Plex Error: Failed to delete Test Item"):
+            plex.delete_collection(item)
+
+        assert plex.stats["deleted"] == 0
 
     def test_delete_user_playlist_includes_user(self):
         item = make_plex_item(title="My Playlist", type="playlist")


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

The run-end webhook builds its `collections_deleted` value from each library's `stats["deleted"]`. Several paths removed collections from Plex and generated individual delete hooks without updating that statistic, causing completion notifications to underreport deletions.

The supplied log demonstrated the issue: `Biopic Movies` and `Musical Movies` were deleted during Movies library operations, while `TMDb Airing Today` was deleted during TV Shows collection processing. The completion notification counted only the latter.

This change introduces a single `delete_collection()` path that increments the statistic only after Plex confirms a successful deletion. Terminal collection-removal paths now use it, while smart/regular conversion remains an uncounted replacement because the same logical collection is immediately recreated.

| Collection deletion path | Before | After |
| --- | --- | --- |
| Below minimum | Counted by its caller | Counted centrally after successful deletion |
| Not scheduled | Counted by its caller | Counted centrally after successful deletion |
| `delete_collections` library operation | Not counted | Counted |
| `--delete-collections` CLI option | Not counted | Counted |
| Dynamic collection `sync` cleanup | Not counted | Counted |
| `delete_collections_named` | Not counted | Counted |
| Smart/regular conversion | Not counted | Still not counted; this is a replacement |

Regression coverage verifies successful collection deletions increment the run statistic, failed deletions do not, and a library operation deleting two collections records both.

Validation:

- Python compilation passed for all changed Python files.
- Black passed for all changed Python files.
- `git diff --check` passed.
- The full GitHub Actions suite now passes on Windows and Ubuntu, including tests, lint, validation, pyright, schema, smoke, regression, imports, and performance.
- Focused pytest collection could not start in the local system Python because the runtime dependencies `tenacity` and `arrapi` are not installed.

## Related Issues [optional]

None.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No