### PR TITLE
feat: Add FlickList connector with list and personal-data builders

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -117,6 +117,7 @@ FLAC
 fldb
 FlickList
 flicklist
+FlickList's
 FlixPatrol
 fontawesome
 FSK
@@ -174,6 +175,7 @@ Letterboxd
 letterboxd
 Letterboxd's
 LGBTQ
+lifecycle
 Limburgish
 Lingala
 LinuxServer
@@ -303,6 +305,7 @@ Schemas
 schemas
 SciFi
 SDTV
+selectable
 Serializd
 serializd
 Serializd's

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -114,6 +114,9 @@ Filmin
 filmin
 filmography
 FLAC
+fldb
+FlickList
+flicklist
 FlixPatrol
 fontawesome
 FSK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support the `folder_location` Plex search option in music-library track builders.
+- Add a FlickList connector (`flicklist` config attribute) with read-only `flicklist_list`, `flicklist_list_details`, `flicklist_user_lists`, `flicklist_watchlist`, `flicklist_favorites`, `flicklist_watched`, `flicklist_ratings`, `flicklist_up_next`, and `flicklist_tracked` builders, plus a `flicklist_description` summary source.
 
 ### Fixed
 

--- a/docs/config/flicklist.md
+++ b/docs/config/flicklist.md
@@ -1,0 +1,55 @@
+---
+hide:
+  - toc
+---
+# FlickList
+
+Configuring [FlickList](https://flicklist.tv/) is optional but is required for `flicklist_*` builders to function.
+
+The `flicklist` attribute is found at the root of the config file. FlickList authentication is a single, non-expiring
+API key; there is no OAuth flow, no refresh token, and no expiry to maintain. The only lifecycle event is the key
+being revoked, which returns a `401` and requires minting a new key.
+
+```yaml
+flicklist:
+  api_key: fs_live_xxxxxxxxxxxxxxxx
+```
+
+| Attribute | Description       | Required                                   |
+|:----------|:------------------|:------------------------------------------:|
+| `api_key` | FlickList API key | :fontawesome-solid-circle-check:{ .green } |
+
+## Getting an API key
+
+* **FlickList's own dashboard.** Any FlickList account can mint a key from Developer → Your Apps, no waiting or
+  approval required. Read and write scopes are both selectable, and page size is configurable there (up to 500).
+* **Kometa Utilities.** A future addition to the [Kometa Utilities website](https://utilities.kometa.wiki), the
+  same site used to authenticate Plex, MyAnimeList, SIMKL, and Trakt, will offer a guided device-code flow that
+  mints a key and hands you a paste-ready `flicklist:` block. Not yet available; this page will be updated once
+  it ships.
+
+## Scopes
+
+`flicklist_list`, `flicklist_list_details`, and `flicklist_user_lists` work with a `read` scope key (or, for public
+lists, no key at all). Every other `flicklist_*` builder reads the authenticated user's own data and requires
+`read` scope. A key missing the required scope returns a clear error naming which scope is missing.
+
+## Rate limits
+
+FlickList allows 1,000 requests/hour per API key. Builds that page through list contents or a user's public lists
+consume more requests the larger those lists are; a user with dozens of public lists will see a correspondingly
+longer run and a log line naming how many lists are being processed. Kometa backs off automatically on a `429`
+and honors the `Retry-After` header when present.
+
+## What FlickList doesn't have
+
+Rotten Tomatoes and Metacritic scores, and structured awards data, are not available from FlickList's API and
+there are no plans to add them. Kometa's existing MDBList/OMDb bridge remains the source for that data regardless
+of whether FlickList is configured.
+
+## Known limitation
+
+Public FlickList lists can be read without any credential at all, but Kometa currently requires the `flicklist`
+config block to be present before any `flicklist_*` builder is accepted — consistent with how every other Kometa
+connector works. If you only ever consume public lists and would rather skip configuring an API key, this is a
+known limitation, not a bug.

--- a/docs/config/overview.md
+++ b/docs/config/overview.md
@@ -53,6 +53,7 @@ requirements for setup that can be found by clicking the links within the table 
 | [`trakt`](trakt.md)                                                                                                                                                                                                   |  :fontawesome-solid-circle-xmark:{ .red }  |
 | [`floppy`](floppy.md)                                                                                                                                                                                                 |  :fontawesome-solid-circle-xmark:{ .red }  |
 | [`yamtrack`](yamtrack.md)                                                                                                                                                                                             |  :fontawesome-solid-circle-xmark:{ .red }  |
+| [`flicklist`](flicklist.md)                                                                                                                                                                                           |  :fontawesome-solid-circle-xmark:{ .red }  |
 | [`mal`](myanimelist.md)                                                                                                                                                                                               |  :fontawesome-solid-circle-xmark:{ .red }  |
 
 ## Configuration Template File Example

--- a/docs/files/builders/flicklist/list.md
+++ b/docs/files/builders/flicklist/list.md
@@ -1,0 +1,65 @@
+---
+hide:
+  - toc
+---
+# FlickList List
+
+Finds every item in a FlickList list, or across a FlickList user's public lists.
+
+???+ warning "FlickList Configuration"
+
+    [Configuring FlickList](../../../config/flicklist.md) in the config is required for these builders.
+
+## flicklist_list
+
+The expected input is a FlickList list URL (`https://flicklist.tv/list/4821`) or its bare numeric id (`4821`).
+Multiple values are supported as either a list :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-lists" } or a comma-separated string.
+
+The `sync_mode: sync` and `collection_order: custom` settings are recommended since FlickList lists can be
+updated externally and are returned in list order.
+
+???+ tip "Details Builder"
+
+    You can replace `flicklist_list` with `flicklist_list_details` if you would like to fetch and use the
+    FlickList list description as the collection summary. Only the first list's description is used when
+    multiple lists are given.
+
+### Example FlickList List Builder(s)
+
+```yaml
+collections:
+  FlickList List:
+    flicklist_list: https://flicklist.tv/list/4821
+    collection_order: custom
+    sync_mode: sync
+```
+
+```yaml
+collections:
+  FlickList List:
+    flicklist_list_details:
+      - 4821
+      - 9310
+    collection_order: custom
+    sync_mode: sync
+```
+
+## flicklist_user_lists
+
+Finds the union of every item across a named FlickList user's public lists.
+
+The expected input is a FlickList username. This does not require an API key with any particular scope — public
+lists are readable without authentication — but Kometa still requires the `flicklist` config block to be present.
+
+A user with many public lists means more requests; Kometa logs how many lists it found for that user before
+processing them.
+
+### Example FlickList User Lists Builder
+
+```yaml
+collections:
+  FlickList Community Picks:
+    flicklist_user_lists: some_flicklist_username
+    collection_order: custom
+    sync_mode: sync
+```

--- a/docs/files/builders/flicklist/overview.md
+++ b/docs/files/builders/flicklist/overview.md
@@ -1,0 +1,22 @@
+---
+hide:
+  - toc
+---
+# FlickList Builders
+
+You can find items using lists and personal data from [FlickList](https://flicklist.tv/).
+
+???+ warning "FlickList Configuration"
+
+    [Configuring FlickList](../../../config/flicklist.md) in the config is required for any of these builders.
+
+| Builder                              | Description                                                         | Works with Movies                          | Works with Shows                           | Works with Playlists and Custom Sort       |
+|:-------------------------------------|:--------------------------------------------------------------------|:------------------------------------------:|:------------------------------------------:|:------------------------------------------:|
+| [`flicklist_list`](list.md)          | Finds every item in a FlickList list.                               | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_user_lists`](list.md)    | Finds every item across a FlickList user's public lists.            | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_watchlist`](personal.md) | Finds every item in the configured FlickList user's watchlist.      | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_favorites`](personal.md) | Finds every item in the configured FlickList user's favorites.      | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_watched`](personal.md)   | Finds every item the configured FlickList user has watched.         | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_up_next`](personal.md)   | Finds the configured FlickList user's next-unwatched-episode queue. | :fontawesome-solid-circle-xmark:{ .red }   | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_tracked`](personal.md)   | Finds shows the configured FlickList user is tracking.              | :fontawesome-solid-circle-xmark:{ .red }   | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |
+| [`flicklist_ratings`](ratings.md)    | Finds every item the configured FlickList user has rated.           | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } | :fontawesome-solid-circle-check:{ .green } |

