### PR TITLE
Validate provider ratings before caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Skip mass metadata rating values above Plex's maximum of 10 instead of sending them to Plex.
+- Skip nonnumeric, non-finite, negative, and above-range provider ratings instead of sending them to Plex or rendering them in rating overlays, and leave invalid provider and overlay values uncached so they remain visible on later runs.
 - Fix CLI arguments (e.g. `--config`) being silently reset to their defaults on Python 3.14, where the `ProcessPoolExecutor` running the actual work now defaults to the `forkserver` multiprocessing start method on Linux instead of `fork`.
 - Fix the `resolution` Defaults overlay file selecting the `-Dovetail` (resolution-paired) edition overlay instead of the plain one when `use_resolution: false` disables resolution overlays entirely, by no longer building the dovetail edition overlays in that case, and fix a related list-mutation-during-iteration bug in overlay suppress/group resolution that could skip a suppress rule for an overlay later in an item's match list.
 - Fixed `audio_codec` track builder

--- a/modules/anidb.py
+++ b/modules/anidb.py
@@ -83,6 +83,7 @@ class AniDBObj:
         self._anidb = anidb
         self.anidb_id = anidb_id
         self._data = data
+        self._invalid_rating_values = []
 
         # def _parse(self, field_name, xpath, is_dict=False):
         #     # Find all elements matching the XPath
@@ -190,6 +191,13 @@ class AniDBObj:
         self.rating = _parse("rating", "//ratings/permanent/text()", is_float=True)
         self.average = _parse("average", "//ratings/temporary/text()", is_float=True)
         self.score = _parse("score", "//ratings/review/text()", is_float=True)
+        for source, xpath in [("rating", "//ratings/permanent/text()"), ("average", "//ratings/temporary/text()"), ("score", "//ratings/review/text()")]:
+            raw_values = [data.get(source)] if isinstance(data, dict) else data.xpath(xpath)
+            if raw_values and not util.is_missing_rating(raw_values[0]) and not util.is_valid_rating(raw_values[0]):
+                self._invalid_rating_values.append((source, raw_values[0]))
+        if logger:
+            for source, value in self._invalid_rating_values:
+                logger.warning(f"AniDB Warning: {source} value {value} is invalid; expected a finite rating from 0 to 10; response will not be cached")
         self.released = _parse("released", "//startdate/text()", is_date=True)
 
         self.tags = _parse("tags", "//anime/tags/tag", is_dict=True)
@@ -207,6 +215,10 @@ class AniDBObj:
                 self.tmdb_id = int(item)
             elif isinstance(item, str):
                 self.tmdb_type = item
+
+    @property
+    def ratings_valid(self):
+        return not self._invalid_rating_values
 
 
 class AniDB:
@@ -406,7 +418,11 @@ class AniDB:
         obj = AniDBObj(self, anidb_id, data_source)
 
         # 4. Update Module Cache
-        if self.cache and not ignore_cache:
+        if not obj.ratings_valid:
+            cache_file = f"config/anidb_cache/anime_{anidb_id}.xml"
+            if os.path.exists(cache_file):
+                os.remove(cache_file)
+        elif self.cache and not ignore_cache:
             self.cache.update_anidb(expired, anidb_id, obj, self.expiration)
         return obj
 

--- a/modules/cache.py
+++ b/modules/cache.py
@@ -13,6 +13,21 @@ logger = util.logger
 SQL_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 
+def _ratings_valid(provider, values, cached=False):
+    invalid = [(field, value, maximum) for field, value, maximum in values if value is not None and not util.is_valid_rating(value, maximum=maximum)]
+    if logger:
+        action = "cached value will be evicted" if cached else "response will not be cached"
+        for field, value, maximum in invalid:
+            logger.warning(f"{provider} Warning: {field} rating value {value} is invalid; expected a finite value from 0 to {maximum}; {action}")
+    return not invalid
+
+
+def _object_ratings_valid(provider, obj, fields):
+    if not getattr(obj, "ratings_valid", True):
+        return False
+    return _ratings_valid(provider, [(field.removesuffix("_rating"), getattr(obj, field, None), maximum) for field, maximum in fields])
+
+
 def sql_identifier(name):
     """Guard for table/column names interpolated into SQL, where ? placeholders can't be used."""
     if not SQL_IDENTIFIER_RE.fullmatch(str(name)):
@@ -563,6 +578,9 @@ class Cache:
                 cursor.execute("SELECT * FROM omdb_data3 WHERE imdb_id = ?", (imdb_id,))
                 row = cursor.fetchone()
                 if row:
+                    if not _ratings_valid("OMDb", [("imdb", row["imdb_rating"], 10), ("metacritic", row["metacritic_rating"], 100)], cached=True):
+                        cursor.execute("DELETE FROM omdb_data3 WHERE imdb_id = ?", (imdb_id,))
+                        return {}, None
                     omdb_dict["imdbID"] = row["imdb_id"] if row["imdb_id"] else None
                     omdb_dict["Title"] = row["title"] if row["title"] else None
                     omdb_dict["Year"] = row["year"] if row["year"] else None
@@ -583,6 +601,8 @@ class Cache:
         return omdb_dict, expired
 
     def update_omdb(self, expired, omdb, expiration):
+        if not _object_ratings_valid("OMDb", omdb, [("imdb_rating", 10), ("metacritic_rating", 100), ("rotten_tomatoes", 100)]):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -620,6 +640,25 @@ class Cache:
                 cursor.execute("SELECT * FROM mdb_data5 WHERE key_id = ?", (key_id,))
                 row = cursor.fetchone()
                 if row:
+                    if not _ratings_valid(
+                        "MDBList",
+                        [
+                            ("score", row["score"], 100),
+                            ("average", row["average"], 100),
+                            ("imdb", row["imdb_rating"], 10),
+                            ("metacritic", row["metacritic_rating"], 100),
+                            ("metacriticuser", row["metacriticuser_rating"], 10),
+                            ("trakt", row["trakt_rating"], 100),
+                            ("tomatoes", row["tomatoes_rating"], 100),
+                            ("tomatoesaudience", row["tomatoesaudience_rating"], 100),
+                            ("tmdb", row["tmdb_rating"], 100),
+                            ("letterboxd", row["letterboxd_rating"], 5),
+                            ("myanimelist", row["myanimelist_rating"], 10),
+                        ],
+                        cached=True,
+                    ):
+                        cursor.execute("DELETE FROM mdb_data5 WHERE key_id = ?", (key_id,))
+                        return {}, None
                     mdb_dict["title"] = row["title"] if row["title"] else None
                     mdb_dict["year"] = row["year"] if row["year"] else None
                     mdb_dict["released"] = row["released"] if row["released"] else None
