### PR TITLE
Consolidate end-of-run warning and error summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fetch MDBList data in cache-aware batches of up to 100 items, substantially reducing API quota usage for library operations, direct rating overlays, and overlay value filters.
+- Consolidate item-specific IDs, titles, GUIDs, and URLs in end-of-run warning and error tables, and move missing overlay template values into the Overlay Summary.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fetch MDBList data in cache-aware batches of up to 100 items, substantially reducing API quota usage for library operations, direct rating overlays, and overlay value filters.
-- Consolidate item-specific IDs, titles, GUIDs, and URLs in end-of-run warning and error tables, and move missing overlay template values into the Overlay Summary.
+- Consolidate item-specific IDs, titles, GUIDs, and URLs in end-of-run warning and error tables, derive missing-rating groups from active overlay sources, and move missing overlay template values into the Overlay Summary.
 
 ### Added
 

--- a/kometa.py
+++ b/kometa.py
@@ -698,6 +698,7 @@ def start(attrs):
                 ("Overlay Warning: No 'trakt_rating' found", r"Overlay Warning: No 'trakt_rating' found for (.*)"),
                 ("Overlay Warning: No 'trakt_user_rating' found", r"Overlay Warning: No 'trakt_user_rating' found for (.*)"),
                 ("Overlay Warning: No 'user_rating' found", r"Overlay Warning: No 'user_rating' found for (.*)"),
+                ("Overlay Error: No '", r"Overlay Error: No '(<<.+>>.*)' found$"),
                 ("Overlays Attempted on", r"Overlays Attempted on (.*): .+"),
                 ("Convert Warning: No TVDb ID or IMDb ID found for AniDB ID", r"Convert Warning: No TVDb ID or IMDb ID found for AniDB ID '(.*)'"),
                 ("Convert Warning: No AniDB ID Found for AniList ID", r"Convert Warning: No AniDB ID Found for AniList ID '(.*)'"),
@@ -728,6 +729,7 @@ def start(attrs):
                 (r"Asset Warning: No poster or background found in an assets folder for '.+'", "Asset Warning: No poster or background found in an assets folder"),
                 (r"Asset Warning: Unable to find asset folder: '.+'", "Asset Warning: Unable to find asset folder"),
                 (r"Collection Error: No valid Plex Collections in .+", "Collection Error: No valid Plex Collections"),
+                (r"Config Warning: Skipping duplicate collection: .+", "Config Warning: Skipping duplicate collection"),
                 (r"(?:Collection|Playlist) Warning: tvdb_episode:\d+_\d+_\d+ -> .+ Season: \d+ Episode: \d+ Missing", "TVDb Episode Missing"),
                 (r"(?:Collection|Playlist) Warning: tvdb_season:\d+_\d+ -> .+ Season: \d+ Missing", "TVDb Season Missing"),
                 (r"(?:Collection|Playlist) Warning: imdb:tt\d+ -> .+ Season: \d+ Episode: \d+ Missing", "IMDb Episode Missing"),
@@ -741,14 +743,29 @@ def start(attrs):
                 (r".+ Error: No Filter Created", "Error: No Filter Created"),
                 (r"Letterboxd Error: No List Items found in .+", "Letterboxd Error: No List Items found"),
                 (r"Letterboxd Error: TMDb Movie ID not found at .+ item is type .+ with tmdb_id .+\.", "Letterboxd Error: TMDb Movie ID not found"),
+                (
+                    r"Letterboxd Warning: cloudscraper hit a Cloudflare challenge for .+; retrying with curl_cffi\.",
+                    "Letterboxd Warning: Cloudflare challenge; retrying with curl_cffi",
+                ),
+                (
+                    r"Letterboxd Warning: letterboxdpy does not reliably support films page .+; using Kometa fallback parsing\.",
+                    "Letterboxd Warning: Using fallback films-page parsing",
+                ),
                 (r"Letterboxd Warning: TMDb link for .+ is for a TV show, not a movie; ignoring TMDb ID .+ from link\.", "Letterboxd Warning: TMDb link is for a TV show, not a movie"),
+                (
+                    r"MDBList Warning: Batch lookup returned no data for \d+ of \d+ requested [A-Za-z]+ IDs: .+",
+                    "MDBList Warning: Batch lookup returned no data for requested IDs",
+                ),
                 (r"Mojo Error: No List Items found in .+", "Mojo Error: No List Items found"),