--- a/docs/files/builders/flicklist/personal.md
+++ b/docs/files/builders/flicklist/personal.md
@@ -57,3 +57,12 @@ collections:
 | `flicklist_watched`   | Entire watched history | —             | Movies and Shows    |
 | `flicklist_up_next`   | All up-next episodes   | Integer limit | Shows only          |
 | `flicklist_tracked`   | Every tracked show     | —             | Shows only          |
+
+!!! note "`flicklist_watchlist` covers more than "plan to watch""
+
+    FlickList's watchlist is richer than a Trakt-style plan-to-watch list: every item carries a
+    `status` of `plan_to_watch`, `watching`, `completed`, `on_hold`, or `dropped`. `flicklist_watchlist`
+    currently returns the entire watchlist regardless of status - there is no way to filter to just
+    one status yet. If you're looking for "shows I've marked completed" specifically, note that this
+    is a different concept from `flicklist_watched`, which reflects actual play history (has the
+    episode/movie been played), not a manually-set watchlist status.

--- a/docs/files/builders/flicklist/personal.md
+++ b/docs/files/builders/flicklist/personal.md
@@ -1,0 +1,59 @@
+---
+hide:
+  - toc
+---
+# FlickList Personal Data
+
+Finds items from the configured FlickList API key's own watchlist, favorites, watched history, up-next queue,
+or tracked shows.
+
+???+ warning "FlickList Configuration"
+
+    [Configuring FlickList](../../../config/flicklist.md) in the config is required for these builders. Each
+    of these builders reads the `read`-scoped personal data of whichever FlickList account the configured
+    `api_key` belongs to.
+
+Each of these builders accepts a blank value or `true`:
+
+```yaml
+collections:
+  FlickList Watchlist:
+    flicklist_watchlist:
+    collection_order: custom
+    sync_mode: sync
+
+  FlickList Favorites:
+    flicklist_favorites: true
+    collection_order: custom
+    sync_mode: sync
+
+  FlickList Watched:
+    flicklist_watched:
+    sync_mode: sync
+
+  FlickList Tracked:
+    flicklist_tracked:
+    collection_order: custom
+    sync_mode: sync
+```
+
+`flicklist_up_next` and `flicklist_tracked` are show-library only, since a next-unwatched-episode queue and a
+tracked-shows list are both inherently show concepts.
+
+`flicklist_up_next` additionally accepts an integer limit on how many upcoming episodes to return:
+
+```yaml
+collections:
+  FlickList Up Next:
+    flicklist_up_next: 20
+    collection_order: custom
+    sync_mode: sync
+```
+
+| Builder               | Blank/`true` means     | Also accepts  | Library restriction |
+|:----------------------|:-----------------------|:--------------|:--------------------|
+| `flicklist_watchlist` | Entire watchlist       | —             | Movies and Shows    |
+| `flicklist_favorites` | Entire favorites list  | —             | Movies and Shows    |
+| `flicklist_watched`   | Entire watched history | —             | Movies and Shows    |
+| `flicklist_up_next`   | All up-next episodes   | Integer limit | Shows only          |
+| `flicklist_tracked`   | Every tracked show     | —             | Shows only          |

--- a/docs/files/builders/flicklist/ratings.md
+++ b/docs/files/builders/flicklist/ratings.md
@@ -1,0 +1,47 @@
+---
+hide:
+  - toc
+---
+# FlickList Ratings
+
+Finds every item the configured FlickList API key's account has rated.
+
+???+ warning "FlickList Configuration"
+
+    [Configuring FlickList](../../../config/flicklist.md) in the config is required for this builder.
+
+`flicklist_ratings` accepts a blank value or `true` for every rated item, a number as a minimum rating, or an
+object with `minimum`/`maximum` bounds. FlickList ratings are documented as half-point increments (0.5–10) but
+the API does not currently enforce that, so a fractional rating like `5.3` can come back from FlickList itself.
+
+## Example FlickList Ratings Builder(s)
+
+```yaml
+collections:
+  FlickList Rated:
+    flicklist_ratings:
+    sync_mode: sync
+```
+
+```yaml
+collections:
+  FlickList Rated 7+:
+    flicklist_ratings: 7
+    sync_mode: sync
+```
+
+```yaml
+collections:
+  FlickList Rated 7 to 9:
+    flicklist_ratings:
+      minimum: 7
+      maximum: 9
+    sync_mode: sync
+```
+
+## Attributes
+
+| Attribute | Description               | Values                   |
+|:----------|:--------------------------|:-------------------------|
+| `minimum` | Lowest rating to include  | Number, 0.5–10, optional |
+| `maximum` | Highest rating to include | Number, 0.5–10, optional |

--- a/docs/files/builders/overview.md
+++ b/docs/files/builders/overview.md
@@ -73,6 +73,17 @@ Builders use third-party services to source items to be added to the collection.
 
 !!! builder
 
+    **[FlickList](../flicklist/overview)** builders grab lists and personal data from your configured FlickList account.
+
+    [:octicons-home-16: View Builder](../flicklist/overview){ .md-button .md-button--primary }
+
+    ??? quicklink "Popular Builders"
+
+        - [:octicons-list-ordered-16: FlickList List](../flicklist/list) - Gets every item in a FlickList list.
+        - [:octicons-list-ordered-16: FlickList Watchlist](../flicklist/personal) - Gets the configured user's FlickList watchlist.
+
+!!! builder
+
     **[Serializd](../serializd/overview)** builders grab shows from Serializd lists and watchlists through its JSON API.
 
     [:octicons-home-16: View Builder](../serializd/overview){ .md-button .md-button--primary }

--- a/json-schema/collection-schema.json
+++ b/json-schema/collection-schema.json
@@ -145,6 +145,7 @@
                 "tmdb_summary": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
                 "trakt_description": { "type": "string" },
                 "yamtrack_description": { "type": "string" },
+                "flicklist_description": { "type": "string" },
                 "tvdb_description": { "type": "string" },
                 "tvdb_summary": { "oneOf": [{ "type": "string" }, { "type": "integer" }] },
 
