### PR TITLE
feat: Add FlickList list sync (sync_to_flicklist_list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `url_theme` and `file_theme` metadata attributes for uploading theme music to individual movies and shows.
 - Support the `folder_location` Plex search option in music-library track builders.
 - Add a FlickList connector (`flicklist` config attribute) with read-only `flicklist_list`, `flicklist_list_details`, `flicklist_user_lists`, `flicklist_watchlist`, `flicklist_favorites`, `flicklist_watched`, `flicklist_ratings`, `flicklist_up_next`, and `flicklist_tracked` builders, plus a `flicklist_description` summary source.
+- Add `sync_to_flicklist_list` and `sync_missing_to_flicklist_list` to sync a collection's contents to a FlickList list, mirroring `sync_to_trakt_list`/`sync_missing_to_trakt_list`.
 
 ### Fixed
 

--- a/docs/files/settings.md
+++ b/docs/files/settings.md
@@ -37,6 +37,8 @@ tags:
   - sync_to_trakt_list
   - sync_to_mdb_list
   - sync_missing_to_trakt_list
+  - sync_to_flicklist_list
+  - sync_missing_to_flicklist_list
   - run_definition
   - default_percent
   - ignore_blank_results
@@ -80,9 +82,11 @@ All the following attributes serve various functions as how the definition funct
 | `show_unfiltered`            | **Description:** definition level `show_unfiltered` toggle.<br>**Default:** `show_unfiltered` [settings value](../config/settings.md) in the Configuration File<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 | `smart_label`                | **Description:** Adds a label to all items found by the builder, which is then used to create a Smart Collection searching for the label<br>See [Smart Label Definitions](#smart-label-defintiions) for more information and use-cases                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `sync_missing_to_trakt_list` | **Description:** Used to also sync missing items to the Trakt List specified by `sync_to_trakt_list`.<br>**Default:** `false`<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `sync_missing_to_flicklist_list` | **Description:** Used to also sync missing items to the FlickList List specified by `sync_to_flicklist_list`.<br>**Default:** `false`<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `sync_mode`                  | **Description:** Used to change how builders sync with this definition.<br>**Default:** `sync_mode` [settings value](../config/settings.md) in the Configuration File<br>**Values:** `sync` or `append`<br>See main [settings page](../config/settings.md#sync-mode)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | `sync_to_trakt_list`         | **Description:** Used to specify a trakt list you want the definition synced to.<br>**Values:** Trakt List Slug you want to sync to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
 | `sync_to_mdb_list`           | **Description:** Syncs a collection to an MDBList static list by exact `name`, creating it when absent. Use a name directly or an object with `name` and optional `mode` (`sync` by default, or `append`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `sync_to_flicklist_list`     | **Description:** Syncs a collection to a FlickList list, by numeric list id or exact `name`. A matching list is used if found among your own FlickList lists; otherwise one is created. See [FlickList Sync Example](#flicklist-sync-example) below.<br>**Values:** FlickList list id (number) or list name (string)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | `template`                   | **Description:** Used to specify a template and Template Variables to use for this definition. See the [Templates Page](templates.md) for more information.<br>**Values:** Dictionary :material-information-outline:{ data-tooltip data-tooltip-id="tippy-yaml-dictionaries" }                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `test`                       | **Description:** When running in Test Mode (`--run-tests` [option](../kometa/environmental.md)) only definitions with `test: true` will be run.<br>**Default:** `false`<br>**Values:** `true` or `false`                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 | `tmdb_birthday`              | **Description:** Controls if the Definition is run based on `tmdb_person`'s Birthday. Has 3 possible attributes `this_month`, `before` and `after`.<br>**Values:**<table class="clearTable"><tr><td>`this_month`</td><td>Run's if Birthday is in current Month</td><td>`true`/`false`</td></tr><tr><td>`before`</td><td>Run if X Number of Days before the Birthday</td><td>Number 0 or greater</td></tr><tr><td>`after`</td><td>Run if X Number of Days after the Birthday</td><td>Number 0 or greater</td></tr></table>                                                                                                                                                                                                                                                                                          |
@@ -116,6 +120,39 @@ If a list with the name specified exists, it will be used. If no list exists, on
 The default `mode` is `sync`, which adds missing items and removes items no
 longer present in the collection. Use `append` to add items without removing
 existing list entries. Movies and shows are supported.
+
+### FlickList Sync Example
+
+`sync_to_flicklist_list` synchronizes a collection with a list in your FlickList account. The list is
+found by numeric id or exact name among your own lists, and created automatically when no match exists.
+
+```yaml
+collections:
+  Recently Added:
+    plex_search:
+      all:
+        added: 30
+    sync_to_flicklist_list: "Recently Added"
+
+  Missing Movies and Shows:
+    plex_search:
+      all:
+        added: 30
+    sync_to_flicklist_list: "Missing Movies and Shows"
+    sync_missing_to_flicklist_list: true
+```
+
+Movies and shows are supported; season/episode-level collections are skipped with a single warning, since
+FlickList lists do not have a concept of individual seasons or episodes.
+
+Unlike `sync_to_trakt_list`, FlickList has no list-reorder endpoint, so `sync_to_flicklist_list` cannot
+preserve a collection's custom order on the FlickList side — items land in the list, but not necessarily
+in the same order as the Kometa collection.
+
+If Kometa cannot confidently match an item already in the FlickList list against the collection's current
+contents (for example, an item added to the list some other way that only carries an id type Kometa
+cannot resolve), that item is left in the list rather than removed. A stale, over-cautious leftover is
+preferred over the alternative of the sync deleting something it shouldn't have.
 
 ## Smart Label Definitions
 

--- a/json-schema/collection-schema.json
+++ b/json-schema/collection-schema.json
@@ -102,9 +102,11 @@
                 "show_missing": { "type": "boolean" },
                 "show_unfiltered": { "type": "boolean" },
                 "sync_missing_to_trakt_list": { "type": "boolean" },
+                "sync_missing_to_flicklist_list": { "type": "boolean" },
                 "sync_mode": { "type": "string", "enum": ["sync", "append"] },
                 "sync_to_trakt_list": { "type": "string", "description": "Trakt list slug to sync this definition to." },
                 "sync_to_mdb_list": { "oneOf": [{ "type": "string" }, { "type": "object", "required": ["name"], "properties": { "name": { "type": "string" }, "mode": { "type": "string", "enum": ["sync", "append"], "default": "sync" } }, "additionalProperties": false }], "description": "MDBList list name, optionally with sync or append mode." },
+                "sync_to_flicklist_list": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "FlickList list id or name to sync this definition to. Created automatically if no matching list is found among your own lists." },
                 "test": { "type": "boolean" },
                 "tmdb_birthday": {
                     "type": "object", "additionalProperties": false,

--- a/kometa.py
+++ b/kometa.py
@@ -1383,7 +1383,7 @@ def run_collection(config, library, metadata, requested_collections):
             if valid and run_item_details and arr_mdb_list_sync:
                 builder.sync_mdb_list()
 
-            if valid and run_item_details and (builder.item_details or builder.custom_sort or builder.sync_to_trakt_list or (builder.sync_to_mdb_list and not arr_mdb_list_sync)):
+            if valid and run_item_details and (builder.item_details or builder.custom_sort or builder.sync_to_trakt_list or builder.sync_to_flicklist_list or (builder.sync_to_mdb_list and not arr_mdb_list_sync)):
                 try:
                     builder.load_collection_items()
                 except Failed:
@@ -1396,6 +1396,8 @@ def run_collection(config, library, metadata, requested_collections):
                         builder.sort_collection()
                     if builder.sync_to_trakt_list:
                         builder.sync_trakt_list()
+                    if builder.sync_to_flicklist_list:
+                        builder.sync_flicklist_list()
                     if builder.sync_to_mdb_list and not arr_mdb_list_sync:
                         builder.sync_mdb_list()
 

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -5745,7 +5745,7 @@ class CollectionBuilder:
             self.library.item_reload(self.obj)
         self.load_collection_items()
         current_ids = []
-        skipped_episodes = 0
+        skipped_seasons_and_episodes = 0
         for item in self.items:
             for pl_library in self.libraries:
                 new_id = None
@@ -5754,13 +5754,13 @@ class CollectionBuilder:
                 elif isinstance(item, Show) and item.ratingKey in pl_library.show_rating_key_map:
                     new_id = ({"tvdb": pl_library.show_rating_key_map[item.ratingKey]}, "show")
                 elif isinstance(item, (Season, Episode)):
-                    skipped_episodes += 1
+                    skipped_seasons_and_episodes += 1
                     break
                 if new_id:
                     current_ids.append(new_id)
                     break
-        if skipped_episodes:
-            logger.warning(f"FlickList Warning: Skipped {skipped_episodes} season/episode item(s); FlickList lists hold movies and shows only")
+        if skipped_seasons_and_episodes:
+            logger.warning(f"FlickList Warning: Skipped {skipped_seasons_and_episodes} season/episode item(s); FlickList lists hold movies and shows only")
         if self.sync_missing_to_flicklist_list:
             current_ids.extend([({"tmdb": mm}, "movie") for mm in self.missing_movies])
             current_ids.extend([({"tvdb": ms}, "show") for ms in self.missing_shows])

--- a/modules/builder.py
+++ b/modules/builder.py
@@ -661,6 +661,7 @@ parts_collection_valid = (
         "item_analyze",
         "sync_to_trakt_list",
         "sync_to_mdb_list",
+        "sync_to_flicklist_list",
     ]
     + episode_parts_only
     + summary_details
@@ -1188,6 +1189,8 @@ class CollectionBuilder:
         self.mdb_list_arr_ids = None
         self.mdb_list_arr_removal_types = set()
         self.sync_missing_to_trakt_list = False
+        self.sync_to_flicklist_list = None
+        self.sync_missing_to_flicklist_list = False
         self.collection_poster = None
         self.collection_background = None
         self.collection_logo = None
@@ -1685,7 +1688,10 @@ class CollectionBuilder:
                     self._trakt(method_name, method_data)
                 elif method_name in yamtrack.builders:
                     self._yamtrack(method_name, method_data)
-                elif method_name in flicklist.builders:
+                elif method_name in flicklist.builders or method_name in [
+                    "sync_to_flicklist_list",
+                    "sync_missing_to_flicklist_list",
+                ]:
                     self._flicklist(method_name, method_data)
                 elif method_name in serializd.builders:
                     self._serializd(method_name, method_data)
@@ -3614,6 +3620,12 @@ class CollectionBuilder:
             self.builders.append((method_name, self.config.FlickList.validate_up_next(self.Type, method_data)))
         elif method_name == "flicklist_ratings":
             self.builders.append((method_name, self.config.FlickList.validate_ratings(self.Type, method_data)))
+        elif method_name == "sync_to_flicklist_list":
+            if isinstance(method_data, dict) or not str(method_data).strip():
+                raise BuilderValidationError(f"{self.Type} Error: sync_to_flicklist_list requires a list id or name")
+            self.sync_to_flicklist_list = method_data
+        elif method_name == "sync_missing_to_flicklist_list":
+            self.sync_missing_to_flicklist_list = util.parse(self.Type, method_name, method_data, datatype="bool", default=False)
 
     def _serializd(self, method_name, method_data):
         if self.config.Serializd is None:
@@ -5724,6 +5736,35 @@ class CollectionBuilder:
             current_ids.extend([(mm, "tmdb") for mm in self.missing_movies])
             current_ids.extend([(ms, "tvdb") for ms in self.missing_shows])
         self.config.Trakt.sync_list(self.sync_to_trakt_list, current_ids)
+
+    def sync_flicklist_list(self):
+        logger.info("")
+        logger.separator(f"Syncing {self.name} {self.Type} to FlickList List {self.sync_to_flicklist_list}", space=False, border=False)
+        logger.info("")
+        if self.obj:
+            self.library.item_reload(self.obj)
+        self.load_collection_items()
+        current_ids = []
+        skipped_episodes = 0
+        for item in self.items:
+            for pl_library in self.libraries:
+                new_id = None
+                if isinstance(item, Movie) and item.ratingKey in pl_library.movie_rating_key_map:
+                    new_id = ({"tmdb": pl_library.movie_rating_key_map[item.ratingKey]}, "movie")
+                elif isinstance(item, Show) and item.ratingKey in pl_library.show_rating_key_map:
+                    new_id = ({"tvdb": pl_library.show_rating_key_map[item.ratingKey]}, "show")
+                elif isinstance(item, (Season, Episode)):
+                    skipped_episodes += 1
+                    break
+                if new_id:
+                    current_ids.append(new_id)
+                    break
+        if skipped_episodes:
+            logger.warning(f"FlickList Warning: Skipped {skipped_episodes} season/episode item(s); FlickList lists hold movies and shows only")
+        if self.sync_missing_to_flicklist_list:
+            current_ids.extend([({"tmdb": mm}, "movie") for mm in self.missing_movies])
+            current_ids.extend([({"tvdb": ms}, "show") for ms in self.missing_shows])
+        self.config.FlickList.sync_list(self.config.Convert, self.sync_to_flicklist_list, current_ids)
 
     def sync_mdb_list(self):
         if not self.sync_to_mdb_list:

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -76,12 +76,9 @@ class FlickList:
             except (TypeError, ValueError):
                 wait_seconds = 60.0
             if wait_seconds > max_retry_after_seconds:
-                # FlickList's own 1000/hr limit means a legitimate Retry-After can be up to an hour (see Â§6);
+                # FlickList's own 1,000/hr limit (documented in docs/config/flicklist.md) means a legitimate Retry-After can be up to an hour;
                 # sleeping the run for that long is worse than failing fast and letting the next scheduled run pick it up.
-                raise Failed(
-                    f"FlickList Error: Rate limited on {path}; server asked us to wait {wait_seconds:.0f} seconds "
-                    f"(over the {max_retry_after_seconds:.0f}s cap) - giving up for now rather than blocking the run"
-                )
+                raise Failed(f"FlickList Error: Rate limited on {path}; server asked us to wait {wait_seconds:.0f} seconds (over the {max_retry_after_seconds:.0f}s cap) - giving up for now rather than blocking the run")
             if logger:
                 logger.warning(f"FlickList Warning: Rate limited on {path}; waiting {wait_seconds} seconds")
             time.sleep(wait_seconds)
@@ -466,7 +463,7 @@ class FlickList:
         appear anywhere in the desired universe; the moment it shares even one id with some
         desired item, it's treated as still wanted, even if that wasn't the id either side would
         have picked as "primary" under the old single-key design. This keeps the conservative-on-
-        delete guarantee from Â§8.2 (a stale entry is cheap, a wrongly deleted one is not) while
+        delete guarantee (a stale entry is cheap, a wrongly deleted one is not) while
         actually covering the cases that fell through it: an unresolved tvdb->tmdb conversion on
         the desired side, and a current item keyed on fldb+imdb with no tmdb/tvdb at all.
         """
@@ -483,7 +480,7 @@ class FlickList:
                 continue
             desired.append((keys, ids_block, media_type))
             desired_keys |= keys
-
+        delete guarantee (a stale entry is cheap, a wrongly deleted one is not) while
         current = []
         current_keys = set()
         unmatched = 0

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -480,7 +480,6 @@ class FlickList:
                 continue
             desired.append((keys, ids_block, media_type))
             desired_keys |= keys
-        delete guarantee (a stale entry is cheap, a wrongly deleted one is not) while
         current = []
         current_keys = set()
         unmatched = 0

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -8,6 +8,7 @@ logger = util.logger
 
 base_url = "https://flicklist.tv/api/v3"
 sync_batch_size = 1000
+max_retry_after_seconds = 120.0
 builders = [
     "flicklist_list",
     "flicklist_list_details",
@@ -74,6 +75,13 @@ class FlickList:
                 wait_seconds = float(retry_after)
             except (TypeError, ValueError):
                 wait_seconds = 60.0
+            if wait_seconds > max_retry_after_seconds:
+                # FlickList's own 1000/hr limit means a legitimate Retry-After can be up to an hour (see Â§6);
+                # sleeping the run for that long is worse than failing fast and letting the next scheduled run pick it up.
+                raise Failed(
+                    f"FlickList Error: Rate limited on {path}; server asked us to wait {wait_seconds:.0f} seconds "
+                    f"(over the {max_retry_after_seconds:.0f}s cap) - giving up for now rather than blocking the run"
+                )
             if logger:
                 logger.warning(f"FlickList Warning: Rate limited on {path}; waiting {wait_seconds} seconds")
             time.sleep(wait_seconds)
@@ -388,30 +396,40 @@ class FlickList:
         return new_id, True
 
     @staticmethod
-    def _comparison_key(ids_block, media_type, convert):
-        """Best available identity for diffing: tmdb (native or Convert-resolved) first, then fldb, then imdb, then tvdb.
-        Returns None only when the ids block carries nothing usable at all."""
+    def _candidate_keys(ids_block, media_type, convert):
+        """Every identifier this item could plausibly be matched on, not just one 'best' key.
+        The old design picked a single best key per side (tmdb first, then fldb, then imdb, then
+        tvdb) and compared those. That breaks whenever the two sides expose different id types for
+        the same title - e.g. a desired show whose tvdb->tmdb Convert lookup misses this run (rate
+        limited or not yet cached) falls back to a bare tvdb key, while the matching FlickList item
+        already carries a native tmdb id and never even looks at its own tvdb value under the old
+        priority order. Two keys for the same title that never intersect reads as "not present",
+        so the real item gets deleted and a duplicate gets added in its place. Returning the full
+        set of candidates and matching on intersection means any single shared id is enough to
+        recognize the same item on both sides, regardless of which id each side happened to key on.
+        Returns an empty set only when the ids block carries nothing usable at all."""
+        keys = set()
         tmdb_id = ids_block.get("tmdb")
         if tmdb_id is not None:
-            return media_type, "tmdb", int(tmdb_id)
+            keys.add((media_type, "tmdb", int(tmdb_id)))
         tvdb_id = ids_block.get("tvdb")
-        if tvdb_id is not None and media_type == "show" and convert is not None:
-            resolved = convert.tvdb_to_tmdb(tvdb_id)
-            if resolved is not None:
-                return media_type, "tmdb", int(resolved)
-        fldb_id = ids_block.get("fldb")
-        if fldb_id is not None:
-            return media_type, "fldb", fldb_id
+        if tvdb_id is not None:
+            keys.add((media_type, "tvdb", tvdb_id))
+            if media_type == "show" and convert is not None:
+                resolved = convert.tvdb_to_tmdb(tvdb_id)
+                if resolved is not None:
+                    keys.add((media_type, "tmdb", int(resolved)))
         imdb_id = ids_block.get("imdb")
         if imdb_id is not None:
+            keys.add((media_type, "imdb", imdb_id))
             if convert is not None:
                 resolved, resolved_type = convert.imdb_to_tmdb(imdb_id)
                 if resolved is not None and (resolved_type or media_type) == media_type:
-                    return media_type, "tmdb", int(resolved)
-            return media_type, "imdb", imdb_id
-        if tvdb_id is not None:
-            return media_type, "tvdb", tvdb_id
-        return None
+                    keys.add((media_type, "tmdb", int(resolved)))
+        fldb_id = ids_block.get("fldb")
+        if fldb_id is not None:
+            keys.add((media_type, "fldb", fldb_id))
+        return keys
 
     @staticmethod
     def _media_type_of(item):
@@ -433,38 +451,56 @@ class FlickList:
             if existing_items and logger:
                 logger.debug(f"FlickList List: {len(existing_items)} item(s) in this batch were already present: {existing_items}")
             if not_found_items and logger:
-                logger.error(f"FlickList Error: {len(not_found_items)} item(s) not found while syncing: {not_found_items}")
+                shown, remaining = not_found_items[:20], len(not_found_items) - 20
+                suffix = f" (+{remaining} more)" if remaining > 0 else ""
+                logger.error(f"FlickList Error: {len(not_found_items)} item(s) not found while syncing: {shown}{suffix}")
         if logger:
             verb = "add" if action == "add" else "remove"
             logger.info(f"FlickList List: submitted {len(payloads)} item(s) to {verb} ({not_found_total} not found)")
 
     def sync_list(self, convert, list_id_or_name, ids):
-        """ids: iterable of (ids_block, media_type) pairs, e.g. ({"tmdb": 550}, "movie")."""
+        """ids: iterable of (ids_block, media_type) pairs, e.g. ({"tmdb": 550}, "movie").
+
+        Matching is by candidate-key-set intersection, not a single best key per item (see
+        _candidate_keys). A current item is only ever removed when NONE of its candidate keys
+        appear anywhere in the desired universe; the moment it shares even one id with some
+        desired item, it's treated as still wanted, even if that wasn't the id either side would
+        have picked as "primary" under the old single-key design. This keeps the conservative-on-
+        delete guarantee from Â§8.2 (a stale entry is cheap, a wrongly deleted one is not) while
+        actually covering the cases that fell through it: an unresolved tvdb->tmdb conversion on
+        the desired side, and a current item keyed on fldb+imdb with no tmdb/tvdb at all.
+        """
         list_id, created = self._resolve_list(list_id_or_name)
         if created and logger:
             logger.info(f"FlickList List '{list_id_or_name}' not found; created a new list (id {list_id})")
         current_items = self._request_paginated(f"/sync/lists/{list_id}/items") or []
+
         desired = []
+        desired_keys = set()
         for ids_block, media_type in ids:
-            key = self._comparison_key(ids_block, media_type, convert)
-            if key is None:
+            keys = self._candidate_keys(ids_block, media_type, convert)
+            if not keys:
                 continue
-            desired.append((key, ids_block, media_type))
-        desired_keys = {key for key, _, _ in desired}
-        current_by_key = {}
+            desired.append((keys, ids_block, media_type))
+            desired_keys |= keys
+
+        current = []
+        current_keys = set()
         unmatched = 0
         for item in current_items:
             item_ids = item.get("ids") or {}
             media_type = self._media_type_of(item)
-            key = self._comparison_key(item_ids, media_type, convert)
-            if key is None:
+            keys = self._candidate_keys(item_ids, media_type, convert)
+            if not keys:
                 unmatched += 1
                 continue
-            current_by_key[key] = (item_ids, media_type)
+            current.append((keys, item_ids, media_type))
+            current_keys |= keys
         if unmatched and logger:
-            logger.warning(f"FlickList Warning: {unmatched} existing list item(s) could not be matched against the desired set; leaving them in place")
-        add_payloads = [{"ids": ids_block, "media_type": media_type} for key, ids_block, media_type in desired if key not in current_by_key]
-        # Never remove an item this run couldn't positively match (see the unmatched count above) - a stale entry is cheap, a wrongly deleted one is not.
-        remove_payloads = [{"ids": item_ids, "media_type": media_type} for key, (item_ids, media_type) in current_by_key.items() if key not in desired_keys]
+            logger.warning(f"FlickList Warning: {unmatched} existing list item(s) had no usable id at all; leaving them in place")
+
+        add_payloads = [{"ids": ids_block, "media_type": media_type} for keys, ids_block, media_type in desired if keys.isdisjoint(current_keys)]
+        # Never remove an item this run couldn't positively rule out (no shared id with the desired universe at all) - a stale entry is cheap, a wrongly deleted one is not.
+        remove_payloads = [{"ids": item_ids, "media_type": media_type} for keys, item_ids, media_type in current if keys.isdisjoint(desired_keys)]
         self._sync_batch(list_id, "add", add_payloads)
         self._sync_batch(list_id, "remove", remove_payloads)

--- a/modules/flicklist.py
+++ b/modules/flicklist.py
@@ -1,11 +1,13 @@
 import time
 
 from modules import util
+from modules.request import DEFAULT_TIMEOUT
 from modules.util import Failed
 
 logger = util.logger
 
 base_url = "https://flicklist.tv/api/v3"
+sync_batch_size = 1000
 builders = [
     "flicklist_list",
     "flicklist_list_details",
@@ -57,6 +59,9 @@ class FlickList:
         while True:
             if method == "POST":
                 response = self.requests.post(url, json=json_data, headers=headers)
+            elif method == "DELETE":
+                # No Requests.delete() wrapper exists yet; the raw session skips the tenacity retry get()/post() carry, but the 429 loop below still applies.
+                response = self.requests.session.delete(url, json=json_data, headers=headers, timeout=DEFAULT_TIMEOUT)
             else:
                 response = self.requests.get(url, headers=headers, params=params)
             if response.status_code != 429:
@@ -356,3 +361,110 @@ class FlickList:
             self._log_info(f"Processing {pretty}")
             return self._parse_ids(self._request_list("/sync/tracked"), is_movie=False)
         raise Failed(f"FlickList Error: Method {method} not supported")
+
+    def _resolve_list(self, list_id_or_name):
+        """Returns (list_id, created). Matches an existing list by numeric id or exact name; creates one if no match."""
+        as_id = None
+        if isinstance(list_id_or_name, int) and not isinstance(list_id_or_name, bool):
+            as_id = list_id_or_name
+        else:
+            text = str(list_id_or_name).strip()
+            if text.isdigit():
+                as_id = int(text)
+        own_lists = self._request_paginated("/sync/lists") or []
+        if as_id is not None:
+            for entry in own_lists:
+                if entry.get("id") == as_id:
+                    return as_id, False
+            raise Failed(f"FlickList Error: List id {as_id} not found among your own lists")
+        name = str(list_id_or_name).strip()
+        for entry in own_lists:
+            if str(entry.get("name") or "").strip() == name:
+                return entry.get("id"), False
+        created = self._request("/sync/lists", json_data={"name": name, "privacy": "private"}, method="POST")
+        new_id = created.get("id") if created else None
+        if new_id is None:
+            raise Failed(f"FlickList Error: Could not create list '{name}'")
+        return new_id, True
+
+    @staticmethod
+    def _comparison_key(ids_block, media_type, convert):
+        """Best available identity for diffing: tmdb (native or Convert-resolved) first, then fldb, then imdb, then tvdb.
+        Returns None only when the ids block carries nothing usable at all."""
+        tmdb_id = ids_block.get("tmdb")
+        if tmdb_id is not None:
+            return media_type, "tmdb", int(tmdb_id)
+        tvdb_id = ids_block.get("tvdb")
+        if tvdb_id is not None and media_type == "show" and convert is not None:
+            resolved = convert.tvdb_to_tmdb(tvdb_id)
+            if resolved is not None:
+                return media_type, "tmdb", int(resolved)
+        fldb_id = ids_block.get("fldb")
+        if fldb_id is not None:
+            return media_type, "fldb", fldb_id
+        imdb_id = ids_block.get("imdb")
+        if imdb_id is not None:
+            if convert is not None:
+                resolved, resolved_type = convert.imdb_to_tmdb(imdb_id)
+                if resolved is not None and (resolved_type or media_type) == media_type:
+                    return media_type, "tmdb", int(resolved)
+            return media_type, "imdb", imdb_id
+        if tvdb_id is not None:
+            return media_type, "tvdb", tvdb_id
+        return None
+
+    @staticmethod
+    def _media_type_of(item):
+        raw = str(item.get("media_type") or "").lower()
+        return "show" if raw in ("tv", "show") else "movie"
+
+    def _sync_batch(self, list_id, action, payloads):
+        if not payloads:
+            return
+        method = "POST" if action == "add" else "DELETE"
+        not_found_total = 0
+        for start in range(0, len(payloads), sync_batch_size):
+            chunk = payloads[start : start + sync_batch_size]
+            results = self._request(f"/sync/lists/{list_id}/items", json_data={"items": chunk}, method=method) or {}
+            existing_items = results.get("existing") or []
+            not_found_items = results.get("not_found") or []
+            not_found_total += len(not_found_items)
+            # `added`/`removed` counts from the API are not reliable net-new/net-removed totals (duplicate submissions in one batch double-count) - the batch size below is the trustworthy number.
+            if existing_items and logger:
+                logger.debug(f"FlickList List: {len(existing_items)} item(s) in this batch were already present: {existing_items}")
+            if not_found_items and logger:
+                logger.error(f"FlickList Error: {len(not_found_items)} item(s) not found while syncing: {not_found_items}")
+        if logger:
+            verb = "add" if action == "add" else "remove"
+            logger.info(f"FlickList List: submitted {len(payloads)} item(s) to {verb} ({not_found_total} not found)")
+
+    def sync_list(self, convert, list_id_or_name, ids):
+        """ids: iterable of (ids_block, media_type) pairs, e.g. ({"tmdb": 550}, "movie")."""
+        list_id, created = self._resolve_list(list_id_or_name)
+        if created and logger:
+            logger.info(f"FlickList List '{list_id_or_name}' not found; created a new list (id {list_id})")
+        current_items = self._request_paginated(f"/sync/lists/{list_id}/items") or []
+        desired = []
+        for ids_block, media_type in ids:
+            key = self._comparison_key(ids_block, media_type, convert)
+            if key is None:
+                continue
+            desired.append((key, ids_block, media_type))
+        desired_keys = {key for key, _, _ in desired}
+        current_by_key = {}
+        unmatched = 0
+        for item in current_items:
+            item_ids = item.get("ids") or {}
+            media_type = self._media_type_of(item)
+            key = self._comparison_key(item_ids, media_type, convert)
+            if key is None:
+                unmatched += 1
+                continue
+            current_by_key[key] = (item_ids, media_type)
+        if unmatched and logger:
+            logger.warning(f"FlickList Warning: {unmatched} existing list item(s) could not be matched against the desired set; leaving them in place")
+        add_payloads = [{"ids": ids_block, "media_type": media_type} for key, ids_block, media_type in desired if key not in current_by_key]
+        # Never remove an item this run couldn't positively match (see the unmatched count above) - a stale entry is cheap, a wrongly deleted one is not.
+        remove_payloads = [{"ids": item_ids, "media_type": media_type} for key, (item_ids, media_type) in current_by_key.items() if key not in desired_keys]
+        self._sync_batch(list_id, "add", add_payloads)
+        self._sync_batch(list_id, "remove", remove_payloads)

--- a/tests/test_flicklist.py
+++ b/tests/test_flicklist.py
@@ -136,6 +136,14 @@ def test_429_gives_up_after_three_attempts(mock_sleep):
     assert len(flicklist.requests.gets) == 3
 
 
+@patch("time.sleep", return_value=None)
+def test_429_with_retry_after_over_cap_fails_fast_instead_of_sleeping(mock_sleep):
+    flicklist = make_flicklist([FakeResponse(status_code=429, headers={"Retry-After": "3600"}, json_data={"error": "rate_limited"})])
+    with pytest.raises(Failed, match="over the 120s cap"):
+        flicklist._request("/me")
+    mock_sleep.assert_not_called()
+
+
 def test_paginated_read_follows_page_count_header():
     flicklist = make_flicklist(
         [
@@ -364,44 +372,46 @@ def test_flicklist_watched_playlist_mode_returns_both_movies_and_shows():
 # --- Layer 2: sync_to_flicklist_list ---
 
 
-def test_comparison_key_native_tmdb():
+def test_candidate_keys_native_tmdb():
     flicklist = make_flicklist([])
-    assert flicklist._comparison_key({"tmdb": 550}, "movie", FakeConvert()) == ("movie", "tmdb", 550)
+    assert flicklist._candidate_keys({"tmdb": 550}, "movie", FakeConvert()) == {("movie", "tmdb", 550)}
 
 
-def test_comparison_key_tvdb_resolves_to_tmdb_via_convert():
+def test_candidate_keys_tvdb_resolves_to_tmdb_via_convert_but_keeps_raw_tvdb_too():
     flicklist = make_flicklist([])
     convert = FakeConvert(tvdb_to_tmdb_map={81189: 1396})
-    assert flicklist._comparison_key({"tvdb": 81189}, "show", convert) == ("show", "tmdb", 1396)
+    keys = flicklist._candidate_keys({"tvdb": 81189}, "show", convert)
+    assert keys == {("show", "tmdb", 1396), ("show", "tvdb", 81189)}
 
 
-def test_comparison_key_tvdb_unresolved_falls_back_to_tvdb():
+def test_candidate_keys_tvdb_unresolved_falls_back_to_tvdb_only():
     flicklist = make_flicklist([])
-    assert flicklist._comparison_key({"tvdb": 81189}, "show", FakeConvert()) == ("show", "tvdb", 81189)
+    assert flicklist._candidate_keys({"tvdb": 81189}, "show", FakeConvert()) == {("show", "tvdb", 81189)}
 
 
-def test_comparison_key_prefers_fldb_over_imdb_when_no_tmdb():
+def test_candidate_keys_includes_both_fldb_and_imdb_when_no_tmdb():
     flicklist = make_flicklist([])
-    key = flicklist._comparison_key({"fldb": "flt_abc", "imdb": "tt0903747"}, "show", FakeConvert())
-    assert key == ("show", "fldb", "flt_abc")
+    keys = flicklist._candidate_keys({"fldb": "flt_abc", "imdb": "tt0903747"}, "show", FakeConvert())
+    assert keys == {("show", "fldb", "flt_abc"), ("show", "imdb", "tt0903747")}
 
 
-def test_comparison_key_imdb_resolves_to_tmdb_via_convert():
+def test_candidate_keys_imdb_resolves_to_tmdb_via_convert_but_keeps_raw_imdb_too():
     flicklist = make_flicklist([])
     convert = FakeConvert(imdb_to_tmdb_map={"tt0903747": (1396, "show")})
-    assert flicklist._comparison_key({"imdb": "tt0903747"}, "show", convert) == ("show", "tmdb", 1396)
+    keys = flicklist._candidate_keys({"imdb": "tt0903747"}, "show", convert)
+    assert keys == {("show", "tmdb", 1396), ("show", "imdb", "tt0903747")}
 
 
-def test_comparison_key_imdb_resolves_wrong_media_type_is_ignored():
+def test_candidate_keys_imdb_resolves_wrong_media_type_is_ignored():
     flicklist = make_flicklist([])
     convert = FakeConvert(imdb_to_tmdb_map={"tt0903747": (1396, "movie")})
-    key = flicklist._comparison_key({"imdb": "tt0903747"}, "show", convert)
-    assert key == ("show", "imdb", "tt0903747")
+    keys = flicklist._candidate_keys({"imdb": "tt0903747"}, "show", convert)
+    assert keys == {("show", "imdb", "tt0903747")}
 
 
-def test_comparison_key_none_when_no_ids_at_all():
+def test_candidate_keys_empty_set_when_no_ids_at_all():
     flicklist = make_flicklist([])
-    assert flicklist._comparison_key({}, "movie", FakeConvert()) is None
+    assert flicklist._candidate_keys({}, "movie", FakeConvert()) == set()
 
 
 def test_resolve_list_matches_by_numeric_id():
@@ -472,6 +482,49 @@ def test_sync_list_chunks_batches_at_1000_items():
     assert len(flicklist.requests.posts) == 2
     assert len(flicklist.requests.posts[0][1]["items"]) == 1000
     assert len(flicklist.requests.posts[1][1]["items"]) == 500
+
+
+def test_sync_list_unresolved_tvdb_conversion_does_not_delete_the_matching_tmdb_item():
+    # Desired show only carries tvdb (Convert misses this run - rate limited/not cached - so it
+    # can't resolve to tmdb, and falls back to a bare tvdb key). The existing FlickList item for
+    # the same show carries both a native tmdb id AND that same tvdb id. Under the old single-best-
+    # key design, the current item's key was tmdb (checked first) and never even looked at its own
+    # tvdb value, so it never matched the desired item's tvdb-only key - the real item got deleted
+    # and a duplicate got added under tvdb. Candidate-key-set matching includes tvdb as one of the
+    # current item's candidates alongside tmdb, so the shared tvdb id keeps them linked.
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[{"id": 4821, "name": "My List"}], headers={}),  # _resolve_list
+            FakeResponse(json_data=[{"ids": {"tmdb": 1396, "tvdb": 81189}, "media_type": "show"}], headers={}),  # current items
+            FakeResponse(json_data={"existing": [], "not_found": []}),  # add batch (should be empty)
+            FakeResponse(json_data={"not_found": []}),  # remove batch (should be empty)
+        ]
+    )
+    ids = [({"tvdb": 81189}, "show")]  # Convert unavailable/misses -> FakeConvert() has no tvdb_to_tmdb_map entry
+    flicklist.sync_list(FakeConvert(), 4821, ids)
+    assert flicklist.requests.posts == []
+    assert flicklist.requests.deletes == []
+
+
+def test_sync_list_current_item_with_only_fldb_and_imdb_matches_desired_tmdb_via_convert():
+    # A current FlickList item may carry only fldb (its own internal id) plus imdb, with no tmdb or
+    # tvdb at all. The desired side (from Kometa/TMDb) only has tmdb. Under the old design the
+    # current item's single best key was fldb (checked before imdb), which never gets compared
+    # against imdb/tmdb at all, so it always looked unmatched and got deleted every run. Candidate
+    # keys must include the Convert-resolved tmdb from its imdb id so the two sides still connect.
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[{"id": 4821, "name": "My List"}], headers={}),  # _resolve_list
+            FakeResponse(json_data=[{"ids": {"fldb": "flt_abc", "imdb": "tt0903747"}, "media_type": "movie"}], headers={}),  # current items
+            FakeResponse(json_data={"existing": [], "not_found": []}),  # add batch (should be empty)
+            FakeResponse(json_data={"not_found": []}),  # remove batch (should be empty)
+        ]
+    )
+    convert = FakeConvert(imdb_to_tmdb_map={"tt0903747": (550, "movie")})
+    ids = [({"tmdb": 550}, "movie")]
+    flicklist.sync_list(convert, 4821, ids)
+    assert flicklist.requests.posts == []
+    assert flicklist.requests.deletes == []
 
 
 def test_sync_list_logs_not_found_but_does_not_raise():

--- a/tests/test_flicklist.py
+++ b/tests/test_flicklist.py
@@ -22,12 +22,23 @@ class FakeResponse:
         return self._json_data
 
 
+class FakeSession:
+    def __init__(self, parent):
+        self._parent = parent
+
+    def delete(self, url, json=None, headers=None, timeout=None):
+        self._parent.deletes.append((url, json, headers))
+        return self._parent._responses.pop(0)
+
+
 class FakeRequests:
     def __init__(self, responses):
         self.local = "2.4.8-build5"
         self._responses = list(responses)
         self.gets = []
         self.posts = []
+        self.deletes = []
+        self.session = FakeSession(self)
 
     def get(self, url, headers=None, params=None):
         self.gets.append((url, headers, params))
@@ -36,6 +47,20 @@ class FakeRequests:
     def post(self, url, json=None, headers=None):
         self.posts.append((url, json, headers))
         return self._responses.pop(0)
+
+
+class FakeConvert:
+    """Stand-in for modules.convert.Convert, controllable per test."""
+
+    def __init__(self, tvdb_to_tmdb_map=None, imdb_to_tmdb_map=None):
+        self._tvdb_to_tmdb_map = tvdb_to_tmdb_map or {}
+        self._imdb_to_tmdb_map = imdb_to_tmdb_map or {}
+
+    def tvdb_to_tmdb(self, tvdb_id, fail=False):
+        return self._tvdb_to_tmdb_map.get(tvdb_id)
+
+    def imdb_to_tmdb(self, imdb_id, fail=False):
+        return self._imdb_to_tmdb_map.get(imdb_id, (None, None))
 
 
 def make_flicklist(responses, read_only=False):
@@ -271,6 +296,8 @@ def test_validate_ratings_accepts_blank_number_and_dict():
 
 # --- flicklist_watched: WatchedMovie/WatchedShow carry no top-level media_type (WatchedShow also
 # nests its `ids` under a `show` object), unlike every other personal endpoint this integration
+# reads. _parse_ids classifies purely off `media_type`, so without normalizing these two # --- flicklist_watched: WatchedMovie/WatchedShow carry no top-level media_type (WatchedShow also
+# nests its `ids` under a `show` object), unlike every other personal endpoint this integration
 # reads. _parse_ids classifies purely off `media_type`, so without normalizing these two shapes
 # first, every watched item is silently dropped regardless of real watch history - these fixtures
 # use the real nested/flat shapes from the live OpenAPI spec, not a flattened stand-in that would
@@ -332,3 +359,128 @@ def test_flicklist_watched_playlist_mode_returns_both_movies_and_shows():
         ]
     )
     assert flicklist.get_flicklist_ids("flicklist_watched", None, is_movie=None) == [(550, "tmdb"), (1396, "tmdb_show")]
+
+
+# --- Layer 2: sync_to_flicklist_list ---
+
+
+def test_comparison_key_native_tmdb():
+    flicklist = make_flicklist([])
+    assert flicklist._comparison_key({"tmdb": 550}, "movie", FakeConvert()) == ("movie", "tmdb", 550)
+
+
+def test_comparison_key_tvdb_resolves_to_tmdb_via_convert():
+    flicklist = make_flicklist([])
+    convert = FakeConvert(tvdb_to_tmdb_map={81189: 1396})
+    assert flicklist._comparison_key({"tvdb": 81189}, "show", convert) == ("show", "tmdb", 1396)
+
+
+def test_comparison_key_tvdb_unresolved_falls_back_to_tvdb():
+    flicklist = make_flicklist([])
+    assert flicklist._comparison_key({"tvdb": 81189}, "show", FakeConvert()) == ("show", "tvdb", 81189)
+
+
+def test_comparison_key_prefers_fldb_over_imdb_when_no_tmdb():
+    flicklist = make_flicklist([])
+    key = flicklist._comparison_key({"fldb": "flt_abc", "imdb": "tt0903747"}, "show", FakeConvert())
+    assert key == ("show", "fldb", "flt_abc")
+
+
+def test_comparison_key_imdb_resolves_to_tmdb_via_convert():
+    flicklist = make_flicklist([])
+    convert = FakeConvert(imdb_to_tmdb_map={"tt0903747": (1396, "show")})
+    assert flicklist._comparison_key({"imdb": "tt0903747"}, "show", convert) == ("show", "tmdb", 1396)
+
+
+def test_comparison_key_imdb_resolves_wrong_media_type_is_ignored():
+    flicklist = make_flicklist([])
+    convert = FakeConvert(imdb_to_tmdb_map={"tt0903747": (1396, "movie")})
+    key = flicklist._comparison_key({"imdb": "tt0903747"}, "show", convert)
+    assert key == ("show", "imdb", "tt0903747")
+
+
+def test_comparison_key_none_when_no_ids_at_all():
+    flicklist = make_flicklist([])
+    assert flicklist._comparison_key({}, "movie", FakeConvert()) is None
+
+
+def test_resolve_list_matches_by_numeric_id():
+    flicklist = make_flicklist([FakeResponse(json_data=[{"id": 4821, "name": "Watchlist"}], headers={})])
+    list_id, created = flicklist._resolve_list(4821)
+    assert (list_id, created) == (4821, False)
+
+
+def test_resolve_list_matches_by_exact_name():
+    flicklist = make_flicklist([FakeResponse(json_data=[{"id": 4821, "name": "Recently Added"}], headers={})])
+    list_id, created = flicklist._resolve_list("Recently Added")
+    assert (list_id, created) == (4821, False)
+
+
+def test_resolve_list_creates_when_no_name_match():
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[], headers={}),
+            FakeResponse(json_data={"id": 9310, "name": "New List"}),
+        ]
+    )
+    list_id, created = flicklist._resolve_list("New List")
+    assert (list_id, created) == (9310, True)
+
+
+def test_resolve_list_unknown_id_raises_failed():
+    flicklist = make_flicklist([FakeResponse(json_data=[{"id": 1, "name": "Other"}], headers={})])
+    with pytest.raises(Failed, match="not found among your own lists"):
+        flicklist._resolve_list(4821)
+
+
+def test_sync_list_adds_new_items_and_removes_stale_ones():
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[{"id": 4821, "name": "My List"}], headers={}),  # _resolve_list
+            FakeResponse(json_data=[{"ids": {"tmdb": 999}, "media_type": "movie"}], headers={}),  # current items
+            FakeResponse(json_data={"existing": [], "not_found": []}),  # add batch
+            FakeResponse(json_data={"not_found": []}),  # remove batch
+        ]
+    )
+    ids = [({"tmdb": 550}, "movie")]
+    flicklist.sync_list(FakeConvert(), 4821, ids)
+    add_call = flicklist.requests.posts[0]
+    assert add_call[1] == {"items": [{"ids": {"tmdb": 550}, "media_type": "movie"}]}
+    remove_call = flicklist.requests.deletes[0]
+    assert remove_call[1] == {"items": [{"ids": {"tmdb": 999}, "media_type": "movie"}]}
+
+
+def test_sync_list_leaves_unmatched_current_items_alone():
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[{"id": 4821, "name": "My List"}], headers={}),  # _resolve_list
+            FakeResponse(json_data=[{"ids": {}, "media_type": "movie"}], headers={}),  # current items, no usable id
+            FakeResponse(json_data={"existing": [], "not_found": []}),  # add batch
+        ]
+    )
+    ids = [({"tmdb": 550}, "movie")]
+    flicklist.sync_list(FakeConvert(), 4821, ids)
+    assert len(flicklist.requests.deletes) == 0
+
+
+def test_sync_list_chunks_batches_at_1000_items():
+    current_page = FakeResponse(json_data=[], headers={})
+    add_batches = [FakeResponse(json_data={"existing": [], "not_found": []}) for _ in range(2)]
+    flicklist = make_flicklist([FakeResponse(json_data=[{"id": 4821, "name": "Big List"}], headers={}), current_page] + add_batches)
+    ids = [({"tmdb": i}, "movie") for i in range(1500)]
+    flicklist.sync_list(FakeConvert(), 4821, ids)
+    assert len(flicklist.requests.posts) == 2
+    assert len(flicklist.requests.posts[0][1]["items"]) == 1000
+    assert len(flicklist.requests.posts[1][1]["items"]) == 500
+
+
+def test_sync_list_logs_not_found_but_does_not_raise():
+    flicklist = make_flicklist(
+        [
+            FakeResponse(json_data=[{"id": 4821, "name": "My List"}], headers={}),
+            FakeResponse(json_data=[], headers={}),
+            FakeResponse(json_data={"existing": [], "not_found": [{"ids": {"tmdb": 550}}]}),
+        ]
+    )
+    ids = [({"tmdb": 550}, "movie")]
+    flicklist.sync_list(FakeConvert(), 4821, ids)  # should not raise


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Stacked on #3520. Adds `sync_to_flicklist_list` (mirrors `sync_to_trakt_list`): after a collection builds, its resolved movies/shows are pushed to a FlickList list by id or name (auto-created if the name doesn't match an existing list), with items no longer in the collection removed from the list. `sync_missing_to_flicklist_list` optionally also includes movies/shows the collection wanted but couldn't find in Plex.

Matching between Kometa's desired set and FlickList's current list contents is done by comparing every usable id on each side (tmdb, tvdb, imdb, fldb - FlickList's own tvdb-to-tmdb resolution reuses Kometa's existing `Convert` cache, so this never touches FlickList's own request budget). A list item is only removed when it shares no id at all with anything currently wanted, which is the conservative-on-delete behavior the design calls for.

Writes are batched at 1000 items per FlickList API call, with `Retry-After` honored on 429s and capped so a very long rate-limit window fails the run instead of blocking it for up to an hour.

## Have you updated the Documentation to reflect changes (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [X] Yes
- [ ] No
- [ ] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No