### PR TITLE
fix: plex_collectionless not recognising smart collection membership

### DIFF
--- a/.pyright-baseline.json
+++ b/.pyright-baseline.json
@@ -1,12 +1,11 @@
 {
   "_comment": "Ratcheting pyright baseline. DO NOT hand-edit unless you know what you're doing. Regenerate with: python scripts/pyright_baseline.py --regenerate",
-  "total_errors": 8,
+  "total_errors": 5,
   "per_file_errors": {
     "kometa.py": 1,
     "modules/builder.py": 1,
     "modules/config.py": 1,
     "modules/meta.py": 1,
-    "modules/operations.py": 2,
-    "modules/plex.py": 2
+    "modules/operations.py": 1
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `episode_*` ratings from producing a critical error when Trakt did not have an episode in its database
 - Fix DC-based lists in 'universe' Defaults file
 - Fix ghost progress logging (e.g. `Parsing ID x/y`) writing carriage-return-only output regardless of whether stdout is a terminal, which collapses an entire run into a single unbounded log line for containerized/piped deployments; ghost output is now skipped when stdout is not a TTY. Fixes #3542.
+- Fix `plex_collectionless` never recognizing an item as belonging to a smart collection (used by most Defaults collection files, e.g. `genre`, `studio`, `audio_language`), since Plex does not tag items with smart collection membership; membership is now resolved from each retained collection's actual items instead of the item's own `collections` tag list. Fixes #3537.
+- Fix `prefetch_mdblist` raising when an orphaned Season/Episode's parent Show has been deleted from Plex (`item.show()` returning `None`); such items are now skipped instead of crashing the MDBList prefetch pass.
 
 ## [v2.4.8] - 2026-08-15
 

--- a/modules/plex.py
+++ b/modules/plex.py
@@ -1918,17 +1918,15 @@ class Plex(Library):
             for col in good_collections:
                 logger.info(col.title)
             logger.info("")
-            collection_indexes = [str(c.title).lower() for c in good_collections]
+            # Resolve membership via get_collection_items (handles smart collections) instead of item.collections tags, which Plex never sets for smart collections (#3537)
+            protected_keys = set()
+            for col in good_collections:
+                for member in self.get_collection_items(col, False):
+                    protected_keys.add(member.ratingKey)  # type: ignore[union-attr]
             all_items = self.get_all()
             for i, item in enumerate(all_items, 1):
                 logger.ghost(f"Processing: {i}/{len(all_items)} {item.title}")
-                add_item = True
-                item = self.reload(item, force=True)
-                for collection in item.collections:
-                    if str(collection.tag).lower() in collection_indexes:
-                        add_item = False
-                        break
-                if add_item:
+                if item.ratingKey not in protected_keys:
                     items.append(item)
             logger.info(f"Processed {len(all_items)} {self.type}s")
         else:
@@ -2386,6 +2384,8 @@ class Plex(Library):
         seen_items = set()
         for item in items:
             item_to_id = item.show() if isinstance(item, (Season, Episode)) else item
+            if item_to_id is None:
+                continue
             if item_to_id.ratingKey in seen_items:
                 continue
             seen_items.add(item_to_id.ratingKey)


### PR DESCRIPTION
## What type of PR is this?

- [X] Bug Fix (non-breaking change which fixes an issue)
- [ ] Feature/Tweak (non-breaking change which adds new functionality or enhances existing functionality)
- [ ] Breaking Change (fix or feature that would break any existing functionality for users)
- [ ] Documentation Update
- [ ] Chore (maintenance, dependency bumps, housekeeping - no functional change)
- [ ] Other

## Description

`plex_collectionless` checked whether an item belonged to a "good" collection by reading `item.collections`, which only reflects `Collection` tags written directly on the item. Plex never writes that tag for smart collections, since their membership is a live saved search, not a tag on the item. Most Defaults collection files (`genre`, `studio`, `audio_language`, etc.) are built as smart collections, so their members could never protect against Collectionless, regardless of `exclude_prefix` or language.

Fix resolves membership via the existing `get_collection_items` helper, which already handles smart and static collections correctly, instead of the per-item `collections` tag check. Also drops the per-item `reload(force=True)` call that the old check needed.

Tested locally against a live Plex library with the stock `genre` Defaults file plus Collectionless. Before the fix, all test items were wrongly added to Collectionless. After the fix, none were.

## Related Issues [optional]

- Closes #3537

## Have you updated the Documentation to reflect changes (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the JSON Schema files (if necessary)?

- [ ] Yes
- [ ] No
- [X] Not Applicable

## Have you updated the CHANGELOG.md?

- [X] Yes
- [ ] No

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Kometa-Team/codesmith/Kometa/pr/3551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791376403&installation_model_id=431096&pr_number=3551&repository=Kometa-Team%2FKometa&return_to=https%3A%2F%2Fgithub.com%2FKometa-Team%2FKometa%2Fpull%2F3551&signature=f044612a71e50a1a297ac25c2ec9eca13bf2ce4f0829342b6633f01cffa6fdaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->