+                (r"No MdbItem for .+ \(Guid: .+\)", "MDBList Warning: No item found"),
                 (r"Text File Error: No IDs found at .+", "Text File Error: No IDs found"),
                 (r"Text File Error: No supported IDs found in .+", "Text File Error: No supported IDs found"),
                 (
                     r"TMDb Error: Collection ID \d+ missing on TMDb; add '\d+' to the franchise exclude list if this is auto-built\.",
                     "TMDb Error: Collection ID missing on TMDb; add it to the franchise exclude list if this is auto-built",
                 ),
+                (r"TMDb Error: No Episode found for TMDb ID \d+ Season \d+ Episode \d+: .+", "TMDb Error: No Episode found for TMDb ID"),
+                (r"TMDb Error: No Movie found for TMDb ID:? \d+(?:: .+)?", "TMDb Error: No Movie found for TMDb ID"),
                 (r"TMDb Error: No valid TMDb IDs in .+", "TMDb Error: No valid TMDb IDs"),
                 (r"Trakt Error: No TVDb ID found for .+", "Trakt Error: No TVDb ID found"),
                 (r"Trakt Error: No valid Trakt Lists in .+", "Trakt Error: No valid Trakt Lists"),
@@ -778,8 +795,9 @@ def start(attrs):
                                     other = True
                                     _name = match.group(1)
                                     if key not in other_message:
-                                        other_message[key] = {"list": [], "count": 0}
+                                        other_message[key] = {"list": [], "count": 0, "name_counts": Counter()}
                                     other_message[key]["count"] += 1
+                                    other_message[key]["name_counts"][_name] += 1
                                     if _name not in other_message[key]["list"]:
                                         other_message[key]["list"].append(_name)
                             if other is False:
@@ -802,13 +820,17 @@ def start(attrs):
             overlay_title = False
             details = run_args["trace"] or run_args["log-requests"]
             for key, _ in other_log_groups:
-                if (key == "No Items found for" or key.startswith("Overlay Warning") or key == "Overlays Attempted on") and key in other_message:
+                if (key == "No Items found for" or key.startswith(("Overlay Warning", "Overlay Error")) or key == "Overlays Attempted on") and key in other_message:
                     if overlay_title is False:
                         logger.separator("Overlay Summary", space=False, border=False)
                         logger.info("")
                         logger.info("Count | Message")
                         logger.separator(f"{logger.separating_character * 5}|", space=False, border=False, side_space=False, left=True)
                         overlay_title = True
+                    if key == "Overlay Error: No '":
+                        for template_value, count in other_message[key]["name_counts"].most_common():
+                            logger.info(f"{count:>5} | Overlay Warning: No '{template_value}' found")
+                        continue
                     overlay_count = other_message[key]["count"]
                     overlay_line = "No Items found" if key == "No Items found for" else key
                     if details:

--- a/kometa.py
+++ b/kometa.py
@@ -280,6 +280,7 @@ timings.registry.enabled = run_args["timings"]
 
 from modules.builder import CollectionBuilder  # noqa: E402
 from modules.config import ConfigFile  # noqa: E402
+from modules.overlay import rating_sources  # noqa: E402
 from modules.request import Requests  # noqa: E402
 from modules.util import BuilderValidationError, Deleted, Failed, FilterFailed, MappingConvertError, NonExisting, NotScheduled, OverlayError, ServiceError  # noqa: E402
 