@@ -650,6 +689,24 @@ class Cache:
         return mdb_dict, expired
 
     def update_mdb(self, expired, key_id, mdb, expiration):
+        if not _object_ratings_valid(
+            "MDBList",
+            mdb,
+            [
+                ("score", 100),
+                ("average", 100),
+                ("imdb_rating", 10),
+                ("metacritic_rating", 100),
+                ("metacriticuser_rating", 10),
+                ("trakt_rating", 100),
+                ("tomatoes_rating", 100),
+                ("tomatoesaudience_rating", 100),
+                ("tmdb_rating", 100),
+                ("letterboxd_rating", 5),
+                ("myanimelist_rating", 10),
+            ],
+        ):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -698,6 +755,9 @@ class Cache:
                 cursor.execute("SELECT * FROM anidb_data4 WHERE anidb_id = ?", (anidb_id,))
                 row = cursor.fetchone()
                 if row:
+                    if not _ratings_valid("AniDB", [("rating", row["rating"], 10), ("average", row["average"], 10), ("score", row["score"], 10)], cached=True):
+                        cursor.execute("DELETE FROM anidb_data4 WHERE anidb_id = ?", (anidb_id,))
+                        return {}, None
                     anidb_dict["main_title"] = row["main_title"]
                     anidb_dict["titles"] = row["titles"] if row["titles"] else None
                     anidb_dict["studio"] = row["studio"] if row["studio"] else None
@@ -716,6 +776,8 @@ class Cache:
         return anidb_dict, expired
 
     def update_anidb(self, expired, anidb_id, anidb, expiration):
+        if not _object_ratings_valid("AniDB", anidb, [("rating", 10), ("average", 10), ("score", 10)]):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -749,6 +811,9 @@ class Cache:
                 cursor.execute("SELECT * FROM mal_data4 WHERE mal_id = ?", (mal_id,))
                 row = cursor.fetchone()
                 if row:
+                    if not _ratings_valid("MyAnimeList", [("score", row["score"], 10)], cached=True):
+                        cursor.execute("DELETE FROM mal_data4 WHERE mal_id = ?", (mal_id,))
+                        return {}, None
                     mal_dict["title"] = row["title"]
                     mal_dict["title_english"] = row["title_english"] if row["title_english"] else None
                     mal_dict["title_japanese"] = row["title_japanese"] if row["title_japanese"] else None
@@ -770,6 +835,8 @@ class Cache:
         return mal_dict, expired
 
     def update_mal(self, expired, mal_id, mal, expiration):
+        if not _object_ratings_valid("MyAnimeList", mal, [("score", 10)]):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -809,6 +876,9 @@ class Cache:
                 cursor.execute("SELECT * FROM tmdb_movie_data2 WHERE tmdb_id = ? AND language = ?", (tmdb_id, language))
                 row = cursor.fetchone()
                 if row:
+                    if not _ratings_valid("TMDb", [("vote_average", row["vote_average"], 10)], cached=True):
+                        cursor.execute("DELETE FROM tmdb_movie_data2 WHERE tmdb_id = ? AND language = ?", (tmdb_id, language))
+                        return {}, None
                     tmdb_dict["title"] = row["title"] if row["title"] else ""
                     tmdb_dict["original_title"] = row["original_title"] if row["original_title"] else ""
                     tmdb_dict["studio"] = row["studio"] if row["studio"] else ""
@@ -832,6 +902,8 @@ class Cache:
         return tmdb_dict, expired
 
     def update_tmdb_movie(self, expired, obj, language, expiration):
+        if not _object_ratings_valid("TMDb", obj, [("vote_average", 10)]):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -876,6 +948,9 @@ class Cache:
                 cursor.execute("SELECT * FROM tmdb_show_data4 WHERE tmdb_id = ? AND language = ?", (tmdb_id, language))
                 row = cursor.fetchone()
                 if row:
+                    if not _ratings_valid("TMDb", [("vote_average", row["vote_average"], 10)], cached=True):
+                        cursor.execute("DELETE FROM tmdb_show_data4 WHERE tmdb_id = ? AND language = ?", (tmdb_id, language))
+                        return {}, None
                     tmdb_dict["title"] = row["title"] if row["title"] else ""
                     tmdb_dict["original_title"] = row["original_title"] if row["original_title"] else ""
                     tmdb_dict["studio"] = row["studio"] if row["studio"] else ""
@@ -903,6 +978,8 @@ class Cache:
         return tmdb_dict, expired
 
     def update_tmdb_show(self, expired, obj, language, expiration):
+        if not _object_ratings_valid("TMDb", obj, [("vote_average", 10)]):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -970,6 +1047,9 @@ class Cache:
             with closing(connection.cursor()) as cursor:
                 cursor.execute("SELECT * FROM tmdb_episode_data2 WHERE tmdb_id = ? AND season_number = ? AND episode_number = ? AND language = ?", (tmdb_id, season_number, episode_number, language))
                 row = cursor.fetchone()
+                if row and not _ratings_valid("TMDb", [("vote_average", row["vote_average"], 10)], cached=True):
+                    cursor.execute("DELETE FROM tmdb_episode_data2 WHERE tmdb_id = ? AND season_number = ? AND episode_number = ? AND language = ?", (tmdb_id, season_number, episode_number, language))
+                    return {}, None
         return self._parse_tmdb_episode_row(row, expiration)
 
     def query_tmdb_episode_by_id(self, episode_id, language, expiration):
@@ -977,9 +1057,14 @@ class Cache:
             with closing(connection.cursor()) as cursor:
                 cursor.execute("SELECT * FROM tmdb_episode_data2 WHERE episode_id = ? AND language = ?", (episode_id, language))
                 row = cursor.fetchone()
