### PR TITLE
fix: ghost logging writing carriage-return-only output when stdout is not a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `audio_language`/`subtitle_language` `plex_search` filters matching zero items whenever a library has multiple Plex-reported locale variants for the requested language (e.g. `de` + `de-DE`); the variants were being `AND` together into an impossible filter instead of `OR`. Regression from #3440.
 - Fix `episode_*` ratings from producing a critical error when Trakt did not have an episode in its database
 - Fix DC-based lists in 'universe' Defaults file
+- Fix ghost progress logging (e.g. `Parsing ID x/y`) writing carriage-return-only output regardless of whether stdout is a terminal, which collapses an entire run into a single unbounded log line for containerized/piped deployments; ghost output is now skipped when stdout is not a TTY. Fixes #3542.
 
 ## [v2.4.8] - 2026-08-15
 

--- a/modules/logs.py
+++ b/modules/logs.py
@@ -296,7 +296,7 @@ class MyLogger:
         return display_title
 
     def ghost(self, text):
-        if not self.ignore_ghost:
+        if not self.ignore_ghost and sys.stdout.isatty():
             try:
                 print(self._space(f"| {text}"), end="\r")
             except UnicodeEncodeError:
@@ -305,7 +305,7 @@ class MyLogger:
             self.spacing = len(text) + 2
 
     def exorcise(self):
-        if not self.ignore_ghost:
+        if not self.ignore_ghost and sys.stdout.isatty():
             print(self._space(" "), end="\r")
             self.spacing = 0
 

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -41,6 +41,22 @@ class TestMyLogger:
         # somehow pollute it by tripping over a recorded value.
         assert logger.info_center not in ["x"]
 
+    def test_ghost_writes_when_stdout_is_a_tty(self, logger, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+        logger.ghost("progress")
+        assert capsys.readouterr().out.endswith("\r")
+
+    def test_ghost_silent_when_stdout_is_not_a_tty(self, logger, monkeypatch, capsys):
+        # Regression test for #3542: non-TTY stdout must never get \r-only output.
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        logger.ghost("progress")
+        assert capsys.readouterr().out == ""
+
+    def test_exorcise_silent_when_stdout_is_not_a_tty(self, logger, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+        logger.exorcise()
+        assert capsys.readouterr().out == ""
+
 
 class TestSecretRedaction:
     @pytest.fixture


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

Logger.ghost() and Logger.exorcise() in modules/logs.py always wrote carriage-return-terminated progress output, with no check for whether stdout is a terminal. In a container or any piped stdout, no newline is ever emitted, so an entire run's ghost output (progress lines like "Parsing ID x/y") collapses into a single unbounded log line. This breaks log collectors that buffer a stream until they see a newline.

Fix: both methods now also check sys.stdout.isatty() before writing, so ghost output is skipped entirely when stdout is not a TTY, matching the default behavior of tqdm and most progress-bar libraries.

Tested locally: added two regression tests in tests/test_logs.py that assert ghost() and exorcise() produce no output when stdout is not a TTY, and one confirming the existing carriage-return behavior is preserved when it is a TTY. Verified the new tests fail against the unfixed code and pass with the fix. Full tests/test_logs.py suite, black, isort, and flake8 all pass.

## Related Issues

- Closes #3542

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058717&installation_model_id=431096&pr_number=3546&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3546&signature=cdbf37bc2654ae9987b01c17da6f9148a9fd990e2f60ae59922238e57134eedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->