@@ -644,6 +645,55 @@
                 "yamtrack_tracked": {
                     "description": "YamTrack tracked movies and shows filtered by status.",
                     "$ref": "#/definitions/yamtrack-tracked"
+                },
+                "flicklist_list": {
+                    "description": "FlickList List URL(s) or numeric id(s).",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "integer" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "integer" }] } }
+                    ]
+                },
+                "flicklist_list_details": {
+                    "description": "FlickList List URL(s) or numeric id(s). Also fetches the list description.",
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "integer" },
+                        { "type": "array", "items": { "oneOf": [{ "type": "string" }, { "type": "integer" }] } }
+                    ]
+                },
+                "flicklist_user_lists": {
+                    "description": "Every movie/show across a FlickList user's public lists.",
+                    "type": "string"
+                },
+                "flicklist_watchlist": {
+                    "description": "FlickList personal watchlist for the configured API key.",
+                    "oneOf": [{ "type": "boolean" }, { "type": "null" }]
+                },
+                "flicklist_favorites": {
+                    "description": "FlickList personal favorites for the configured API key.",
+                    "oneOf": [{ "type": "boolean" }, { "type": "null" }]
+                },
+                "flicklist_watched": {
+                    "description": "FlickList personal watched history for the configured API key.",
+                    "oneOf": [{ "type": "boolean" }, { "type": "null" }]
+                },
+                "flicklist_up_next": {
+                    "description": "FlickList next-unwatched-episode queue for the configured API key. Blank/true for all, or an integer limit. Show libraries only.",
+                    "oneOf": [{ "type": "boolean" }, { "type": "null" }, { "type": "integer", "minimum": 1 }]
+                },
+                "flicklist_tracked": {
+                    "description": "FlickList tracked shows for the configured API key. Show libraries only.",
+                    "oneOf": [{ "type": "boolean" }, { "type": "null" }]
+                },
+                "flicklist_ratings": {
+                    "description": "FlickList personal ratings for the configured API key. Blank/true for all, a number as a minimum rating, or an object with minimum/maximum.",
+                    "oneOf": [
+                        { "type": "boolean" },
+                        { "type": "null" },
+                        { "type": "number", "minimum": 0.5, "maximum": 10 },
+                        { "$ref": "#/definitions/flicklist-ratings-entry" }
+                    ]
                 },
 
                 "icheckmovies_list": {
@@ -1517,6 +1567,15 @@
             "type": "object", "additionalProperties": false,
             "properties": {
                 "limit": { "type": "integer", "minimum": 1, "maximum": 500 }
+            }
+        },
+
+        "flicklist-ratings-entry": {
+            "description": "flicklist_ratings object form — optional minimum/maximum rating.",
+            "type": "object", "additionalProperties": false,
+            "properties": {
+                "minimum": { "type": "number", "minimum": 0.5, "maximum": 10 },
+                "maximum": { "type": "number", "minimum": 0.5, "maximum": 10 }
             }
         },
 

--- a/json-schema/config-schema.json
+++ b/json-schema/config-schema.json
@@ -55,6 +55,9 @@
     "yamtrack": {
       "$ref": "#/definitions/yamtrack-api"
     },
+    "flicklist": {
+      "$ref": "#/definitions/flicklist-api"
+    },
     "serializd": {
       "$ref": "#/definitions/serializd-api"
     },
@@ -1130,6 +1133,17 @@
       },
       "required": [],
       "title": "yamtrack"