+                if row and not _ratings_valid("TMDb", [("vote_average", row["vote_average"], 10)], cached=True):
+                    cursor.execute("DELETE FROM tmdb_episode_data2 WHERE episode_id = ? AND language = ?", (episode_id, language))
+                    return {}, None
         return self._parse_tmdb_episode_row(row, expiration)
 
     def update_tmdb_episode(self, expired, obj, language, expiration):
+        if not _object_ratings_valid("TMDb", obj, [("vote_average", 10)]):
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:
@@ -1431,6 +1516,10 @@ class Cache:
                 row = cursor.fetchone()
                 if row:
                     value = row["value"]
+                    if data_type.endswith("_rating") and not util.is_valid_rating(value):
+                        logger.warning(f"Overlay Cache Warning: {data_type} value {value} is invalid; expected a finite value from 0 to 10; cached value will be evicted")
+                        cursor.execute("DELETE FROM overlay_value_cache WHERE rating_key = ? AND type = ?", (str(rating_key), data_type))
+                        return None, None
                     if row["expiration_date"]:
                         datetime_object = datetime.strptime(row["expiration_date"], "%Y-%m-%d")
                         time_between_insertion = datetime.now() - datetime_object
@@ -1444,10 +1533,17 @@ class Cache:
                 cursor.execute("SELECT * FROM overlay_value_cache WHERE rating_key = ?", (str(rating_key),))
                 for row in cursor.fetchall():
                     if row:
-                        values[row["type"]] = row["value"]
+                        if row["type"].endswith("_rating") and not util.is_valid_rating(row["value"]):
+                            logger.warning(f"Overlay Cache Warning: {row['type']} value {row['value']} is invalid; expected a finite value from 0 to 10; cached value will be evicted")
+                            cursor.execute("DELETE FROM overlay_value_cache WHERE rating_key = ? AND type = ?", (str(rating_key), row["type"]))
+                        else:
+                            values[row["type"]] = row["value"]
         return values
 
     def update_overlay_value_cache(self, expired, rating_key, data_type, value):
+        if data_type.endswith("_rating") and not util.is_valid_rating(value):
+            logger.warning(f"Overlay Cache Warning: {data_type} value {value} is invalid; expected a finite value from 0 to 10; value will not be cached")
+            return
         expiration_date = datetime.now() if expired is True else (datetime.now() - timedelta(days=random.randint(1, self.expiration)))
         with self.connection as connection:
             with closing(connection.cursor()) as cursor:

--- a/modules/mdblist.py
+++ b/modules/mdblist.py
@@ -48,6 +48,14 @@ headers = {"User-Agent": "Kometa"}
 class MDbObj:
     def __init__(self, data):
         self._data = data
+        self._invalid_rating_values = []
+
+        def _rating(source, value, maximum, is_int=True):
+            parsed = util.check_num(value, is_int=is_int)
+            if not util.is_missing_rating(value) and not util.is_valid_rating(value, maximum=maximum):
+                self._invalid_rating_values.append((source, value))
+            return parsed
+
         self.title = data.get("title")
         self.year = util.check_num(data.get("release_year") or data.get("year"))
         self.type = data.get("mediatype") or data.get("type")
@@ -64,8 +72,8 @@ class MDbObj:
             self.released_digital = None
 
         self.traktid = util.check_num(data.get("traktid"))
-        self.score = util.check_num(data.get("score"))
-        self.average = util.check_num(data.get("score_average"))
+        self.score = _rating("score", data.get("score"), 100)
+        self.average = _rating("average", data.get("score_average"), 100)
 
         self.imdb_rating = None
         self.metacritic_rating = None
@@ -78,26 +86,33 @@ class MDbObj:
         self.myanimelist_rating = None
         for rating in data.get("ratings", []):
             if rating["source"] == "imdb":
-                self.imdb_rating = util.check_num(rating["value"], is_int=False)
+                self.imdb_rating = _rating("imdb", rating["value"], 10, is_int=False)
             elif rating["source"] == "metacritic":
-                self.metacritic_rating = util.check_num(rating["value"])
+                self.metacritic_rating = _rating("metacritic", rating["value"], 100)
             elif rating["source"] == "metacriticuser":
-                self.metacriticuser_rating = util.check_num(rating["value"], is_int=False)
+                self.metacriticuser_rating = _rating("metacriticuser", rating["value"], 10, is_int=False)
             elif rating["source"] == "trakt":
-                self.trakt_rating = util.check_num(rating["value"])
+                self.trakt_rating = _rating("trakt", rating["value"], 100)
             elif rating["source"] == "tomatoes":
-                self.tomatoes_rating = util.check_num(rating["value"])
+                self.tomatoes_rating = _rating("tomatoes", rating["value"], 100)
             elif rating["source"] in ("tomatoesaudience", "popcorn"):
-                self.tomatoesaudience_rating = util.check_num(rating["value"])
+                self.tomatoesaudience_rating = _rating("tomatoesaudience", rating["value"], 100)
             elif rating["source"] == "tmdb":
-                self.tmdb_rating = util.check_num(rating["value"])
+                self.tmdb_rating = _rating("tmdb", rating["value"], 100)
             elif rating["source"] == "letterboxd":
-                self.letterboxd_rating = util.check_num(rating["value"], is_int=False)
+                self.letterboxd_rating = _rating("letterboxd", rating["value"], 5, is_int=False)
             elif rating["source"] == "myanimelist":
-                self.myanimelist_rating = util.check_num(rating["value"], is_int=False)
+                self.myanimelist_rating = _rating("myanimelist", rating["value"], 10, is_int=False)
         self.content_rating = data.get("certification")
         self.commonsense = bool(data.get("commonsense"))
         self.age_rating = data.get("age_rating")
+        if logger:
+            for source, value in self._invalid_rating_values:
+                logger.warning(f"MDBList Warning: {source} rating value {value} is invalid; expected a finite value in the provider's supported range; response will not be cached")
+
+    @property
+    def ratings_valid(self):
+        return not self._invalid_rating_values
 
 
 class MDBList:
@@ -215,14 +230,16 @@ class MDBList:
             mdb_dict, expired = self.cache.query_mdb(key, self.expiration)
             if mdb_dict and expired is False:
                 mdb = MDbObj(mdb_dict)
-                self._run_cache[key] = mdb
-                return mdb
+                if mdb.ratings_valid:
+                    self._run_cache[key] = mdb
+                    return mdb
+                expired = True
         logger.trace(f"ID: {key}")
         mdb_tuple = self._request(item_url, params={})
         mdb = MDbObj(mdb_tuple[0])
