### PR TITLE
fix: tolerate Plex image update timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Continue metadata and overlay processing when a Plex request times out while removing an existing `Overlay` label during image updates; log the failed image update instead of aborting the library run.
 - Skip nonnumeric, non-finite, negative, and above-range provider ratings instead of sending them to Plex or rendering them in rating overlays, and leave invalid provider and overlay values uncached so they remain visible on later runs.
 - Fix CLI arguments (e.g. `--config`) being silently reset to their defaults on Python 3.14, where the `ProcessPoolExecutor` running the actual work now defaults to the `forkserver` multiprocessing start method on Linux instead of `fork`.
 - Fix the `resolution` Defaults overlay file selecting the `-Dovetail` (resolution-paired) edition overlay instead of the plain one when `use_resolution: false` disables resolution overlays entirely, by no longer building the dovetail edition overlays in that case, and fix a related list-mutation-during-iteration bug in overlay suppress/group resolution that could skip a suppress rule for an overlay later in an item's match list.

--- a/modules/library.py
+++ b/modules/library.py
@@ -3,6 +3,7 @@ import time
 from abc import ABC, abstractmethod
 
 from PIL import Image
+from requests.exceptions import RequestException
 
 from modules import timings, util
 from modules.meta import MetadataFile, OverlayFile
@@ -311,7 +312,7 @@ class Library(ABC):
                     logger.info(f"Metadata: {poster.attribute} updated {poster.message}")
                 elif self.show_asset_not_needed:
                     logger.info(f"Metadata: {poster.prefix}poster update not needed")
-            except Failed:
+            except (Failed, RequestException):
                 logger.stacktrace()
                 logger.error(f"Metadata: {poster.attribute} failed to update {poster.message}")
 
@@ -326,7 +327,7 @@ class Library(ABC):
                     logger.info(f"Metadata: {background.attribute} updated {background.message}")
                 elif self.show_asset_not_needed:
                     logger.info(f"Metadata: {background.prefix}background update not needed")
-            except Failed:
+            except (Failed, RequestException):
                 logger.stacktrace()
                 logger.error(f"Metadata: {background.attribute} failed to update {background.message}")
 
@@ -341,7 +342,7 @@ class Library(ABC):
                     logger.info(f"Metadata: {logo.attribute} updated {logo.message}")
                 elif self.show_asset_not_needed:
                     logger.info(f"Metadata: {logo.prefix}logo update not needed")
-            except Failed:
+            except (Failed, RequestException):
                 logger.stacktrace()
                 logger.error(f"Metadata: {logo.attribute} failed to update {logo.message}")
 
@@ -356,7 +357,7 @@ class Library(ABC):
                     logger.info(f"Metadata: {square_art.attribute} updated {square_art.message}")
                 elif self.show_asset_not_needed:
                     logger.info(f"Metadata: {square_art.prefix}square art update not needed")
-            except Failed:
+            except (Failed, RequestException):
                 logger.stacktrace()
                 logger.error(f"Metadata: {square_art.attribute} failed to update {square_art.message}")
 

--- a/tests/test_plex.py
+++ b/tests/test_plex.py
@@ -238,6 +238,29 @@ class TestImageUpdate:
         assert plex.filter_attr_cache == {(7, "labels"): ["Keep"]}
 
 
+class TestUploadImages:
+    def test_plex_timeout_removing_overlay_does_not_abort(self, monkeypatch):
+        import modules.library as library_module
+
+        test_logger = FakeLogger()
+        monkeypatch.setattr(library_module, "logger", test_logger)
+        plex = make_plex(config=SimpleNamespace(Cache=None))
+        plex.image_table_name = "images"
+        plex.show_asset_not_needed = False
+        plex.reload = MagicMock()
+        plex.item_labels = MagicMock(return_value=[SimpleNamespace(tag="Overlay")])
+        plex._upload_image = MagicMock()
+        item = make_plex_item(rating_key=123)
+        item.removeLabel.side_effect = ReadTimeout("Plex did not respond")
+        poster = SimpleNamespace(compare="poster", attribute="asset_directory", message="poster")
+
+        result = plex.upload_images(item, poster=poster, overlay=True)
+
+        assert result == (False, False, False, False)
+        plex._upload_image.assert_not_called()
+        assert "Metadata: asset_directory failed to update poster" in test_logger.error_messages
+
+
 # ═══════════════════════════════════════════════════════════════════════
 # validate_image_size
 # ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Catches Plex request failures, including ReadTimeout, during metadata image updates. A timeout while removing an existing Overlay label is logged as a failed image update and no longer aborts the library run; subsequent image processing continues.

Added a regression test covering a Plex timeout during Overlay-label removal.

Validation: 1488 tests passed and all pre-commit hooks passed.

## Related Issues [optional]

- Related Issue #
- Closes #

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949558&installation_model_id=431096&pr_number=3545&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3545&signature=a4700351e6cd9a09cdc6d612255321de436caf7b0c8af5d24c83e48307554b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->