+    },
+    "flicklist-api": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "api_key": {
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "flicklist"
     },
     "floppy-api": {
       "type": "object",
@@ -4507,7 +4521,7 @@
       "type": "object",
       "additionalProperties": false,
       "patternProperties": {
-        "^(?!plex|tmdb|tautulli|webhooks|omdb|mdblist|notifiarr|gotify|ntfy|anidb|radarr|sonarr|trakt|yamtrack|serializd|floppy|mal).+$": {
+        "^(?!plex|tmdb|tautulli|webhooks|omdb|mdblist|notifiarr|gotify|ntfy|anidb|radarr|sonarr|trakt|yamtrack|flicklist|serializd|floppy|mal).+$": {
           "additionalProperties": false,
           "properties": {
             "metadata_files": {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,6 +195,7 @@ nav:
       - Trakt: config/trakt.md
       - Floppy: config/floppy.md
       - YamTrack: config/yamtrack.md
+      - FlickList: config/flicklist.md
       - MyAnimeList: config/myanimelist.md
       - Kometa Utilities Authentication: config/authentication.md
       - Webhooks: config/webhooks.md
@@ -408,6 +409,11 @@ nav:
         - Overview: files/builders/yamtrack/overview.md
         - List: files/builders/yamtrack/list.md
         - Tracked: files/builders/yamtrack/tracked.md
+      - FlickList:
+        - Overview: files/builders/flicklist/overview.md
+        - List: files/builders/flicklist/list.md
+        - Personal: files/builders/flicklist/personal.md
+        - Ratings: files/builders/flicklist/ratings.md
       - Serializd:
         - Overview: files/builders/serializd/overview.md
         - Charts: files/builders/serializd/charts.md

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -1841,6 +1841,11 @@ class CollectionBuilder:
                 self.summaries[method_name] = self.config.Trakt.list_description(self.config.Trakt.validate_list(method_data)[0])
             except Failed as e:
                 logger.error(f"Trakt Error: List description not found: {e}")
+        elif method_name == "flicklist_description":
+            try:
+                self.summaries[method_name] = self.config.FlickList.list_description(self.config.FlickList._parse_list_id(method_data))
+            except Failed as e:
+                logger.error(f"FlickList Error: List description not found: {e}")
         elif method_name == "letterboxd_description":
             self.summaries[method_name] = self.config.Letterboxd.get_list_description(method_data, self.language)
         elif method_name == "icheckmovies_description":
@@ -3589,15 +3594,17 @@ class CollectionBuilder:
                 self.builders.append(("flicklist_list", flicklist_list))
             if method_name.endswith("_details"):
                 try:
-                    self.summaries[method_name] = self.config.FlickList.list_description(flicklist_lists[0])
+                    description = self.config.FlickList.list_description(flicklist_lists[0])
+                    if description:
+                        self.summaries[method_name] = description
                 except Failed as e:
                     logger.error(f"FlickList Error: List description not found: {e}")
         elif method_name == "flicklist_user_lists":
             username = self.config.FlickList.validate_username(self.Type, method_data)
             self.builders.append((method_name, username))
         elif method_name in ("flicklist_watchlist", "flicklist_favorites", "flicklist_watched", "flicklist_tracked"):
-            self.config.FlickList.validate_flag(self.Type, method_name, method_data)
-            self.builders.append((method_name, True))
+            if self.config.FlickList.validate_flag(self.Type, method_name, method_data):
+                self.builders.append((method_name, True))
         elif method_name == "flicklist_up_next":
             self.builders.append((method_name, self.config.FlickList.validate_up_next(self.Type, method_data)))
         elif method_name == "flicklist_ratings":

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -11,7 +11,7 @@ from plexapi.video import Episode, Movie, Season, Show
 from tmdbapis import TMDbException
 from tmdbapis.tmdb import discover_movie_sort_options, discover_tv_sort_options
 
-from modules import anidb, anilist, floppy, icheckmovies, imdb, letterboxd, mal, mdblist, mojo, plex, radarr, serializd, simkl, sonarr, stevenlu, tautulli, textfile, timings, tmdb, tracearr, trakt, tvdb, util, yamtrack
+from modules import anidb, anilist, flicklist, floppy, icheckmovies, imdb, letterboxd, mal, mdblist, mojo, plex, radarr, serializd, simkl, sonarr, stevenlu, tautulli, textfile, timings, tmdb, tracearr, trakt, tvdb, util, yamtrack
 from modules.overlay import Overlay, rating_sources
 from modules.poster import KometaImage
 from modules.request import quote
@@ -50,6 +50,7 @@ all_builders = (
     + simkl.builders
     + radarr.builders
     + sonarr.builders
+    + flicklist.builders
 )
 show_only_builders = [
     *serializd.builders,
@@ -64,6 +65,8 @@ show_only_builders = [
     "item_tmdb_season_titles",
     "sonarr_all",
     "sonarr_taglist",
+    "flicklist_up_next",
+    "flicklist_tracked",
 ]
 movie_only_builders = [
     "letterboxd_list",
@@ -107,6 +110,7 @@ summary_details = [
     "floppy_description",
     "letterboxd_description",
     "icheckmovies_description",
+    "flicklist_description",
 ]
 poster_details = ["url_poster", "tmdb_poster", "tmdb_profile", "tvdb_poster", "file_poster"]
 background_details = ["url_background", "tmdb_background", "tvdb_background", "file_background"]
@@ -223,8 +227,14 @@ none_details = [
     "item_critic_rating",
     "item_audience_rating",
     "item_user_rating",
+    "flicklist_watchlist",
+    "flicklist_favorites",
+    "flicklist_watched",
+    "flicklist_up_next",
+    "flicklist_tracked",
+    "flicklist_ratings",
 ]
-none_builders = ["radarr_taglist", "sonarr_taglist"]
+none_builders = ["radarr_taglist", "sonarr_taglist", "flicklist_watchlist", "flicklist_favorites", "flicklist_watched", "flicklist_up_next", "flicklist_tracked", "flicklist_ratings"]
 radarr_details = [
     "radarr_add_missing",
     "radarr_add_existing",
@@ -586,6 +596,11 @@ custom_sort_builders = [
     "anidb_tag_name",
     "simkl_trending",
     "simkl_dvd",
+    "flicklist_list",
+    "flicklist_user_lists",
+    "flicklist_watchlist",
+    "flicklist_favorites",
+    "flicklist_up_next",
 ]
 episode_parts_only = ["plex_pilots"]
 overlay_only = ["overlay", "suppress_overlays", "value_filter"]
@@ -1570,6 +1585,8 @@ class CollectionBuilder:
                     raise BuilderValidationError(f"{self.Type} Error: '{method_final}' attribute not compatible with playlists")
                 elif not self.config.Trakt and "trakt" in method_name:
                     raise ServiceError(f"{self.Type} Error: '{method_final}' requires Trakt to be configured")
+                elif not self.config.FlickList and "flicklist" in method_name:
+                    raise ServiceError(f"{self.Type} Error: '{method_final}' requires FlickList to be configured")
                 elif not self.library.Radarr and "radarr" in method_name:
                     raise ServiceError(f"{self.Type} Error: '{method_final}' requires Radarr to be configured")
                 elif not self.library.Sonarr and "sonarr" in method_name:
@@ -1666,6 +1683,8 @@ class CollectionBuilder:
                     self._trakt(method_name, method_data)
                 elif method_name in yamtrack.builders:
                     self._yamtrack(method_name, method_data)
+                elif method_name in flicklist.builders:
+                    self._flicklist(method_name, method_data)
                 elif method_name in serializd.builders:
                     self._serializd(method_name, method_data)
                 elif method_name in floppy.builders:
@@ -3561,6 +3580,29 @@ class CollectionBuilder:
             if description:
                 self.summaries[method_name] = description
 
+    def _flicklist(self, method_name, method_data):
+        if self.config.FlickList is None:
+            raise BuilderValidationError(f"{self.Type} Error: flicklist attribute not found in config")
+        if method_name in ("flicklist_list", "flicklist_list_details"):
+            flicklist_lists = self.config.FlickList.validate_lists(self.Type, method_data)
+            for flicklist_list in flicklist_lists:
+                self.builders.append(("flicklist_list", flicklist_list))
+            if method_name.endswith("_details"):
+                try:
+                    self.summaries[method_name] = self.config.FlickList.list_description(flicklist_lists[0])
+                except Failed as e:
+                    logger.error(f"FlickList Error: List description not found: {e}")
+        elif method_name == "flicklist_user_lists":
+            username = self.config.FlickList.validate_username(self.Type, method_data)
+            self.builders.append((method_name, username))
+        elif method_name in ("flicklist_watchlist", "flicklist_favorites", "flicklist_watched", "flicklist_tracked"):
+            self.config.FlickList.validate_flag(self.Type, method_name, method_data)
+            self.builders.append((method_name, True))
+        elif method_name == "flicklist_up_next":
+            self.builders.append((method_name, self.config.FlickList.validate_up_next(self.Type, method_data)))
+        elif method_name == "flicklist_ratings":
+            self.builders.append((method_name, self.config.FlickList.validate_ratings(self.Type, method_data)))
+
     def _serializd(self, method_name, method_data):
         if self.config.Serializd is None:
             raise BuilderValidationError(f"{self.Type} Error: serializd attribute not found in config")
@@ -3751,6 +3793,9 @@ class CollectionBuilder:
                     ids.extend(self.config.Convert.myanimelist_to_ids(mal_ids, self.library))
             else:
                 ids = self.config.YamTrack.get_ids(method, value, self.library.is_movie if not self.playlist else None)
+        elif "flicklist" in method:
+            #  is_movie=None = playlist mode; must return BOTH movie and show entries.
+            ids = self.config.FlickList.get_flicklist_ids(method, value, self.library.is_movie if not self.playlist else None)
         elif "serializd" in method:
             ids = self.config.Serializd.get_builder_ids(method, value)
         elif "floppy" in method:
@@ -5342,6 +5387,8 @@ class CollectionBuilder:
             summary = ("trakt_list_details", self.summaries["trakt_list_details"])
         elif "yamtrack_list_details" in self.summaries:
             summary = ("yamtrack_list_details", self.summaries["yamtrack_list_details"])
+        elif "flicklist_list_details" in self.summaries:
+            summary = ("flicklist_list_details", self.summaries["flicklist_list_details"])
         elif "floppy_list_details" in self.summaries:
             summary = ("floppy_list_details", self.summaries["floppy_list_details"])
         elif "tmdb_list_details" in self.summaries:

--- a/modules/config.py
+++ b/modules/config.py
@@ -9,6 +9,7 @@ from modules.apprise_notify import AppriseNotify
 from modules.cache import Cache
 from modules.convert import Convert
 from modules.ergast import Ergast
+from modules.flicklist import FlickList
 from modules.floppy import Floppy
 from modules.github import GitHub
 from modules.gotify import Gotify
@@ -1278,6 +1279,28 @@ class ConfigFile:
                 logger.info(f"YamTrack Connection {'Failed' if self.YamTrack is None else 'Successful'}")
             else:
                 logger.info("yamtrack attribute not found")
+
+            logger.separator()
+
+            self.FlickList = None
+            if "flicklist" in self.data:
+                logger.info("Connecting to FlickList...")
+                try:
+                    flicklist_obj = FlickList(
+                        self.Requests,
+                        self.read_only,
+                        {"api_key": check_for_attribute(self.data, "api_key", parent="flicklist", throw=True)},
+                    )
+                    flicklist_obj.test_connection()
+                    self.FlickList = flicklist_obj
+                except Failed as e:
+                    if str(e).endswith("is blank"):
+                        logger.warning(e)
+                    else:
+                        logger.error(e)
+                logger.info(f"FlickList Connection {'Failed' if self.FlickList is None else 'Successful'}")
+            else:
+                logger.info("flicklist attribute not found")
 
             logger.separator()
 

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -1,0 +1,337 @@
+import time
+
+from modules import util
+from modules.util import Failed
+
+logger = util.logger
+
+base_url = "https://flicklist.tv/api/v3"
+builders = [
+    "flicklist_list",
+    "flicklist_list_details",
+    "flicklist_user_lists",
+    "flicklist_watchlist",
+    "flicklist_favorites",
+    "flicklist_watched",
+    "flicklist_ratings",
+    "flicklist_up_next",
+    "flicklist_tracked",
+]
+show_only_methods = ["flicklist_up_next", "flicklist_tracked"]
+
+
+class FlickList:
+    def __init__(self, requests, read_only, params):
+        self.requests = requests
+        self.read_only = read_only
+        self.api_key = params["api_key"]
+        if logger:
+            logger.secret(self.api_key)
+        self.user_agent = f"Kometa/{self.requests.local} (+https://kometa.wiki)"
+        self._me = None
+        # No network I/O here; modules/config.py calls test_connection() separately so a failed connect can be neutered without a half-built object.
+
+    def test_connection(self):
+        me = self._request("/me")
+        self._me = me if isinstance(me, dict) else {}
+        username = self._me.get("username")
+        if logger:
+            logger.info(f"FlickList Connected as {username}" if username else "FlickList Connection Successful")
+
+    def _headers(self, anonymous=False):
+        headers = {"Content-Type": "application/json", "User-Agent": self.user_agent}
+        if not anonymous:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    @staticmethod
+    def _parse_error_body(response):
+        try:
+            payload = response.json()
+            return payload.get("detail") or payload.get("error") or response.reason
+        except ValueError:
+            return response.text[:200] if response.text else response.reason
+
+    def _send(self, path, url, headers, params, json_data, method):
+        attempts = 0
+        while True:
+            if method == "POST":
+                response = self.requests.post(url, json=json_data, headers=headers)
+            else:
+                response = self.requests.get(url, headers=headers, params=params)
+            if response.status_code != 429:
+                return response
+            attempts += 1
+            if attempts >= 3:
+                raise Failed(f"FlickList Error: Rate limited on {path} after 3 attempts this run; giving up for now")
+            retry_after = response.headers.get("Retry-After")
+            try:
+                wait_seconds = float(retry_after)
+            except (TypeError, ValueError):
+                wait_seconds = 60.0
+            if logger:
+                logger.warning(f"FlickList Warning: Rate limited on {path}; waiting {wait_seconds} seconds")
+            time.sleep(wait_seconds)
+
+    def _raise_for_status(self, path, response, ignore_404):
+        if response.status_code == 401:
+            raise Failed("FlickList Error: API key was rejected; it may have been revoked. Mint a new one and update your config.")
+        if response.status_code == 403:
+            raise Failed(f"FlickList Error: API key is missing a required scope for {path}")
+        if response.status_code == 404 and ignore_404:
+            return True
+        if response.status_code >= 400:
+            raise Failed(f"FlickList Error: ({response.status_code}) {self._parse_error_body(response)}")
+        return False
+
+    def _request_raw(self, path, params=None, json_data=None, method="GET", anonymous=False, ignore_404=False):
+        """Single call, no pagination. Returns whatever the endpoint sends back (dict, list, or None on a swallowed 404)."""
+        url = f"{base_url}{path}"
+        if logger:
+            logger.trace(f"URL: {url}")
+            if params:
+                logger.trace(f"Params: {params}")
+            if json_data is not None:
+                logger.trace(f"JSON: {json_data}")
+        headers = self._headers(anonymous=anonymous)
+        response = self._send(path, url, headers, params, json_data, method)
+        if self._raise_for_status(path, response, ignore_404):
+            return None
+        if response.status_code == 204 or not response.content:
+            return None
+        try:
+            return response.json()
+        except ValueError:
+            raise Failed(f"FlickList Error: {path} returned a non-JSON response body")
+
+    def _request(self, path, params=None, json_data=None, method="GET", anonymous=False, ignore_404=False):
+        """Single-call request against an object-returning endpoint. Always returns a dict, or None when ignore_404 swallowed a 404."""
+        data = self._request_raw(path, params=params, json_data=json_data, method=method, anonymous=anonymous, ignore_404=ignore_404)
+        if data is None:
+            return None
+        return data if isinstance(data, dict) else {}
+
+    def _request_list(self, path, params=None, anonymous=False):
+        """Single-call request against an array-returning endpoint (the un-paginated 'None' family). Always returns a list; a 404/204/empty body is treated as an empty list."""
+        data = self._request_raw(path, params=params, anonymous=anonymous)
+        return data if isinstance(data, list) else []
+
+    def _request_paginated(self, path, params=None, anonymous=False, ignore_404=False):
+        """Multi-page request against the header-paginated family. Always returns a list, or None when ignore_404 swallowed a 404."""
+        url = f"{base_url}{path}"
+        if logger:
+            logger.trace(f"URL: {url}")
+            if params:
+                logger.trace(f"Params: {params}")
+        headers = self._headers(anonymous=anonymous)
+        results = []
+        page = 1
+        page_count = 1
+        while page <= page_count:
+            call_params = dict(params) if params else None
+            if page > 1:
+                call_params = call_params or {}
+                call_params["page"] = page
+            response = self._send(path, url, headers, call_params, None, "GET")
+            if self._raise_for_status(path, response, ignore_404):
+                return None
+            if response.status_code == 204 or not response.content:
+                return []
+            try:
+                data = response.json()
+            except ValueError:
+                raise Failed(f"FlickList Error: {path} returned a non-JSON response body")
+            if isinstance(data, list):
+                results.extend(data)
+            elif isinstance(data, dict):
+                results.append(data)
+            if page == 1:
+                if logger:
+                    logger.trace(f"Limit: {response.headers.get('X-FlickList-Limit')}")
+                try:
+                    page_count = int(response.headers.get("X-FlickList-Page-Count", 1))
+                except (TypeError, ValueError):
+                    page_count = 1
+            page += 1
+        return results
+
+    def _parse_ids(self, items, is_movie=None):
+        ids = []
+        seen = set()
+        for item in items or []:
+            ids_block = item.get("ids") or {}
+            media_type = str(item.get("media_type") or "").lower()
+            is_show = media_type in ("tv", "show")
+            is_item_movie = media_type == "movie"
+            if is_movie is True and not is_item_movie:
+                continue
+            if is_movie is False and not is_show:
+                continue
+            tmdb_id = ids_block.get("tmdb")
+            tvdb_id = ids_block.get("tvdb")
+            imdb_id = ids_block.get("imdb")
+            fldb_id = ids_block.get("fldb")
+            if is_item_movie and tmdb_id:
+                key = (int(tmdb_id), "tmdb")
+            elif is_show and tmdb_id:
+                key = (int(tmdb_id), "tmdb_show")
+            elif is_show and tvdb_id:
+                key = (int(tvdb_id), "tvdb")
+            elif imdb_id:
+                # Kometa's Convert layer resolves imdb-only ids downstream; a GET /v3/find/{id} call here would spend the one genuinely expensive read on every read, not just unresolved ones.
+                key = (str(imdb_id), "imdb")
+            else:
+                title = item.get("title") or item.get("name") or fldb_id or "Unknown"
+                if logger:
+                    logger.warning(f"FlickList Warning: No usable ID found for {title}; skipping")
+                continue
+            dedupe_key = fldb_id or key
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            ids.append(key)
+        return ids
+
+    @staticmethod
+    def _parse_list_id(value):
+        if isinstance(value, bool):
+            raise Failed(f"FlickList Error: Could not parse a list id from {value}")
+        if isinstance(value, int):
+            return value
+        text = str(value).strip()
+        if text.isdigit():
+            return int(text)
+        candidate = text.rstrip("/").rsplit("/", 1)[-1]
+        if candidate.isdigit():
+            return int(candidate)
+        raise Failed(f"FlickList Error: Could not parse a list id from {value}")
+
+    def validate_lists(self, err_type, method_data):
+        valid_ids = []
+        for value in util.get_list(method_data, split=False, return_none=False):
+            if isinstance(value, dict):
+                raise Failed(f"{err_type} Error: FlickList List cannot be a dictionary")
+            valid_ids.append(self._parse_list_id(value))
+        if not valid_ids:
+            raise Failed(f"{err_type} Error: No valid FlickList Lists")
+        return valid_ids
+
+    @staticmethod
+    def validate_username(err_type, method_data):
+        if isinstance(method_data, dict) or not str(method_data).strip():
+            raise Failed(f"{err_type} Error: flicklist_user_lists requires a username")
+        return str(method_data).strip()
+
+    @staticmethod
+    def validate_flag(err_type, method_name, method_data):
+        if method_data is None:
+            return True
+        if not util.parse(err_type, method_name, method_data, datatype="bool", default=True):
+            raise Failed(f"{err_type} Error: {method_name} must be set to true")
+        return True
+
+    @staticmethod
+    def validate_up_next(err_type, method_data):
+        if method_data is None or isinstance(method_data, bool):
+            return None
+        try:
+            limit = int(method_data)
+        except (TypeError, ValueError):
+            raise Failed(f"{err_type} Error: flicklist_up_next must be blank, true, or an integer limit")
+        if limit < 1:
+            raise Failed(f"{err_type} Error: flicklist_up_next limit must be a positive integer")
+        return limit
+
+    @staticmethod
+    def validate_ratings(err_type, method_data):
+        def to_float(value, label):
+            try:
+                return float(value)
+            except (TypeError, ValueError):
+                raise Failed(f"{err_type} Error: flicklist_ratings {label} must be a number")
+
+        if method_data is None or isinstance(method_data, bool):
+            return {"minimum": None, "maximum": None}
+        if isinstance(method_data, dict):
+            dict_methods = {dm.lower(): dm for dm in method_data}
+            minimum = to_float(method_data[dict_methods["minimum"]], "minimum") if "minimum" in dict_methods else None
+            maximum = to_float(method_data[dict_methods["maximum"]], "maximum") if "maximum" in dict_methods else None
+            return {"minimum": minimum, "maximum": maximum}
+        return {"minimum": to_float(method_data, "minimum"), "maximum": None}
+
+    def _list_items(self, list_id):
+        return self._request_paginated(f"/lists/{list_id}/items")
+
+    def list_description(self, list_id):
+        data = self._request(f"/lists/{list_id}") or {}
+        return data.get("description") or ""
+
+    def _user_lists_ids(self, username, is_movie):
+        lists = self._request_paginated(f"/users/{username}/lists", anonymous=True, ignore_404=True)
+        if lists is None:
+            raise Failed(f"FlickList Error: User {username} not found")
+        if not lists:
+            raise Failed(f"FlickList Error: User {username} has no public lists")
+        if logger:
+            logger.info(f"Processing FlickList User Lists: {len(lists)} lists from {username}")
+        ids = []
+        seen = set()
+        for entry in lists:
+            list_id = entry.get("id")
+            if list_id is None:
+                continue
+            for item_id in self._parse_ids(self._list_items(list_id), is_movie=is_movie):
+                if item_id not in seen:
+                    seen.add(item_id)
+                    ids.append(item_id)
+        return ids
+
+    @staticmethod
+    def _log_info(message):
+        if logger:
+            logger.info(message)
+
+    def get_flicklist_ids(self, method, value, is_movie):
+        pretty = method.replace("_", " ").title()
+        if method in ("flicklist_list", "flicklist_list_details"):
+            self._log_info(f"Processing {pretty}: {value}")
+            return self._parse_ids(self._list_items(value), is_movie=is_movie)
+        if method == "flicklist_user_lists":
+            return self._user_lists_ids(value, is_movie)
+        if method == "flicklist_watchlist":
+            self._log_info(f"Processing {pretty}")
+            return self._parse_ids(self._request_list("/sync/watchlist"), is_movie=is_movie)
+        if method == "flicklist_favorites":
+            self._log_info(f"Processing {pretty}")
+            return self._parse_ids(self._request_list("/sync/favorites"), is_movie=is_movie)
+        if method == "flicklist_watched":
+            self._log_info(f"Processing {pretty}")
+            items = []
+            if is_movie is not False:
+                items.extend(self._request_list("/sync/watched/movies"))
+            if is_movie is not True:
+                items.extend(self._request_list("/sync/watched/shows"))
+            return self._parse_ids(items, is_movie=is_movie)
+        if method == "flicklist_ratings":
+            self._log_info(f"Processing {pretty}")
+            minimum = value.get("minimum") if isinstance(value, dict) else None
+            maximum = value.get("maximum") if isinstance(value, dict) else None
+            filtered = []
+            for item in self._request_list("/sync/ratings"):
+                rating = item.get("rating")
+                if rating is None:
+                    continue
+                if minimum is not None and rating < minimum:
+                    continue
+                if maximum is not None and rating > maximum:
+                    continue
+                filtered.append(item)
+            return self._parse_ids(filtered, is_movie=is_movie)
+        if method == "flicklist_up_next":
+            self._log_info(f"Processing {pretty}")
+            params = {"limit": value} if value else None
+            return self._parse_ids(self._request_list("/sync/up_next", params=params), is_movie=False)
+        if method == "flicklist_tracked":
+            self._log_info(f"Processing {pretty}")
+            return self._parse_ids(self._request_list("/sync/tracked"), is_movie=False)
+        raise Failed(f"FlickList Error: Method {method} not supported")

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -193,6 +193,26 @@ class FlickList:
         return ids
 
     @staticmethod
+    def _normalize_watched_movie(item):
+        """WatchedMovie carries a top-level `ids` block but no `media_type` field at all - the
+        endpoint is movie-only by construction, so the schema omits it. _parse_ids relies on
+        `media_type` to classify each item, so every watched movie was silently dropped (matched
+        neither the movie nor show branch) until this tagged it explicitly."""
+        item = dict(item)
+        item["media_type"] = "movie"
+        return item
+
+    @staticmethod
+    def _normalize_watched_show(item):
+        """WatchedShow has no top-level `media_type` OR `ids` - both live one level down, under
+        `show` ({"show": {"title": ..., "ids": {...}}, "plays": ..., "seasons": [...]}). Unwrap it
+        and tag the type so _parse_ids has an `ids` block to look at at all, not just a type to
+        classify it by - without this every watched show was silently dropped twice over."""
+        show = dict(item.get("show") or {})
+        show["media_type"] = "tv"
+        return show
+
+    @staticmethod
     def _parse_list_id(value):
         if isinstance(value, bool):
             raise Failed(f"FlickList Error: Could not parse a list id from {value}")
@@ -309,9 +329,9 @@ class FlickList:
             self._log_info(f"Processing {pretty}")
             items = []
             if is_movie is not False:
-                items.extend(self._request_list("/sync/watched/movies"))
+                items.extend(self._normalize_watched_movie(item) for item in self._request_list("/sync/watched/movies"))
             if is_movie is not True:
-                items.extend(self._request_list("/sync/watched/shows"))
+                items.extend(self._normalize_watched_show(item) for item in self._request_list("/sync/watched/shows"))
             return self._parse_ids(items, is_movie=is_movie)
         if method == "flicklist_ratings":
             self._log_info(f"Processing {pretty}")

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -224,11 +224,12 @@ class FlickList:
 
     @staticmethod
     def validate_flag(err_type, method_name, method_data):
+        """True/blank enables the builder; explicit false just leaves it out, same as omitting the
+        attribute - erroring on `method_name: false` punished a value config.yml owners can reach
+        for naturally (e.g. templating a shared block where one library sets a flag off)."""
         if method_data is None:
             return True
-        if not util.parse(err_type, method_name, method_data, datatype="bool", default=True):
-            raise Failed(f"{err_type} Error: {method_name} must be set to true")
-        return True
+        return util.parse(err_type, method_name, method_data, datatype="bool", default=True)
 
     @staticmethod
     def validate_up_next(err_type, method_data):

--- a/tests/test_flicklist.py
+++ b/tests/test_flicklist.py
@@ -267,3 +267,68 @@ def test_validate_ratings_accepts_blank_number_and_dict():
     assert FlickList.validate_ratings("Collection", None) == {"minimum": None, "maximum": None}
     assert FlickList.validate_ratings("Collection", 7) == {"minimum": 7.0, "maximum": None}
     assert FlickList.validate_ratings("Collection", {"minimum": 7, "maximum": 9}) == {"minimum": 7.0, "maximum": 9.0}
+
+
+# --- flicklist_watched: WatchedMovie/WatchedShow carry no top-level media_type (WatchedShow also
+# nests its `ids` under a `show` object), unlike every other personal endpoint this integration
+# reads. _parse_ids classifies purely off `media_type`, so without normalizing these two shapes
+# first, every watched item is silently dropped regardless of real watch history - these fixtures
+# use the real nested/flat shapes from the live OpenAPI spec, not a flattened stand-in that would
+# pass against both the buggy and fixed code. ---
+
+
+def _watched_movie_payload(tmdb=550, title="Fight Club", plays=3):
+    # Real WatchedMovie shape: top-level `ids`, no `media_type` key at all.
+    return {"title": title, "year": 1999, "plays": plays, "last_watched_at": "2026-05-14T02:10:33.000Z", "ids": {"tmdb": tmdb}}
+
+
+def _watched_show_payload(tmdb=1396, title="Breaking Bad", plays=62):
+    # Real WatchedShow shape: no top-level `media_type` OR `ids` - both live under `show`.
+    return {
+        "show": {"title": title, "ids": {"tmdb": tmdb}},
+        "plays": plays,
+        "last_watched_at": "2026-05-14T02:10:33.000Z",
+        "reset_at": None,
+        "seasons": [],
+    }
+
+
+def test_normalize_watched_movie_tags_media_type_without_losing_ids():
+    flicklist = make_flicklist([])
+    normalized = flicklist._normalize_watched_movie(_watched_movie_payload(tmdb=550))
+    assert normalized["media_type"] == "movie"
+    assert normalized["ids"] == {"tmdb": 550}
+
+
+def test_normalize_watched_show_unwraps_show_object_and_tags_media_type():
+    flicklist = make_flicklist([])
+    normalized = flicklist._normalize_watched_show(_watched_show_payload(tmdb=1396))
+    assert normalized["media_type"] == "tv"
+    assert normalized["ids"] == {"tmdb": 1396}
+
+
+def test_normalize_watched_show_missing_show_key_does_not_raise():
+    flicklist = make_flicklist([])
+    normalized = flicklist._normalize_watched_show({"plays": 1, "seasons": []})
+    assert normalized["media_type"] == "tv"
+    assert normalized.get("ids") is None
+
+
+def test_flicklist_watched_movie_library_returns_real_watched_movies():
+    flicklist = make_flicklist([FakeResponse(json_data=[_watched_movie_payload(tmdb=550)])])
+    assert flicklist.get_flicklist_ids("flicklist_watched", None, is_movie=True) == [(550, "tmdb")]
+
+
+def test_flicklist_watched_show_library_returns_real_watched_shows():
+    flicklist = make_flicklist([FakeResponse(json_data=[_watched_show_payload(tmdb=1396)])])
+    assert flicklist.get_flicklist_ids("flicklist_watched", None, is_movie=False) == [(1396, "tmdb_show")]
+
+
+def test_flicklist_watched_playlist_mode_returns_both_movies_and_shows():
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[_watched_movie_payload(tmdb=550)]),
+            FakeResponse(json_data=[_watched_show_payload(tmdb=1396)]),
+        ]
+    )
+    assert flicklist.get_flicklist_ids("flicklist_watched", None, is_movie=None) == [(550, "tmdb"), (1396, "tmdb_show")]

--- a/tests/test_flicklist.py
+++ b/tests/test_flicklist.py
@@ -1,0 +1,269 @@
+from unittest.mock import patch
+
+import pytest
+
+from modules.flicklist import FlickList
+from modules.util import Failed
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None, headers=None, content=b"{}", text=None, reason="OK", raise_on_json=False):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.headers = headers or {}
+        self.content = content
+        self.text = text if text is not None else ("" if content == b"" else content.decode("utf-8", errors="ignore"))
+        self.reason = reason
+        self._raise_on_json = raise_on_json
+
+    def json(self):
+        if self._raise_on_json:
+            raise ValueError("not JSON")
+        return self._json_data
+
+
+class FakeRequests:
+    def __init__(self, responses):
+        self.local = "2.4.8-build5"
+        self._responses = list(responses)
+        self.gets = []
+        self.posts = []
+
+    def get(self, url, headers=None, params=None):
+        self.gets.append((url, headers, params))
+        return self._responses.pop(0)
+
+    def post(self, url, json=None, headers=None):
+        self.posts.append((url, json, headers))
+        return self._responses.pop(0)
+
+
+def make_flicklist(responses, read_only=False):
+    return FlickList(FakeRequests(responses), read_only, {"api_key": "fs_live_test"})
+
+
+def test_user_agent_includes_local_version():
+    flicklist = make_flicklist([])
+    assert flicklist.user_agent == "Kometa/2.4.8-build5 (+https://kometa.wiki)"
+
+
+def test_test_connection_success_logs_username():
+    flicklist = make_flicklist([FakeResponse(json_data={"username": "chris"})])
+    flicklist.test_connection()
+    assert flicklist._me == {"username": "chris"}
+
+
+def test_test_connection_failure_raises_failed():
+    flicklist = make_flicklist([FakeResponse(status_code=401, json_data={"error": "unauthorized"})])
+    with pytest.raises(Failed, match="API key was rejected"):
+        flicklist.test_connection()
+
+
+def test_401_raises_revoked_message_without_retry():
+    flicklist = make_flicklist([FakeResponse(status_code=401, json_data={"error": "unauthorized"})])
+    with pytest.raises(Failed, match="revoked"):
+        flicklist._request("/me")
+    assert len(flicklist.requests.gets) == 1
+
+
+def test_403_names_missing_scope():
+    flicklist = make_flicklist([FakeResponse(status_code=403, json_data={"error": "forbidden"})])
+    with pytest.raises(Failed, match=r"missing a required scope for /sync/watchlist"):
+        flicklist._request("/sync/watchlist")
+
+
+def test_non_json_error_body_on_500_raises_failed_not_valueerror():
+    flicklist = make_flicklist([FakeResponse(status_code=500, content=b"internal server error", text="internal server error", raise_on_json=True, reason="Internal Server Error")])
+    with pytest.raises(Failed, match="internal server error"):
+        flicklist._request("/me")
+
+
+@patch("time.sleep", return_value=None)
+def test_429_with_retry_after_honors_header_value(mock_sleep):
+    flicklist = make_flicklist(
+        [
+            FakeResponse(status_code=429, headers={"Retry-After": "5"}, json_data={"error": "rate_limited"}),
+            FakeResponse(json_data={"username": "chris"}),
+        ]
+    )
+    flicklist._request("/me")
+    mock_sleep.assert_called_once_with(5.0)
+
+
+@patch("time.sleep", return_value=None)
+def test_429_without_header_and_html_body_still_backs_off(mock_sleep):
+    flicklist = make_flicklist(
+        [
+            FakeResponse(status_code=429, headers={}, content=b"<html>rate limited</html>", text="<html>rate limited</html>", raise_on_json=True, reason="Too Many Requests"),
+            FakeResponse(json_data={"username": "chris"}),
+        ]
+    )
+    flicklist._request("/me")
+    mock_sleep.assert_called_once_with(60.0)
+
+
+@patch("time.sleep", return_value=None)
+def test_429_gives_up_after_three_attempts(mock_sleep):
+    responses = [FakeResponse(status_code=429, headers={}, json_data={"error": "rate_limited"}) for _ in range(3)]
+    flicklist = make_flicklist(responses)
+    with pytest.raises(Failed, match="Rate limited"):
+        flicklist._request("/me")
+    assert len(flicklist.requests.gets) == 3
+
+
+def test_paginated_read_follows_page_count_header():
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[{"id": 1}], headers={"X-FlickList-Page-Count": "2", "X-FlickList-Limit": "500"}),
+            FakeResponse(json_data=[{"id": 2}]),
+        ]
+    )
+    results = flicklist._request_paginated("/lists/1/items")
+    assert results == [{"id": 1}, {"id": 2}]
+    assert len(flicklist.requests.gets) == 2
+
+
+def test_paginated_read_without_page_count_header_is_single_page():
+    flicklist = make_flicklist([FakeResponse(json_data=[{"id": 1}], headers={})])
+    results = flicklist._request_paginated("/lists/1/items")
+    assert results == [{"id": 1}]
+    assert len(flicklist.requests.gets) == 1
+
+
+def test_no_limit_param_is_ever_sent_on_paginated_reads():
+    flicklist = make_flicklist([FakeResponse(json_data=[{"id": 1}], headers={"X-FlickList-Page-Count": "2"}), FakeResponse(json_data=[{"id": 2}])])
+    flicklist._request_paginated("/lists/1/items")
+    for _, _, params in flicklist.requests.gets:
+        assert not params or "limit" not in params
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (4821, 4821),
+        ("4821", 4821),
+        ("https://flicklist.tv/list/4821", 4821),
+        ("https://flicklist.tv/list/4821/", 4821),
+    ],
+)
+def test_parse_list_id_accepts_bare_id_and_url(value, expected):
+    assert FlickList._parse_list_id(value) == expected
+
+
+def test_parse_list_id_rejects_garbage():
+    with pytest.raises(Failed, match="Could not parse a list id"):
+        FlickList._parse_list_id("not-a-list")
+
+
+def test_validate_lists_returns_ids_for_multiple_values():
+    flicklist = make_flicklist([])
+    assert flicklist.validate_lists("Collection", ["4821", "https://flicklist.tv/list/9310"]) == [4821, 9310]
+
+
+def test_validate_lists_rejects_dict_entries():
+    flicklist = make_flicklist([])
+    with pytest.raises(Failed, match="cannot be a dictionary"):
+        flicklist.validate_lists("Collection", [{"bad": True}])
+
+
+def _movie(tmdb=None, tvdb=None, imdb=None, fldb=None, title="Movie", media_type="movie"):
+    ids = {}
+    if tmdb is not None:
+        ids["tmdb"] = tmdb
+    if tvdb is not None:
+        ids["tvdb"] = tvdb
+    if imdb is not None:
+        ids["imdb"] = imdb
+    if fldb is not None:
+        ids["fldb"] = fldb
+    return {"ids": ids, "media_type": media_type, "title": title}
+
+
+def test_parse_ids_movie_with_tmdb():
+    flicklist = make_flicklist([])
+    assert flicklist._parse_ids([_movie(tmdb=550)]) == [(550, "tmdb")]
+
+
+def test_parse_ids_show_with_tmdb():
+    flicklist = make_flicklist([])
+    assert flicklist._parse_ids([_movie(tmdb=1396, media_type="show")]) == [(1396, "tmdb_show")]
+
+
+def test_parse_ids_show_with_tvdb_only():
+    flicklist = make_flicklist([])
+    assert flicklist._parse_ids([_movie(tvdb=81189, media_type="show")]) == [(81189, "tvdb")]
+
+
+def test_parse_ids_imdb_only():
+    flicklist = make_flicklist([])
+    assert flicklist._parse_ids([_movie(imdb="tt0903747", media_type="show")]) == [("tt0903747", "imdb")]
+
+
+def test_parse_ids_media_type_tv_and_show_both_resolve_to_show():
+    flicklist = make_flicklist([])
+    tv_item = _movie(tmdb=1396, media_type="tv")
+    show_item = _movie(tmdb=1397, media_type="show")
+    assert flicklist._parse_ids([tv_item, show_item]) == [(1396, "tmdb_show"), (1397, "tmdb_show")]
+
+
+def test_parse_ids_no_usable_id_warns_and_skips():
+    flicklist = make_flicklist([])
+    assert flicklist._parse_ids([{"ids": {}, "media_type": "movie", "title": "Mystery Movie"}]) == []
+
+
+def test_parse_ids_unknown_key_in_ids_block_is_ignored():
+    flicklist = make_flicklist([])
+    item = {"ids": {"tmdb": 550, "anilist": None, "some_future_key": "xyz"}, "media_type": "movie", "title": "Fight Club"}
+    assert flicklist._parse_ids([item]) == [(550, "tmdb")]
+
+
+def test_parse_ids_is_movie_true_filters_to_movies_only():
+    flicklist = make_flicklist([])
+    items = [_movie(tmdb=550, media_type="movie"), _movie(tmdb=1396, media_type="show")]
+    assert flicklist._parse_ids(items, is_movie=True) == [(550, "tmdb")]
+
+
+def test_parse_ids_is_movie_false_filters_to_shows_only():
+    flicklist = make_flicklist([])
+    items = [_movie(tmdb=550, media_type="movie"), _movie(tmdb=1396, media_type="show")]
+    assert flicklist._parse_ids(items, is_movie=False) == [(1396, "tmdb_show")]
+
+
+def test_parse_ids_is_movie_none_returns_both_movie_and_show_playlist_mode():
+    flicklist = make_flicklist([])
+    items = [_movie(tmdb=550, media_type="movie"), _movie(tmdb=1396, media_type="show")]
+    assert flicklist._parse_ids(items, is_movie=None) == [(550, "tmdb"), (1396, "tmdb_show")]
+
+
+def test_parse_ids_dedupes_on_fldb():
+    flicklist = make_flicklist([])
+    items = [_movie(tmdb=550, fldb="flt_abc"), _movie(tmdb=550, fldb="flt_abc")]
+    assert flicklist._parse_ids(items) == [(550, "tmdb")]
+
+
+def test_validate_flag_accepts_blank_as_true():
+    flicklist = make_flicklist([])
+    assert flicklist.validate_flag("Collection", "flicklist_watchlist", None) is True
+
+
+def test_validate_flag_rejects_explicit_false():
+    flicklist = make_flicklist([])
+    with pytest.raises(Failed, match="must be set to true"):
+        flicklist.validate_flag("Collection", "flicklist_watchlist", False)
+
+
+def test_validate_up_next_accepts_blank_true_and_int():
+    assert FlickList.validate_up_next("Collection", None) is None
+    assert FlickList.validate_up_next("Collection", True) is None
+    assert FlickList.validate_up_next("Collection", 20) == 20
+
+
+def test_validate_up_next_rejects_non_integer():
+    with pytest.raises(Failed, match="blank, true, or an integer limit"):
+        FlickList.validate_up_next("Collection", "soon")
+
+
+def test_validate_ratings_accepts_blank_number_and_dict():
+    assert FlickList.validate_ratings("Collection", None) == {"minimum": None, "maximum": None}
+    assert FlickList.validate_ratings("Collection", 7) == {"minimum": 7.0, "maximum": None}
+    assert FlickList.validate_ratings("Collection", {"minimum": 7, "maximum": 9}) == {"minimum": 7.0, "maximum": 9.0}

