### PR TITLE
Fix resolution overlay's edition_dovetail wrongly winning over plain edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix the `resolution` Defaults overlay file selecting the `-Dovetail` (resolution-paired) edition overlay instead of the plain one when `use_resolution: false` disables resolution overlays entirely, by no longer building the dovetail edition overlays in that case, and fix a related list-mutation-during-iteration bug in overlay suppress/group resolution that could skip a suppress rule for an overlay later in an item's match list.
 - Fixed `audio_codec` track builder
 - Include collections removed by the `delete_collections` library operation, the `--delete-collections` CLI option, dynamic collection sync, and `delete_collections_named` in the run-end notification total.
 - Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.

--- a/defaults/overlays/resolution.yml
+++ b/defaults/overlays/resolution.yml
@@ -175,15 +175,21 @@ templates:
             value: '(?i)Criterion|\[CC\]'
           - key: openmatte
             value: '(?i)\b(Open[ ._-]?Matte)\b'
+      require_resolution:
+        conditions:
+          - type: edition_dovetail
+            value: <<use_resolution>>
     optional:
       - search
       - use_<<key>>
       - use_edition
+      - use_resolution
       - allowed_libraries
     run_definition:
       - <<use_<<key>>>>
       - <<use_edition>>
       - <<allowed_libraries>>
+      - <<require_resolution>>
     ignore_blank_results: true
     plex_all: true
     filters:

--- a/modules/overlays.py
+++ b/modules/overlays.py
@@ -589,7 +589,7 @@ class Overlays:
 
         for over_key, (item, over_names) in key_to_overlays.items():
             group_status = {}
-            for over_name in over_names:
+            for over_name in list(over_names):
                 for suppress_name in properties[over_name].suppress:
                     if suppress_name in over_names:
                         key_to_overlays[over_key][1].remove(suppress_name)

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -6,9 +6,12 @@ loading logic that can be tested without real Plex/GitHub connections.
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from ruamel.yaml import YAML
 
 import modules.builder  # noqa: F401 — pre-import to break circular deps
 from modules.meta import DataFile
@@ -177,6 +180,45 @@ class TestApplyTemplateNestedVarResolution:
         result = df.apply_template("Test Name", "test_mapping", {}, template_call, {})
 
         assert result["summary"] == "8"
+
+
+class TestResolutionEditionDovetailTemplate:
+    @staticmethod
+    def _apply_edition_template(*, overlay_type, use_resolution=None):
+        resolution_path = Path(__file__).resolve().parents[1] / "defaults" / "overlays" / "resolution.yml"
+        with resolution_path.open(encoding="utf-8") as handle:
+            edition_template = YAML(typ="safe").load(handle)["templates"]["edition"]
+
+        df = make_datafile(
+            data_type="Overlay",
+            library=SimpleNamespace(type="Movie", name="Movies"),
+            templates={"edition": (edition_template, {})},
+        )
+        variables = {
+            "name": "edition",
+            "key": "imax",
+            "search": "IMAX",
+            "type": overlay_type,
+            "allowed_libraries": "movie",
+        }
+        if use_resolution is not None:
+            variables["use_resolution"] = use_resolution
+
+        return df.apply_template("IMAX", "IMAX", {}, [variables], {})
+
+    @pytest.mark.parametrize(
+        ("use_resolution", "expected"),
+        [(None, ["movie"]), (True, ["movie", True]), (False, ["movie", False])],
+    )
+    def test_dovetail_follows_use_resolution(self, use_resolution, expected):
+        result = self._apply_edition_template(overlay_type="edition_dovetail", use_resolution=use_resolution)
+
+        assert result["run_definition"] == expected
+
+    def test_plain_edition_is_not_disabled_with_resolution(self):
+        result = self._apply_edition_template(overlay_type="edition", use_resolution=False)
+
+        assert result["run_definition"] == ["movie"]
 
 
 # ═══════════════════════════════════════════════════════════════════════

--- a/tests/test_overlays.py
+++ b/tests/test_overlays.py
@@ -77,6 +77,41 @@ class TestGetOverlayItems:
         assert result == []
 
 