-        if self.cache and not ignore_cache:
+        if self.cache and not ignore_cache and mdb.ratings_valid:
             self.cache.update_mdb(expired, key, mdb, self.expiration)
-        if not ignore_cache:
+        if not ignore_cache and mdb.ratings_valid:
             self._run_cache[key] = mdb
         return mdb
 
@@ -251,9 +268,11 @@ class MDBList:
                 mdb_dict, expired = self.cache.query_mdb(key, self.expiration)
                 if mdb_dict and expired is False:
                     mdb = MDbObj(mdb_dict)
-                    self._run_cache[key] = mdb
-                    results[media_id] = mdb
-                    continue
+                    if mdb.ratings_valid:
+                        self._run_cache[key] = mdb
+                        results[media_id] = mdb
+                        continue
+                    expired = True
             pending.append(media_id)
             expired_by_id[media_id] = expired
 
@@ -273,9 +292,10 @@ class MDBList:
                 mdb = MDbObj(data)
                 results[media_id] = mdb
                 key = self._cache_key(media_provider, media_type, media_id)
-                self._run_cache[key] = mdb
-                if self.cache:
-                    self.cache.update_mdb(expired_by_id[media_id], key, mdb, self.expiration)
+                if mdb.ratings_valid:
+                    self._run_cache[key] = mdb
+                    if self.cache:
+                        self.cache.update_mdb(expired_by_id[media_id], key, mdb, self.expiration)
         missing_ids = [media_id for media_id in pending if media_id not in results]
         if missing_ids and logger:
             sample = ", ".join(str(media_id) for media_id in missing_ids[:10])
@@ -285,6 +305,8 @@ class MDBList:
 
     def cache_item_alias(self, media_provider, media_type, media_id, mdb):
         key = self._cache_key(media_provider, media_type, media_id)
+        if not mdb.ratings_valid:
+            return
         self._run_cache[key] = mdb
         if self.cache:
             _, expired = self.cache.query_mdb(key, self.expiration)

--- a/modules/omdb.py
+++ b/modules/omdb.py
@@ -13,6 +13,7 @@ class OMDbObj:
     def __init__(self, imdb_id, data):
         self._imdb_id = imdb_id
         self._data = data
+        self._invalid_rating_values = []
         if data["Response"] == "False":
             raise Failed(f"OMDb Error: {data['Error']} IMDb ID: {imdb_id}")
 
@@ -51,11 +52,28 @@ class OMDbObj:
         except KeyError:
             pass
 
+        for source, value, maximum, replace in [
+            ("imdb", data.get("imdbRating"), 10, None),
+            ("metacritic", data.get("Metascore"), 100, None),
+            ("tomatoes", data.get("tempRT"), 100, "%"),
+        ]:
+            if replace and isinstance(value, str):
+                value = value.replace(replace, "")
+            if not util.is_missing_rating(value) and not util.is_valid_rating(value, maximum=maximum):
+                self._invalid_rating_values.append((source, value))
+
         self.imdb_id = _parse("imdbID")
         self.type = _parse("Type")
         self.series_id = _parse("seriesID")
         self.season_num = _parse("Season", is_int=True)
         self.episode_num = _parse("Episode", is_int=True)
+        if logger:
+            for source, value in self._invalid_rating_values:
+                logger.warning(f"OMDb Warning: {source} rating value {value} is invalid; expected a finite value in the provider's supported range; response will not be cached")
+
+    @property
+    def ratings_valid(self):
+        return not self._invalid_rating_values
 
 
 class OMDb:
@@ -73,12 +91,15 @@ class OMDb:
         if self.cache and not ignore_cache:
             omdb_dict, expired = self.cache.query_omdb(imdb_id, self.expiration)
             if omdb_dict and expired is False:
-                return OMDbObj(imdb_id, omdb_dict)
+                cached = OMDbObj(imdb_id, omdb_dict)
+                if cached.ratings_valid:
+                    return cached
+                expired = True
         logger.trace(f"IMDb ID: {imdb_id}")
         response = self.requests.get(base_url, params={"apikey": self.apikey, "i": imdb_id})
         if response.status_code < 400:
             omdb = OMDbObj(imdb_id, response.json())
-            if self.cache and not ignore_cache:
+            if self.cache and not ignore_cache and omdb.ratings_valid:
                 self.cache.update_omdb(expired, omdb, self.expiration)
             return omdb
         else:

--- a/modules/operations.py
+++ b/modules/operations.py
@@ -46,11 +46,20 @@ def _item_batches(items_iterable, batch_size):
 
 
 def _format_plex_rating(value, source, rating_name):
-    rating = float(value)
-    if rating > 10:
-        logger.warning(f"{source} {rating_name} value {rating:g} exceeds Plex maximum of 10; skipping")
+    if not util.is_valid_rating(value):
+        logger.warning(f"{source} {rating_name} value {value} is invalid for Plex; expected a finite number from 0 to 10; skipping")
         raise Failed
+    rating = float(value)
     return f"{rating:.1f}"
+
+
+def _scale_provider_rating(value, source, rating_name, maximum, factor):
+    if util.is_missing_rating(value):
+        return None
+    if not util.is_valid_rating(value, maximum=maximum):
+        logger.warning(f"{source} {rating_name} value {value} is invalid for the provider's 0 to {maximum} scale; expected a finite number; skipping")
+        raise Failed
+    return float(value) * factor
 
 
 def _image_operation_summary_rows(counts):
@@ -620,35 +629,35 @@ class Operations:
                                     elif str(option).startswith("omdb"):
                                         omdb_item = omdb_obj()
                                         if option == "omdb_metascore":