--- a/tests/test_flicklist.py
+++ b/tests/test_flicklist.py
@@ -246,10 +246,10 @@ def test_validate_flag_accepts_blank_as_true():
     assert flicklist.validate_flag("Collection", "flicklist_watchlist", None) is True
 
 
-def test_validate_flag_rejects_explicit_false():
+def test_validate_flag_explicit_false_returns_false_without_raising():
+    # false just means "don't add this builder" - same as omitting the attribute - not a config error.
     flicklist = make_flicklist([])
-    with pytest.raises(Failed, match="must be set to true"):
-        flicklist.validate_flag("Collection", "flicklist_watchlist", False)
+    assert flicklist.validate_flag("Collection", "flicklist_watchlist", False) is False
 
 
 def test_validate_up_next_accepts_blank_true_and_int():


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Adds `flicklist` as a new metadata/list source, following the same shape as the existing Trakt/YamTrack connectors. Authenticates with a single pasted API key (no OAuth in this repo - a separate device-code auth helper page lives in Kometa-Utilities).

New builders: `flicklist_list` / `flicklist_list_details` (any FlickList list by id or URL), `flicklist_user_lists` (all of a user's public lists), `flicklist_watchlist`, `flicklist_favorites`, `flicklist_watched`, `flicklist_ratings` (with optional min/max filtering), `flicklist_up_next` and `flicklist_tracked` (both show-only).

This PR is read-only, no writes to FlickList yet. List-sync (`sync_to_flicklist_list`) and the `flicklist_user` mass-rating source are separate, stacked PRs on top of this one (#3521 and a third) so each can be reviewed independently.

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No