+class TestCompileOverlays:
+    def test_suppress_rules_are_not_skipped_after_an_earlier_removal(self, monkeypatch):
+        test_logger = FakeLogger()
+        test_logger.separating_character = "="
+        monkeypatch.setattr("modules.overlays.logger", test_logger)
+        item = SimpleNamespace(ratingKey=1)
+        overlay_names = ["Extended-Dovetail", "IMAX-Dovetail", "Extended", "IMAX"]
+        suppressions = {
+            "Extended-Dovetail": [],
+            "IMAX-Dovetail": [],
+            "Extended": ["Extended-Dovetail"],
+            "IMAX": ["IMAX-Dovetail"],
+        }
+
+        def builder_factory(_config, _overlay_file, name, _data, library, overlay):
+            overlay_object = SimpleNamespace(mapping_name=name, keys=[], suppress=suppressions[name], group=None, weight=0)
+            return SimpleNamespace(
+                overlay=overlay_object,
+                builders=[],
+                found_items=[item],
+                limit=None,
+                display_filters=lambda: None,
+            )
+
+        monkeypatch.setattr("modules.overlays.CollectionBuilder", builder_factory)
+        overlay_file = SimpleNamespace(overlays={name: {} for name in overlay_names})
+        library = MagicMock(overlay_files=[overlay_file])
+        library.get_item_display_title.return_value = "Test Movie"
+        overlays = make_overlays(library=library)
+
+        key_to_overlays, _ = overlays.compile_overlays()
+
+        assert key_to_overlays[item.ratingKey][1] == ["Extended", "IMAX"]
+
+
 class TestScanOverlayBackupExtensions:
     """Covers the listdir-snapshot helper that replaced up to 3 os.path.exists() calls per item
     in run_overlays' per-item loop - see the perf-profiling project's steady-state findings."""


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

With `use_resolution: false` set on the `resolution` Defaults overlay file, an item matching two different editions (e.g. both "Extended Edition" and "IMAX") could end up with the wrong one applied when using `weight_<<key>>` to change the priority of one of them — specifically, boosting one edition's weight above the others caused the `-Dovetail` (resolution-paired) variant of that edition to be applied instead of the plain one.

Two contributing bugs, both in `defaults/overlays/resolution.yml`'s edition/resolution "dovetail" positioning system:

1. **`compile_overlays()`'s suppress-rule loop mutated the list it was iterating.** `over_names` in `modules/overlays.py` is the same list object as `key_to_overlays[over_key][1]`; the loop removed elements from it via `.remove()` while a plain `for over_name in over_names:` was mid-iteration. Removing an earlier element shifts the list left, causing the *next* element's turn in the loop to be skipped. Because `resolution.yml` defines every `*-Dovetail` overlay before its plain counterpart, this reliably dropped a later plain overlay's own suppress rule (which normally removes its `-Dovetail` sibling) whenever an earlier plain overlay's suppression fired first for the same item — letting the `-Dovetail` sibling incorrectly survive into the weight-based group tiebreak. **Fix:** iterate a snapshot (`list(over_names)`) instead of the live list.

2. **The `edition_dovetail` overlays (e.g. `IMAX-Dovetail`) were built even when they could never legitimately be used.** They exist solely to reposition an edition badge alongside a resolution badge; with `use_resolution: false`, no resolution overlay is ever active, so a dovetail variant should never be selected — but it was still being built and queried against Plex every run, and (per bug 1) could still win the group tiebreak. **Fix:** added a `require_resolution` conditional (gated on `type: edition_dovetail`) to the `edition` template's `run_definition`, mirroring how the `resolution` template already gates itself on `use_resolution`, so these overlays aren't built at all when resolution overlays are disabled.

**Verification:** Since this touches a shipped Defaults file and I don't have a live Plex server in this environment, I verified fix #2 with a standalone harness that drives the real `MetadataFile.apply_template()` against the actual `defaults/overlays/resolution.yml` content (no Plex/network needed — it's pure template-variable resolution): `edition_dovetail`'s `run_definition` resolves to `false` only when `use_resolution` is explicitly `false`, is unaffected when unset or `true`, and plain `edition` overlays are unaffected in all three cases. I also traced fix #1 by replicating the exact suppress/group algorithm from `compile_overlays()` against the real weight/suppress/group values for `Extended-Edition`/`IMAX` and their `-Dovetail` counterparts, confirming the buggy live-list version picks `IMAX-Dovetail` while the fixed version picks `IMAX`, matching the reported symptom exactly. I was not able to run a full live overlay pass against a real Plex library, so a maintainer with a test library should confirm end-to-end before merging.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790795607&installation_model_id=431096&pr_number=3540&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3540&signature=909df8afc58a99d17f7a9a736a9fbfd11c6cc6af7be3345fa124d0693dc6b9c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->