-                                            found_rating = omdb_item.metacritic_rating / 10 if omdb_item.metacritic_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(omdb_item.metacritic_rating, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "omdb_tomatoes":
-                                            found_rating = omdb_item.rotten_tomatoes / 10 if omdb_item.rotten_tomatoes else None  # noqa
+                                            found_rating = _scale_provider_rating(omdb_item.rotten_tomatoes, option, name_display[item_attr], 100, 0.1)  # noqa
                                         else:
                                             found_rating = omdb_item.imdb_rating  # noqa
                                     elif str(option).startswith("mdb"):
                                         mdb_item = mdb_obj()
                                         if option == "mdb_average":
-                                            found_rating = mdb_item.average / 10 if mdb_item.average else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.average, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "mdb_imdb":
                                             found_rating = mdb_item.imdb_rating if mdb_item.imdb_rating else None  # noqa
                                         elif option == "mdb_metacritic":
-                                            found_rating = mdb_item.metacritic_rating / 10 if mdb_item.metacritic_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.metacritic_rating, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "mdb_metacriticuser":
                                             found_rating = mdb_item.metacriticuser_rating if mdb_item.metacriticuser_rating else None  # noqa
                                         elif option == "mdb_trakt":
-                                            found_rating = mdb_item.trakt_rating / 10 if mdb_item.trakt_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.trakt_rating, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "mdb_tomatoes":
-                                            found_rating = mdb_item.tomatoes_rating / 10 if mdb_item.tomatoes_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.tomatoes_rating, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "mdb_tomatoesaudience":
-                                            found_rating = mdb_item.tomatoesaudience_rating / 10 if mdb_item.tomatoesaudience_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.tomatoesaudience_rating, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "mdb_tmdb":
-                                            found_rating = mdb_item.tmdb_rating / 10 if mdb_item.tmdb_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.tmdb_rating, option, name_display[item_attr], 100, 0.1)  # noqa
                                         elif option == "mdb_letterboxd":
-                                            found_rating = mdb_item.letterboxd_rating * 2 if mdb_item.letterboxd_rating else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.letterboxd_rating, option, name_display[item_attr], 5, 2)  # noqa
                                         elif option == "mdb_myanimelist":
                                             found_rating = mdb_item.myanimelist_rating if mdb_item.myanimelist_rating else None  # noqa
                                         else:
-                                            found_rating = mdb_item.score / 10 if mdb_item.score else None  # noqa
+                                            found_rating = _scale_provider_rating(mdb_item.score, option, name_display[item_attr], 100, 0.1)  # noqa
                                     elif option == "anidb_rating":
                                         found_rating = anidb_obj().rating  # noqa
                                     elif option == "anidb_average":

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -2469,8 +2469,22 @@ class Plex(Library):
         if self.config.Cache:
             cached_value, expired = self.config.Cache.query_overlay_value_cache(item.ratingKey, variable_name)
             if cached_value is not None and not expired:
-                return float(cached_value)
+                if util.is_valid_rating(cached_value):
+                    return float(cached_value)
+                if logger:
+                    logger.warning(f"Overlay Warning: {variable_name} value {cached_value} is invalid; expected a finite value from 0 to 10; skipping")
         found_rating = None
+        cacheable = True
+
+        def _scale_rating(value, maximum, factor):
+            if util.is_missing_rating(value):
+                return None
+            if not util.is_valid_rating(value, maximum=maximum):
+                if logger:
+                    logger.warning(f"Overlay Warning: {variable_name} value {value} is invalid for the provider's 0 to {maximum} scale; expected a finite number; skipping")
+                return None
+            return float(value) * factor
+
         item_to_id = item.show() if isinstance(item, (Season, Episode)) else item
         tmdb_id, tvdb_id, imdb_id = self.get_ids(item_to_id)
         if variable_name == "tmdb_rating":
@@ -2577,28 +2591,29 @@ class Plex(Library):
                 if not mdb_item:
                     raise MappingConvertError(f"Mapping/Convert Error: No MdbItem for {item.title} (Guid: {item.guid})")
             if mdb_item:
+                cacheable = getattr(mdb_item, "ratings_valid", True)
                 if variable_name == "mdb_average_rating":
-                    found_rating = mdb_item.average / 10 if mdb_item.average else None
+                    found_rating = _scale_rating(mdb_item.average, 100, 0.1)
                 elif variable_name == "mdb_imdb_rating":
                     found_rating = mdb_item.imdb_rating if mdb_item.imdb_rating else None
                 elif variable_name == "mdb_metacritic_rating":
-                    found_rating = mdb_item.metacritic_rating / 10 if mdb_item.metacritic_rating else None
+                    found_rating = _scale_rating(mdb_item.metacritic_rating, 100, 0.1)
                 elif variable_name == "mdb_metacriticuser_rating":
                     found_rating = mdb_item.metacriticuser_rating if mdb_item.metacriticuser_rating else None
                 elif variable_name == "mdb_trakt_rating":
-                    found_rating = mdb_item.trakt_rating / 10 if mdb_item.trakt_rating else None
+                    found_rating = _scale_rating(mdb_item.trakt_rating, 100, 0.1)
                 elif variable_name == "mdb_tomatoes_rating":
-                    found_rating = mdb_item.tomatoes_rating / 10 if mdb_item.tomatoes_rating else None
+                    found_rating = _scale_rating(mdb_item.tomatoes_rating, 100, 0.1)
                 elif variable_name == "mdb_tomatoesaudience_rating":
-                    found_rating = mdb_item.tomatoesaudience_rating / 10 if mdb_item.tomatoesaudience_rating else None
+                    found_rating = _scale_rating(mdb_item.tomatoesaudience_rating, 100, 0.1)
                 elif variable_name == "mdb_tmdb_rating":
-                    found_rating = mdb_item.tmdb_rating / 10 if mdb_item.tmdb_rating else None
+                    found_rating = _scale_rating(mdb_item.tmdb_rating, 100, 0.1)
                 elif variable_name == "mdb_letterboxd_rating":
-                    found_rating = mdb_item.letterboxd_rating * 2 if mdb_item.letterboxd_rating else None
+                    found_rating = _scale_rating(mdb_item.letterboxd_rating, 5, 2)
                 elif variable_name == "mdb_myanimelist_rating":
                     found_rating = mdb_item.myanimelist_rating if mdb_item.myanimelist_rating else None
                 else:
-                    found_rating = mdb_item.score / 10 if mdb_item.score else None
+                    found_rating = _scale_rating(mdb_item.score, 100, 0.1)
         elif str(variable_name).startswith("omdb"):
             if not getattr(self.config, "OMDb", None):
                 raise OverlayError("Overlay Error: OMDb is not configured in your config file")
@@ -2609,10 +2624,11 @@ class Plex(Library):
             else:
                 try:
                     omdb_obj = self.config.OMDb.get_omdb(imdb_id, True)