@@ -667,37 +668,7 @@ def start(attrs):
 
             other_log_groups = [
                 ("No Items found for", r"No Items found for .* \(\d+\) (.*)"),
-                ("Overlay Warning: No 'anidb_average_rating' found", r"Overlay Warning: No 'anidb_average_rating' found for (.*)"),
-                ("Overlay Warning: No 'anidb_rating' found", r"Overlay Warning: No 'anidb_rating' found for (.*)"),
-                ("Overlay Warning: No 'anidb_score_rating' found", r"Overlay Warning: No 'anidb_score_rating' found for (.*)"),
-                ("Overlay Warning: No 'audience_rating' found", r"Overlay Warning: No 'audience_rating' found for (.*)"),
-                ("Overlay Warning: No 'critic_rating' found", r"Overlay Warning: No 'critic_rating' found for (.*)"),
-                ("Overlay Warning: No 'imdb_rating' found", r"Overlay Warning: No 'imdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'mal_rating' found", r"Overlay Warning: No 'mal_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_average_rating' found", r"Overlay Warning: No 'mdb_average_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_imdb_rating' found", r"Overlay Warning: No 'mdb_imdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_letterboxd_rating' found", r"Overlay Warning: No 'mdb_letterboxd_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_metacritic_rating' found", r"Overlay Warning: No 'mdb_metacritic_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_metacriticuser_rating' found", r"Overlay Warning: No 'mdb_metacriticuser_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_myanimelist_rating' found", r"Overlay Warning: No 'mdb_myanimelist_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_rating' found", r"Overlay Warning: No 'mdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_tmdb_rating' found", r"Overlay Warning: No 'mdb_tmdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_tomatoesaudience_rating' found", r"Overlay Warning: No 'mdb_tomatoesaudience_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_tomatoes_rating' found", r"Overlay Warning: No 'mdb_tomatoes_rating' found for (.*)"),
-                ("Overlay Warning: No 'mdb_trakt_rating' found", r"Overlay Warning: No 'mdb_trakt_rating' found for (.*)"),
-                ("Overlay Warning: No 'omdb_imdb_rating' found", r"Overlay Warning: No 'omdb_imdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'omdb_metascore_rating' found", r"Overlay Warning: No 'omdb_metascore_rating' found for (.*)"),
-                ("Overlay Warning: No 'omdb_rating' found", r"Overlay Warning: No 'omdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'omdb_tomatoes_rating' found", r"Overlay Warning: No 'omdb_tomatoes_rating' found for (.*)"),
-                ("Overlay Warning: No 'plex_imdb_rating' found", r"Overlay Warning: No 'plex_imdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'plex_tmdb_rating' found", r"Overlay Warning: No 'plex_tmdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'plex_tomatoesaudience_rating' found", r"Overlay Warning: No 'plex_tomatoesaudience_rating' found for (.*)"),
-                ("Overlay Warning: No 'plex_tomatoes_rating' found", r"Overlay Warning: No 'plex_tomatoes_rating' found for (.*)"),
-                ("Overlay Warning: No 'plex_user_rating' found", r"Overlay Warning: No 'plex_user_rating' found for (.*)"),
-                ("Overlay Warning: No 'tmdb_rating' found", r"Overlay Warning: No 'tmdb_rating' found for (.*)"),
-                ("Overlay Warning: No 'trakt_rating' found", r"Overlay Warning: No 'trakt_rating' found for (.*)"),
-                ("Overlay Warning: No 'trakt_user_rating' found", r"Overlay Warning: No 'trakt_user_rating' found for (.*)"),
-                ("Overlay Warning: No 'user_rating' found", r"Overlay Warning: No 'user_rating' found for (.*)"),
+                *[(f"Overlay Warning: No '{rating_source}' found", rf"Overlay Warning: No '{re.escape(rating_source)}' found for (.*)") for rating_source in ["audience_rating", "critic_rating", "user_rating", *rating_sources]],
                 ("Overlay Error: No '", r"Overlay Error: No '(<<.+>>.*)' found$"),
                 ("Overlays Attempted on", r"Overlays Attempted on (.*): .+"),
                 ("Convert Warning: No TVDb ID or IMDb ID found for AniDB ID", r"Convert Warning: No TVDb ID or IMDb ID found for AniDB ID '(.*)'"),
@@ -710,7 +681,6 @@ def start(attrs):
                 ("Convert Warning: No IMDb ID found for TVDb ID", r"Convert Warning: No IMDb ID found for TVDb ID '(.*)'"),
                 ("Convert Warning: No TVDb ID found for IMDb ID", r"Convert Warning: No TVDb ID found for IMDb ID '(.*)'"),
                 ("Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid", r"Convert Warning: No AniDB ID to Convert to MyAnimeList ID for Guid '(.*)'"),
-                ("Convert Warning: No MyAnimeList Found for AniDB ID:", r"Convert Warning: No MyAnimeList Found for AniDB ID: (.*) of Guid: .*"),
                 ("Convert Error: No AniDB ID found for IMDb ID", r"Convert Error: No AniDB ID found for IMDb ID '(.*)'"),
                 ("Convert Error: No AniDB ID found for TVDb ID", r"Convert Error: No AniDB ID found for TVDb ID '(.*)'"),
                 ("Convert Error: No MyAnimeList ID found for AniDB ID", r"Convert Error: No MyAnimeList ID found for AniDB ID '(.*)'"),
@@ -740,7 +710,6 @@ def start(attrs):
                 (r".+ Error: Theme Path Does Not Exist: .+", "Error: Theme Path Does Not Exist"),
                 (r".+ Error: No builders were found", "Error: No builders were found"),
                 (r".+ Error: No Plex Filter Created", "Error: No Plex Filter Created"),
-                (r".+ Error: No Filter Created", "Error: No Filter Created"),
                 (r"Letterboxd Error: No List Items found in .+", "Letterboxd Error: No List Items found"),
                 (r"Letterboxd Error: TMDb Movie ID not found at .+ item is type .+ with tmdb_id .+\.", "Letterboxd Error: TMDb Movie ID not found"),
                 (
@@ -767,7 +736,6 @@ def start(attrs):
                 (r"TMDb Error: No Episode found for TMDb ID \d+ Season \d+ Episode \d+: .+", "TMDb Error: No Episode found for TMDb ID"),
                 (r"TMDb Error: No Movie found for TMDb ID:? \d+(?:: .+)?", "TMDb Error: No Movie found for TMDb ID"),
                 (r"TMDb Error: No valid TMDb IDs in .+", "TMDb Error: No valid TMDb IDs"),
-                (r"Trakt Error: No TVDb ID found for .+", "Trakt Error: No TVDb ID found"),
                 (r"Trakt Error: No valid Trakt Lists in .+", "Trakt Error: No valid Trakt Lists"),
                 (r"TVDb Error: No TVDb IDs found at .+", "TVDb Error: No TVDb IDs found"),
                 (r".*Poster \| No Reset Image Found", "Poster Warning: No Reset Image Found"),

--- a/tests/test_kometa.py
+++ b/tests/test_kometa.py
@@ -31,10 +31,16 @@ def _summary_log_groups() -> list[tuple[str, str]]:
 
 
 def _other_log_groups() -> list[tuple[str, str]]:
-    """Extract the named summary section rules without importing kometa.py."""
+    """Extract literal named summary rules without importing kometa.py."""
     for node in ast.walk(_module_ast()):
         if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "other_log_groups" for target in node.targets):
-            return ast.literal_eval(node.value)
+            groups = []
+            for element in node.value.elts:
+                try:
+                    groups.append(ast.literal_eval(element))
+                except ValueError:
+                    pass  # Rating-source groups are generated dynamically from modules.overlay.
+            return groups
     raise AssertionError("other_log_groups was not found in kometa.py")
 
 
@@ -149,13 +155,40 @@ def test_overlay_summary_uses_warning_labeling() -> None:
     messages for missing ratings.
     """
     text = KOMETA_PY.read_text(encoding="utf-8")
-    assert "(\"Overlay Warning: No 'anidb_average_rating' found\"," in text
+    assert 'for rating_source in ["audience_rating", "critic_rating", "user_rating", *rating_sources]' in text
     assert 'logger.separator("Overlay Summary", space=False, border=False)' in text
     assert 'logger.info("Count | Message")' in text
     assert 'logger.separator("Convert Summary", space=False, border=False)' in text
     assert 'return f"{message} for {source}"' in text
     assert 'r".+ Warning: No Logo Found at .+", "Warning: No Logo Found"' in text
     assert "Plex Error: resolution: No matches found with regex pattern" not in text
+
+
+def test_overlay_summary_groups_follow_current_rating_sources() -> None:
+    """The generated groups must follow active sources instead of a stale manual copy."""
+    overlay_tree = ast.parse((REPO_ROOT / "modules" / "overlay.py").read_text(encoding="utf-8"))
+    sources = None
+    for node in ast.walk(overlay_tree):
+        if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "rating_sources" for target in node.targets):
+            sources = ast.literal_eval(node.value)
+            break
+    assert sources is not None
+    assert "floppy_rating" in sources
+    assert "serializd_rating" in sources
+    assert "plex_user_rating" not in sources
+
+    text = KOMETA_PY.read_text(encoding="utf-8")
+    assert "from modules.overlay import rating_sources" in text
+    assert "re.escape(rating_source)" in text
+    assert "plex_user_rating" not in text
+
+
+def test_stale_summary_rules_are_removed() -> None:
+    """Rules without current emitters should not linger in the summary catalog."""
+    text = KOMETA_PY.read_text(encoding="utf-8")
+    assert "Convert Warning: No MyAnimeList Found for AniDB ID:" not in text
+    assert 'r".+ Error: No Filter Created"' not in text
+    assert "Trakt Error: No TVDb ID found for" not in text
 
 
 def test_overlay_attempts_are_reported_in_overlay_summary() -> None:

--- a/tests/test_kometa.py
+++ b/tests/test_kometa.py
@@ -30,11 +30,26 @@ def _summary_log_groups() -> list[tuple[str, str]]:
     raise AssertionError("summary_log_groups was not found in kometa.py")
 
 
+def _other_log_groups() -> list[tuple[str, str]]:
+    """Extract the named summary section rules without importing kometa.py."""
+    for node in ast.walk(_module_ast()):
+        if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "other_log_groups" for target in node.targets):
+            return ast.literal_eval(node.value)
+    raise AssertionError("other_log_groups was not found in kometa.py")
+
+
 def _summarize_log_message(message: str) -> str:
     for pattern, replacement in _summary_log_groups():
         if re.match(pattern, message):
             return replacement
     return message
+
+
+def _named_log_group(message: str) -> tuple[str, str] | None:
+    for key, pattern in _other_log_groups():
+        if message.startswith(key) and (match := re.match(pattern, message)):
+            return key, match.group(1)
+    return None
 
 
 def test_issue_3244_resource_import_is_guarded() -> None:
@@ -154,6 +169,16 @@ def test_overlay_attempts_are_reported_in_overlay_summary() -> None:
     assert 'key == "Overlays Attempted on"' in text
 
 
+def test_missing_overlay_template_values_are_grouped_by_placeholder() -> None:
+    """Generic text-overlay misses belong in Overlay Summary, grouped by template value."""
+    assert _named_log_group("Overlay Error: No '<<user_rating>>' found") == ("Overlay Error: No '", "<<user_rating>>")
+    assert _named_log_group("Overlay Error: No '<<critic_rating>>' found") == ("Overlay Error: No '", "<<critic_rating>>")
+    text = KOMETA_PY.read_text(encoding="utf-8")
+    assert 'key.startswith(("Overlay Warning", "Overlay Error"))' in text
+    assert 'other_message[key]["name_counts"][_name] += 1' in text
+    assert "Overlay Warning: No '{template_value}' found" in text
+
+
 def test_letterboxd_tmdb_failures_are_summarized() -> None:
     """Regression for repeated Letterboxd per-item TMDb lookup noise.
 
@@ -164,6 +189,22 @@ def test_letterboxd_tmdb_failures_are_summarized() -> None:
     text = KOMETA_PY.read_text(encoding="utf-8")
     assert 'r"Letterboxd Error: TMDb Movie ID not found at .+ item is type .+ with tmdb_id .+\\."' in text
     assert 'r"Letterboxd Warning: TMDb link for .+ is for a TV show, not a movie; ignoring TMDb ID .+ from link\\."' in text
+
+
+def test_dynamic_run_summary_messages_are_consolidated() -> None:
+    """IDs, titles, GUIDs, and URLs from the supplied large log should not create one row each."""
+    cases = {
+        "Config Warning: Skipping duplicate collection: Pusher": "Config Warning: Skipping duplicate collection",
+        "MDBList Warning: Batch lookup returned no data for 6 of 6 requested tmdb IDs: 584729, 586152": "MDBList Warning: Batch lookup returned no data for requested IDs",
+        "No MdbItem for 4k77 DNR (Guid: local://597050)": "MDBList Warning: No item found",
+        "Letterboxd Warning: letterboxdpy does not reliably support films page https://letterboxd.com/user/films/rated/5/; using Kometa fallback parsing.": "Letterboxd Warning: Using fallback films-page parsing",
+        "Letterboxd Warning: cloudscraper hit a Cloudflare challenge for https://letterboxd.com/user/list/example/; retrying with curl_cffi.": "Letterboxd Warning: Cloudflare challenge; retrying with curl_cffi",
+        "TMDb Error: No Movie found for TMDb ID: 1710116": "TMDb Error: No Movie found for TMDb ID",
+        "TMDb Error: No Movie found for TMDb ID 1710116: (404 [Not Found]) Requested Item Not Found": "TMDb Error: No Movie found for TMDb ID",
+        "TMDb Error: No Episode found for TMDb ID 330444 Season 1931 Episode 17: (404 [Not Found]) Requested Item Not Found": "TMDb Error: No Episode found for TMDb ID",
+    }
+    for message, expected in cases.items():
+        assert _summarize_log_message(message) == expected
 
 
 def test_asset_paths_and_warnings_are_summarized() -> None:


### PR DESCRIPTION
## What type of PR is this?

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [X] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

This PR consolidates item-specific warning and error messages in the end-of-run report so dynamic titles, GUIDs, IDs, and URLs do not produce dozens of nearly identical rows.

The detailed messages at their original log locations are unchanged and remain searchable. Only the final summary presentation is normalized.

### Consolidated message families

The changes were derived from replaying a 169,584-line production `meta.log` through the updated grouping rules.

| Current message family | Occurrences | Rows before | Summary after |
| --- | ---: | ---: | --- |
| `No MdbItem for <title> (Guid: <guid>)` | 53 | 52 | `MDBList Warning: No item found` |
| `TMDb Error: No Movie found for TMDb ID: <id>` | 22 | 16 | `TMDb Error: No Movie found for TMDb ID` |
| `TMDb Error: No Episode found for TMDb ID <id> Season <n> Episode <n>...` | 22 | 22 | `TMDb Error: No Episode found for TMDb ID` |
| `Config Warning: Skipping duplicate collection: <name>` | 2 | 2 | `Config Warning: Skipping duplicate collection` |
| Letterboxd fallback-parser URLs | 2 | 2 | `Letterboxd Warning: Using fallback films-page parsing` |
| Letterboxd Cloudflare challenge URLs | 3 | 3 | `Letterboxd Warning: Cloudflare challenge; retrying with curl_cffi` |
| MDBList batch misses with request counts and ID samples | 2 | 2 | `MDBList Warning: Batch lookup returned no data for requested IDs` |

### Summary replay results

| Summary | Rows before | Rows after | Change |
| --- | ---: | ---: | ---: |
| Warning Summary | 78 | 19 | -59 |
| Error Summary | 43 | 7 | -36 |
| Overlay Summary | 2 | 5 | +3 categorized rows |

The Overlay Summary grows intentionally because generic missing template-value messages now appear in their relevant summary instead of the generic Warning Summary.

### Missing overlay template values

The prior report placed these 335 messages in Warning Summary even though they are overlay-specific. They now appear as separate Overlay Summary rows so the affected value remains visible.

| Missing template value | Count |
| --- | ---: |
| `<<user_rating>>` | 172 |
| `<<critic_rating>>` | 160 |
| `<<audience_rating%>>%` | 3 |
| **Total** | **335** |

### Behavior and safety

| Behavior | Result |
| --- | --- |
| Original warning/error at its source location | Unchanged |
| Normal end-of-run report | Dynamic values collapse into stable categories |
| Missing overlay template values | Routed to Overlay Summary and counted per placeholder |
| Trace or request-log detail behavior | Existing detailed-summary behavior remains available |
| User configuration | No changes |
| JSON schemas | No changes |

### Validation

| Check | Result |
| --- | --- |
| Full pytest suite | 1,338 passed |
| Focused summary tests | 13 passed |
| Replay against supplied 169,584-line log | Warning rows 78 → 19; error rows 43 → 7 |
| Black formatting check | Passed |
| `git diff --check` | Passed |

Regression coverage includes representative duplicate-collection, MDBList, Letterboxd, TMDb movie, TMDb episode, and overlay-template messages from the supplied log.

## Related Issues [optional]

- None

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

This changes internal end-of-run summary formatting only; no user-facing configuration or workflow changed.

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

No supported attributes, values, or configuration structures changed.

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790694282&installation_model_id=431096&pr_number=3529&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3529&signature=21ccdb91f3547aff5ddfe9fd552f975a8043fb72634f983a42db3b616ac6c7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->