+                    cacheable = getattr(omdb_obj, "ratings_valid", True)
                     if variable_name == "omdb_metascore_rating":
-                        found_rating = omdb_obj.metacritic_rating / 10 if omdb_obj.metacritic_rating else None
+                        found_rating = _scale_rating(omdb_obj.metacritic_rating, 100, 0.1)
                     elif variable_name == "omdb_tomatoes_rating":
-                        found_rating = omdb_obj.rotten_tomatoes / 10 if omdb_obj.rotten_tomatoes else None
+                        found_rating = _scale_rating(omdb_obj.rotten_tomatoes, 100, 0.1)
                     else:
                         found_rating = omdb_obj.imdb_rating if omdb_obj.imdb_rating else None
                 except Exception:
@@ -2625,6 +2641,7 @@ class Plex(Library):
                     raise OverlayError("Overlay Error: AniDB is not configured in your config file")
                 if anidb_id:
                     anidb_obj = self.config.AniDB.get_anime(anidb_id)
+                    cacheable = getattr(anidb_obj, "ratings_valid", True)
                     if variable_name == "anidb_rating_rating":
                         found_rating = anidb_obj.rating
                     elif variable_name == "anidb_average_rating":
@@ -2655,12 +2672,12 @@ class Plex(Library):
             except KeyError:
                 found_rating = None
         if found_rating is not None:
-            # Sources are inconsistent (e.g. IMDb returns a string); normalize to float so callers can compare numerically.
-            try:
-                found_rating = float(found_rating)
-            except (TypeError, ValueError):
+            if not util.is_valid_rating(found_rating):
+                if logger:
+                    logger.warning(f"Overlay Warning: {variable_name} value {found_rating} is invalid; expected a finite value from 0 to 10; skipping")
                 return None
-            if self.config.Cache:
+            found_rating = float(found_rating)
+            if self.config.Cache and cacheable:
                 self.config.Cache.update_overlay_value_cache(False, item.ratingKey, variable_name, found_rating)
         return found_rating
 

--- a/modules/util.py
+++ b/modules/util.py
@@ -1,4 +1,5 @@
 import glob
+import math
 import ntpath
 import os
 import re
@@ -54,6 +55,20 @@ class FilterFailed(Failed):
 
 class Continue(Exception):
     pass
+
+
+def is_missing_rating(value):
+    return value is None or (isinstance(value, str) and value.strip().upper() in ["", "N/A"])
+
+
+def is_valid_rating(value, minimum=0, maximum=10):
+    if isinstance(value, bool) or is_missing_rating(value):
+        return False
+    try:
+        rating = float(value)
+    except (TypeError, ValueError, OverflowError):
+        return False
+    return math.isfinite(rating) and minimum <= rating <= maximum
 
 
 class Deleted(Exception):

--- a/tests/test_anidb.py
+++ b/tests/test_anidb.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 import modules.builder  # noqa: F401
+from tests.conftest import FakeLogger
+
+
+def make_cached_anidb_data(**overrides):
+    data = {
+        "main_title": "Test Anime",
+        "titles": "{}",
+        "studio": None,
+        "rating": 8.5,
+        "average": 8.0,
+        "score": None,
+        "released": None,
+        "tags": "{}",
+        "mal_id": None,
+        "imdb_id": None,
+        "tmdb_id": None,
+        "tmdb_type": None,
+    }
+    data.update(overrides)
+    return data
 
 
 class TestAniDB:
@@ -18,3 +40,22 @@ class TestAniDB:
 
     def test_is_authorized_false_initially(self, adapter):
         assert adapter.is_authorized is False
+
+    @pytest.mark.parametrize("value", [-0.1, 10.1, "bad", float("nan"), float("inf"), True])
+    def test_invalid_rating_is_reported_and_marked_uncacheable(self, value, monkeypatch):
+        from modules.anidb import AniDBObj
+
+        logger = FakeLogger()
+        monkeypatch.setattr("modules.anidb.logger", logger)
+
+        result = AniDBObj(SimpleNamespace(language="en"), 1, make_cached_anidb_data(rating=value))
+
+        assert not result.ratings_valid
+        assert any("response will not be cached" in message for message in logger.warning_messages)
+
+    def test_missing_rating_is_not_invalid(self):
+        from modules.anidb import AniDBObj
+
+        result = AniDBObj(SimpleNamespace(language="en"), 1, make_cached_anidb_data(rating=None))
+
+        assert result.ratings_valid

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -172,6 +172,17 @@ class TestTMDbEpisodeCache:
 
         assert count == 1
 
+    @pytest.mark.parametrize("value", [-0.1, 10.1, float("nan"), float("inf"), "bad", True])
+    def test_invalid_rating_is_not_written(self, tmp_path, value):
+        from modules import cache as cache_module
+
+        cache = make_cache(tmp_path)
+
+        cache.update_tmdb_episode(False, make_tmdb_episode(vote_average=value), "en", 30)
+
+        assert cache.query_tmdb_episode_by_id(6855841, "en", 30) == ({}, None)
+        assert any(f"TMDb Warning: vote_average rating value {value}" in message for message in cache_module.logger.warning_messages)
+
     def test_partial_season_write_preserves_richer_external_ids(self, tmp_path):
         cache = make_cache(tmp_path)
         cache.update_tmdb_episode(False, make_tmdb_episode(imdb_id="tt1234567", tvdb_id=7654321), "en", 30)
@@ -402,6 +413,27 @@ class TestMdbCache:
         result, expired = cache.query_mdb("no-such-key", expiration=30)
         assert result == {}
         assert expired is None
+
+    def test_invalid_rating_is_not_written(self, tmp_path):
+        cache = make_cache(tmp_path)
+
+        cache.update_mdb(False, "invalid", _make_mdb_obj(letterboxd_rating=5.1), expiration=30)
+
+        assert cache.query_mdb("invalid", expiration=30) == ({}, None)
+
+    def test_stale_invalid_rating_is_evicted(self, tmp_path):
+        from modules import cache as cache_module
+
+        cache = make_cache(tmp_path)
+        cache.update_mdb(False, "stale", _make_mdb_obj(), expiration=30)
+        with sqlite3.connect(cache.cache_path) as connection:
+            connection.execute("UPDATE mdb_data5 SET letterboxd_rating = ? WHERE key_id = ?", (5.1, "stale"))
+
+        assert cache.query_mdb("stale", expiration=30) == ({}, None)
+        with sqlite3.connect(cache.cache_path) as connection:
+            count = connection.execute("SELECT COUNT(*) FROM mdb_data5 WHERE key_id = ?", ("stale",)).fetchone()[0]
+        assert count == 0
+        assert any("MDBList Warning: letterboxd rating value 5.1" in message and "cached value will be evicted" in message for message in cache_module.logger.warning_messages)
 
 
 def _make_anidb_obj(**overrides):
@@ -868,6 +900,29 @@ class TestOverlayValueCache:
         cache.update_overlay_value_cache(False, 5173, "mdb_tomatoes_rating", "8.1")
         assert cache.query_overlay_value_cache(5173, "plex_imdb_rating")[0] == "7.3"
         assert cache.query_overlay_value_cache(5173, "mdb_tomatoes_rating")[0] == "8.1"
+
+    @pytest.mark.parametrize("value", [-0.1, 10.1, "bad", "nan", "inf"])
+    def test_invalid_rating_is_not_written(self, tmp_path, value):
+        from modules import cache as cache_module
+
+        cache = make_cache(tmp_path)
+
+        cache.update_overlay_value_cache(False, 5173, "mdb_letterboxd_rating", value)
+
+        assert cache.query_overlay_value_cache(5173, "mdb_letterboxd_rating") == (None, None)
+        assert any("value will not be cached" in message for message in cache_module.logger.warning_messages)
+
+    def test_legacy_invalid_rating_is_reported_and_evicted(self, tmp_path):
+        from modules import cache as cache_module
+
+        cache = make_cache(tmp_path)
+        cache.update_overlay_value_cache(False, 5173, "title", "placeholder")
+        with sqlite3.connect(cache.cache_path) as connection:
+            connection.execute("UPDATE overlay_value_cache SET type = ?, value = ? WHERE rating_key = ?", ("mdb_letterboxd_rating", "10.2", "5173"))
+
+        assert cache.query_overlay_value_cache(5173, "mdb_letterboxd_rating") == (None, None)
+        assert _ovc_row_count(cache, 5173, "mdb_letterboxd_rating") == 0
+        assert any("cached value will be evicted" in message for message in cache_module.logger.warning_messages)
 
     def test_miss_returns_none(self, tmp_path):
         cache = make_cache(tmp_path)

--- a/tests/test_fetch_overlay_value.py
+++ b/tests/test_fetch_overlay_value.py
@@ -199,6 +199,49 @@ def test_non_numeric_string_returns_none():
     cache.update_overlay_value_cache.assert_not_called()
 
 
+def test_out_of_range_cached_rating_is_rejected_and_reported(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    cache = MagicMock()
+    cache.query_overlay_value_cache.return_value = (10.2, False)
+    plx = _make_plex(cache=cache, get_ratings=MagicMock(return_value={}))
+
+    result = plx.fetch_overlay_value(_item(), "plex_imdb_rating")
+
+    assert result is None
+    assert any("value 10.2 is invalid" in call.args[0] for call in logger.warning.call_args_list)
+    cache.update_overlay_value_cache.assert_not_called()
+
+
+def test_out_of_range_letterboxd_rating_is_not_rendered_or_cached(monkeypatch):
+    logger = MagicMock()
+    monkeypatch.setattr(plex_module, "logger", logger)
+    cache = MagicMock()
+    cache.query_overlay_value_cache.return_value = (None, None)
+    plx = _make_plex(cache=cache, get_ids=MagicMock(return_value=(550, None, None)))
+    plx.config.MDBList = MagicMock(limit=False)
+    plx.config.MDBList.get_movie.return_value = SimpleNamespace(letterboxd_rating=5.1, ratings_valid=False)
+
+    result = plx.fetch_overlay_value(_item(), "mdb_letterboxd_rating")
+
+    assert result is None
+    assert any("provider's 0 to 5 scale" in call.args[0] for call in logger.warning.call_args_list)
+    cache.update_overlay_value_cache.assert_not_called()
+
+
+def test_valid_rating_from_tainted_provider_response_is_not_overlay_cached():
+    cache = MagicMock()
+    cache.query_overlay_value_cache.return_value = (None, None)
+    plx = _make_plex(cache=cache, get_ids=MagicMock(return_value=(550, None, None)))
+    plx.config.MDBList = MagicMock(limit=False)
+    plx.config.MDBList.get_movie.return_value = SimpleNamespace(imdb_rating=8.2, ratings_valid=False)
+
+    result = plx.fetch_overlay_value(_item(), "mdb_imdb_rating")
+
+    assert result == 8.2
+    cache.update_overlay_value_cache.assert_not_called()
+
+
 # ── None handling ──────────────────────────────────────────────────────────────
 
 

--- a/tests/test_mdblist.py
+++ b/tests/test_mdblist.py
@@ -81,6 +81,28 @@ class TestMDbObj:
         m = MDbObj({**self._BASE, "released": "2023-06-15", "released_digital": None})
         assert m.released == datetime(2023, 6, 15)
 
+    @pytest.mark.parametrize(
+        ("source", "value"),
+        [("letterboxd", 5.1), ("imdb", -0.1), ("metacritic", 101), ("myanimelist", "bad"), ("trakt", float("nan"))],
+    )
+    def test_marks_provider_native_rating_outside_its_scale_invalid(self, source, value, monkeypatch):
+        from modules.mdblist import MDbObj
+
+        logger = FakeLogger()
+        monkeypatch.setattr("modules.mdblist.logger", logger)
+
+        m = MDbObj({**self._BASE, "ratings": [{"source": source, "value": value}]})
+
+        assert not m.ratings_valid
+        assert any("response will not be cached" in message for message in logger.warning_messages)
+
+    def test_missing_provider_ratings_are_not_treated_as_invalid(self):
+        from modules.mdblist import MDbObj
+
+        m = MDbObj({**self._BASE, "score": None, "ratings": [{"source": "imdb", "value": "N/A"}]})
+
+        assert m.ratings_valid
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # MDBList
@@ -149,6 +171,22 @@ class TestMDBList:
 
         assert result[101].title == "Cached"
         adapter._request.assert_not_called()
+        adapter.cache.update_mdb.assert_not_called()
+
+    def test_invalid_response_is_returned_but_not_cached_in_memory_or_sqlite(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.mdblist.logger", FakeLogger())
+        adapter.cache.query_mdb.return_value = ({}, None)
+        adapter._request = MagicMock(
+            return_value=(
+                {"id": 101, "title": "Invalid", "released": None, "released_digital": None, "ratings": [{"source": "letterboxd", "value": 5.1}]},
+                {},
+            )
+        )
+
+        result = adapter.get_movie(101)
+
+        assert result.letterboxd_rating == 5.1
+        assert "tm101" not in adapter._run_cache
         adapter.cache.update_mdb.assert_not_called()
 
     def test_get_items_fetches_only_missing_and_expired_entries(self, adapter):

--- a/tests/test_omdb.py
+++ b/tests/test_omdb.py
@@ -29,3 +29,33 @@ class TestOMDb:
         adapter.requests.get.return_value = FakeResponse({"Title": "T", "Year": "2023", "imdbID": "tt1", "Response": "True"}, 200)
         r = adapter.get_omdb("tt1", ignore_cache=True)
         assert r.title == "T"
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            {"imdbRating": "10.1"},
+            {"imdbRating": "nan"},
+            {"Metascore": "-1"},
+            {"Ratings": [{"Source": "Rotten Tomatoes", "Value": "101%"}]},
+            {"imdbRating": "not-a-rating"},
+        ],
+    )
+    def test_invalid_provider_rating_is_returned_but_not_cached(self, adapter, monkeypatch, response):
+        logger = FakeLogger()
+        monkeypatch.setattr("modules.omdb.logger", logger)
+        adapter.requests.get.return_value = FakeResponse({"Title": "T", "imdbID": "tt1", "Response": "True", **response}, 200)
+
+        result = adapter.get_omdb("tt1")
+
+        assert not result.ratings_valid
+        adapter.cache.update_omdb.assert_not_called()
+        assert any("response will not be cached" in message for message in logger.warning_messages)
+
+    def test_missing_provider_rating_can_be_cached(self, adapter, monkeypatch):
+        monkeypatch.setattr("modules.omdb.logger", FakeLogger())
+        adapter.requests.get.return_value = FakeResponse({"Title": "T", "imdbID": "tt1", "imdbRating": "N/A", "Response": "True"}, 200)
+
+        result = adapter.get_omdb("tt1")
+
+        assert result.ratings_valid
+        adapter.cache.update_omdb.assert_called_once()

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -12,6 +12,8 @@ from collections import Counter
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
+
 import modules.builder  # noqa: F401 -- pre-import to break plex<->builder circular import
 import modules.operations as ops_module
 
@@ -849,7 +851,22 @@ class TestFlushCombinedEdits:
         Operations(config=config, library=library).run_operations()
 
         library.Plex.editField.assert_not_called()
-        ops_module.logger.warning.assert_any_call("mdb_letterboxd User Rating value 10.2 exceeds Plex maximum of 10; skipping")
+        ops_module.logger.warning.assert_any_call("mdb_letterboxd User Rating value 5.1 is invalid for the provider's 0 to 5 scale; expected a finite number; skipping")
+
+    @pytest.mark.parametrize("value", [-0.1, 100.1, "bad", float("nan"), float("inf"), float("-inf"), True])
+    def test_every_illegal_provider_rating_is_not_sent_to_plex(self, value):
+        ops_module.logger.reset_mock()
+        item = make_mass_edit_item(1, "Invalid Provider Rating")
+        library = make_mass_edit_library([item], mass_user_rating_update=["mdb"])
+        library.get_ids.return_value = (123, None, None)
+        config = MagicMock()
+        config.MDBList.limit = False
+        config.MDBList.get_movie.return_value = SimpleNamespace(score=value)
+
+        Operations(config=config, library=library).run_operations()
+
+        library.Plex.editField.assert_not_called()
+        assert any("expected a finite number" in call.args[0] for call in ops_module.logger.warning.call_args_list)
 
     def test_merges_multiple_attribute_types_into_one_put(self):
         """An item needing rating + audience rating + genre + content rating all changed in

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -130,6 +130,26 @@ class TestCheckNum:
         assert check_num("") is None
 
 
+class TestRatingValidation:
+    @pytest.mark.parametrize("value", [0, 10, 7.5, "0", "10", "7.5"])
+    def test_accepts_finite_values_in_range(self, value):
+        from modules.util import is_valid_rating
+
+        assert is_valid_rating(value)
+
+    @pytest.mark.parametrize("value", [-0.1, 10.1, "not-a-rating", float("nan"), float("inf"), float("-inf"), None, "", "N/A", True, False, []])
+    def test_rejects_every_illegal_rating_shape(self, value):
+        from modules.util import is_valid_rating
+
+        assert not is_valid_rating(value)
+
+    def test_supports_provider_native_scale(self):
+        from modules.util import is_valid_rating
+
+        assert is_valid_rating(100, maximum=100)
+        assert not is_valid_rating(100.1, maximum=100)
+
+
 class TestGetIdFromImdbUrl:
     def test_full_url(self):
         from modules.util import get_id_from_imdb_url


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Validates ratings against provider-native scales and the Plex 0–10 scale before mass metadata updates or rating-overlay rendering. Nonnumeric, non-finite, boolean, negative, and above-range values are logged and skipped.

Invalid MDBList, OMDb, AniDB, MyAnimeList, and TMDb responses are not persisted. Existing illegal provider-cache and overlay-value-cache entries are logged and evicted so recurring provider problems remain visible on subsequent runs. Invalid responses also cannot be hidden by the per-run MDBList cache or by a valid derived overlay value.

Added regression coverage for provider parsing, native-scale conversion, Plex updates, overlay rendering, cache insertion, and legacy cache eviction.

Validation:
- `pytest -q`: 1,411 passed
- `prek run --all-files --show-diff-on-failure`: Black, isort, flake8, and pyspelling passed
- `git diff --check`: passed

## Related Issues [optional]

None.

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790870061&installation_model_id=431096&pr_number=3544&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3544&signature=6d94dd58f11e1c7afe7bdc1d29df4c5303e097dd017377e5024fe830de9ae177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->